### PR TITLE
fix(bot): adicionar função escapeMarkdownV2 para Telegram

### DIFF
--- a/server/utils/formatters.js
+++ b/server/utils/formatters.js
@@ -103,3 +103,41 @@ export function calculateStreak(logs, timezone = 'America/Sao_Paulo') {
   
   return streak;
 }
+
+/**
+ * Escape special characters for Telegram MarkdownV2 format
+ * According to: https://core.telegram.org/bots/api#markdownv2-style
+ * 
+ * @param {string} text - Text to escape
+ * @returns {string} Escaped text safe for MarkdownV2
+ * 
+ * @example
+ * escapeMarkdownV2("Omega 3!") // Returns "Omega 3\!"
+ * escapeMarkdownV2("Vitamina D (1000UI)") // Returns "Vitamina D \(1000UI\)"
+ */
+export function escapeMarkdownV2(text) {
+  if (!text || typeof text !== 'string') return '';
+  
+  // Order matters: escape backslash FIRST to avoid double-escaping
+  // Then escape all other reserved characters
+  return text
+    .replace(/\\/g, '\\\\')  // Must be first!
+    .replace(/_/g, '\\_')
+    .replace(/\*/g, '\\*')
+    .replace(/\[/g, '\\[')
+    .replace(/\]/g, '\\]')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)')
+    .replace(/~/g, '\\~')
+    .replace(/`/g, '\\`')
+    .replace(/>/g, '\\>')
+    .replace(/#/g, '\\#')
+    .replace(/\+/g, '\\+')
+    .replace(/-/g, '\\-')
+    .replace(/=/g, '\\=')
+    .replace(/\|/g, '\\|')
+    .replace(/{/g, '\\{')
+    .replace(/}/g, '\\}')
+    .replace(/\./g, '\\.')
+    .replace(/!/g, '\\!');
+}


### PR DESCRIPTION
# 📦 fix(bot): adicionar função escapeMarkdownV2 para Telegram

## 🎯 Resumo

Esta PR implementa a função `escapeMarkdownV2` no arquivo `server/utils/formatters.js` para escapar corretamente caracteres especiais no formato MarkdownV2 do Telegram. Isso resolve o erro recorrente de DLQ: "Character '!' is reserved and must be escaped".

---

## 📋 Tarefas Implementadas

### ✅ Implementação
- [x] Criar função `escapeMarkdownV2` exportável
- [x] Escapar backslash PRIMEIRO para evitar double-escaping
- [x] Escapar todos os 18 caracteres reservados do MarkdownV2

### ✅ Validação
- [x] Lint sem erros
- [x] Testes críticos passando (162 tests)
- [x] Build bem-sucedido

---

## 🔧 Arquivos Principais

```
server/utils/
└── formatters.js     # Adicionada função escapeMarkdownV2 (linhas 107-143)
```

---

## ✅ Checklist de Verificação

### Código
- [x] Todos os testes passam (`npm run test:critical`)
- [x] Lint sem erros (`npm run lint`)
- [x] Build bem-sucedido (`npm run build`)

### Funcionalidade
- [x] Função exporta corretamente
- [x] Escapa backslash primeiro (ordem correta)
- [x] Escapa todos os 18 caracteres reservados

---

## 🚀 Como Testar

```bash
# Validar sintaxe
node -c server/utils/formatters.js

# Executar testes
npm run test:critical

# Build
npm run build
```

**Resultado esperado:**
- Função disponível para importação
- Pronta para ser integrada em `tasks.js` (próxima tarefa)

---

## 🔗 Issues Relacionadas

- Related to: Erro de DLQ "Character '!' is reserved and must be escaped"
- Spec: `plans/TELEGRAM_MARKDOWNV2_ESCAPE_SPEC.md`

---

## 📝 Notas para Reviewers

1. **Caracteres escapados:** Todos os 18 caracteres reservados conforme [Telegram API](https://core.telegram.org/bots/api#markdownv2-style)
2. **Ordem:** Backslash é escapado primeiro para evitar double-escaping
3. **Próximos passos:** Integrar em `tasks.js` e outros arquivos do bot (tarefas separadas)

---

/cc @gemini-code-assist