### PR TITLE
fix(gemini): add polling for inline comments to resolve timing issue

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -170,6 +170,52 @@ jobs:
         with:
           ref: ${{ needs.detect.outputs.branch }}
       
+      # ==========================================
+      # FIX: Aguardar comentários inline do Gemini
+      # O Gemini posta um resumo inicial rapidamente (~30s),
+      # mas os comentários inline vêm depois (~60-90s).
+      # ==========================================
+      - name: Wait for Gemini Inline Comments
+        id: wait-inline
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const maxAttempts = 10; // 10 * 15s = 2.5 min
+            const interval = 15000; // 15 seconds
+            const prNumber = parseInt("${{ needs.detect.outputs.pr_number }}");
+            
+            console.log('⏳ Waiting for Gemini inline comments...');
+            
+            for (let i = 0; i < maxAttempts; i++) {
+              // Buscar comentários inline (review comments)
+              const { data: reviewComments } = await github.rest.pulls.listReviewComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              
+              const geminiInlineComments = reviewComments.filter(c => 
+                c.user.login === 'gemini-code-assist[bot]'
+              );
+              
+              if (geminiInlineComments.length > 0) {
+                console.log(`✅ Found ${geminiInlineComments.length} Gemini inline comments after ${i * 15} seconds`);
+                core.setOutput('inline_comments_found', 'true');
+                core.setOutput('inline_comments_count', geminiInlineComments.length.toString());
+                return;
+              }
+              
+              console.log(`Attempt ${i + 1}/${maxAttempts}: No inline comments yet, waiting...`);
+              
+              if (i < maxAttempts - 1) {
+                await new Promise(resolve => setTimeout(resolve, interval));
+              }
+            }
+            
+            console.log('⚠️ No Gemini inline comments found after 2.5 minutes');
+            core.setOutput('inline_comments_found', 'false');
+            core.setOutput('inline_comments_count', '0');
+      
       - name: Fetch Gemini Comments
         id: fetch
         uses: actions/github-script@v7


### PR DESCRIPTION
## 🐛 Bug Fix

### Problema
O Gemini Code Assist posta um resumo inicial rapidamente (~30s), mas os comentários inline vêm depois (~60-90s). O workflow era triggerado quando o resumo era postado, mas quando executava, os comentários inline ainda não estavam disponíveis.

### Sintoma
- Parsing encontrava 0 review comments
- Artifact não era gerado
- Resumo postado mostrava "Total de Issues: 0"

### Solução
Adicionado step "Wait for Gemini Inline Comments" com polling de 2.5 minutos (10 tentativas x 15s) para aguardar os comentários inline do Gemini.

### Testes
- ✅ Lint: 0 errors
- ✅ Testes críticos: 146 passed
- ✅ Build: sucesso

### Arquivos Modificados
- `.github/workflows/gemini-review.yml` - Adicionado step de polling
- `plans/PLANO_REFATORACAO_GEMINI_INTEGRATION.md` - Documentado bug e testes
