### PR TITLE
chore: configuração Claude Code - auto-aprovação de CLIs (Phase 0)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run *)",
+      "Bash(npm install *)",
+      "Bash(npm list *)",
+      "Bash(npx *)",
+      "Bash(node *)",
+      "Bash(git status)",
+      "Bash(git diff *)",
+      "Bash(git log *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git checkout *)",
+      "Bash(git push *)",
+      "Bash(git pull *)",
+      "Bash(git branch *)",
+      "Bash(git merge *)",
+      "Bash(git stash *)",
+      "Bash(gh *)",
+      "Bash(vercel *)",
+      "Bash(find *)",
+      "Bash(ls *)",
+      "Bash(mkdir *)",
+      "Bash(mv *)",
+      "Bash(cp *)",
+      "Bash(rm *)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Cria `.claude/settings.json` com lista de permissões para ferramentas de desenvolvimento
- Permite auto-aprovação de: `npm`, `git`, `gh`, `vercel`, `node`, utilitários de terminal (`find`, `ls`, `mkdir`, `mv`, `cp`, `rm`)
- `curl`/`wget` mantidos fora da lista (requerem aprovação manual por segurança)

## Contexto

Este PR é o **Pré-requisito** da série de refatoração Wave 9. Sem essa configuração, o agente precisa de aprovação manual em cada comando durante as sessões de refatoração.

## Test plan

- [ ] Verificar que `.claude/settings.json` é válido (JSON correto)
- [ ] Confirmar que `.env` não foi incluído acidentalmente
- [ ] Sem impacto em código de produção

🤖 Generated with [Claude Code](https://claude.com/claude-code)