### PR TITLE
refactor: fase 2 - migra PWA para src/shared/components/pwa/

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ import Loading from '@shared/components/ui/Loading'
 import Landing from './views/Landing'
 import { OnboardingProvider, OnboardingWizard } from '@shared/components/onboarding'
 import { DashboardProvider } from '@dashboard/hooks/useDashboardContext.jsx'
-import InstallPrompt from './components/pwa/InstallPrompt'
+import InstallPrompt from '@shared/components/pwa/InstallPrompt'
 
 function App() {
   const [session, setSession] = useState(null)

--- a/src/shared/components/pwa/InstallPrompt.css
+++ b/src/shared/components/pwa/InstallPrompt.css
@@ -1,0 +1,402 @@
+/**
+ * PWA Install Prompt Styles
+ * 
+ * Glassmorphism design following project design tokens
+ * Responsive for mobile and desktop
+ */
+
+/* ============================================
+   MAIN INSTALL PROMPT BANNER
+   ============================================ */
+.install-prompt {
+  position: fixed;
+  top: 16px; /* Position at top of viewport */
+  left: 16px;
+  right: 16px;
+  z-index: 9999; /* Highest z-index to ensure clickability */
+  pointer-events: auto;
+
+  background: var(--glass-standard, rgba(255, 255, 255, 0.08));
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--glass-heavy, rgba(255, 255, 255, 0.15));
+  border-radius: var(--border-radius-xl, 16px);
+  box-shadow: var(--shadow-2xl, 0 25px 50px -12px rgba(0, 0, 0, 0.5));
+
+  padding: var(--spacing-md, 16px);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.install-prompt__content {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md, 16px);
+}
+
+/* App Icon */
+.install-prompt__icon {
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+  background: linear-gradient(
+    135deg,
+    var(--color-primary, #ec4899),
+    var(--color-secondary, #06b6d4)
+  );
+  border-radius: var(--border-radius-lg, 12px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  box-shadow: var(--shadow-md, 0 4px 6px -1px rgba(0, 0, 0, 0.3));
+}
+
+/* Text Content */
+.install-prompt__text {
+  flex: 1;
+  min-width: 0;
+}
+
+.install-prompt__title {
+  font-size: var(--font-size-base, 16px);
+  font-weight: var(--font-weight-semibold, 600);
+  color: var(--color-text-primary, #ffffff);
+  margin: 0 0 var(--spacing-xs, 4px) 0;
+  line-height: 1.3;
+}
+
+.install-prompt__description {
+  font-size: var(--font-size-sm, 14px);
+  color: var(--color-text-secondary, rgba(255, 255, 255, 0.7));
+  margin: 0;
+  line-height: 1.4;
+}
+
+/* Actions */
+.install-prompt__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm, 8px);
+  flex-shrink: 0;
+}
+
+.install-prompt__install-btn {
+  background: linear-gradient(
+    135deg,
+    var(--color-primary, #ec4899),
+    var(--color-primary-dark, #db2777)
+  );
+  color: white;
+  border: none;
+  border-radius: var(--border-radius-md, 8px);
+  padding: var(--spacing-sm, 8px) var(--spacing-md, 16px);
+  font-size: var(--font-size-sm, 14px);
+  font-weight: var(--font-weight-medium, 500);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+  pointer-events: auto;
+  position: relative;
+  z-index: 10000;
+}
+
+.install-prompt__install-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-lg, 0 10px 15px -3px rgba(0, 0, 0, 0.4));
+  background: linear-gradient(
+    135deg,
+    var(--color-primary-light, #f472b6),
+    var(--color-primary, #ec4899)
+  );
+}
+
+.install-prompt__install-btn:active {
+  transform: translateY(0);
+}
+
+.install-prompt__dismiss-btn {
+  background: var(--glass-light, rgba(255, 255, 255, 0.03));
+  border: 1px solid var(--glass-heavy, rgba(255, 255, 255, 0.15));
+  color: var(--color-text-secondary, rgba(255, 255, 255, 0.7));
+  border-radius: var(--border-radius-md, 8px);
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 16px;
+  padding: 0;
+  pointer-events: auto;
+  position: relative;
+  z-index: 10000;
+}
+
+.install-prompt__dismiss-btn:hover {
+  background: var(--glass-standard, rgba(255, 255, 255, 0.08));
+  color: var(--color-text-primary, #ffffff);
+}
+
+/* ============================================
+   MODAL OVERLAY & INSTRUCTIONS
+   ============================================ */
+.install-prompt__modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: var(--z-index-modal, 1000);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-lg, 24px);
+}
+
+.install-prompt__modal {
+  background: var(--glass-standard, rgba(255, 255, 255, 0.08));
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--glass-heavy, rgba(255, 255, 255, 0.15));
+  border-radius: var(--border-radius-xl, 16px);
+  box-shadow: var(--shadow-2xl, 0 25px 50px -12px rgba(0, 0, 0, 0.5));
+  width: 100%;
+  max-width: 400px;
+  overflow: hidden;
+}
+
+/* Modal Header */
+.install-prompt__modal-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md, 16px);
+  padding: var(--spacing-lg, 24px) var(--spacing-lg, 24px) var(--spacing-md, 16px);
+  border-bottom: 1px solid var(--glass-heavy, rgba(255, 255, 255, 0.15));
+}
+
+.install-prompt__modal-icon {
+  font-size: 32px;
+}
+
+.install-prompt__modal-title {
+  flex: 1;
+  font-size: var(--font-size-lg, 18px);
+  font-weight: var(--font-weight-semibold, 600);
+  color: var(--color-text-primary, #ffffff);
+  margin: 0;
+}
+
+.install-prompt__modal-close {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary, rgba(255, 255, 255, 0.7));
+  font-size: 20px;
+  cursor: pointer;
+  padding: var(--spacing-xs, 4px);
+  line-height: 1;
+  transition: color 0.2s ease;
+}
+
+.install-prompt__modal-close:hover {
+  color: var(--color-text-primary, #ffffff);
+}
+
+/* Modal Content */
+.install-prompt__modal-content {
+  padding: var(--spacing-lg, 24px);
+}
+
+.install-prompt__steps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md, 16px);
+}
+
+.install-prompt__step {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-md, 16px);
+}
+
+.install-prompt__step-number {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  background: linear-gradient(
+    135deg,
+    var(--color-primary, #ec4899),
+    var(--color-secondary, #06b6d4)
+  );
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-sm, 14px);
+  font-weight: var(--font-weight-semibold, 600);
+  color: white;
+}
+
+.install-prompt__step-text {
+  flex: 1;
+  font-size: var(--font-size-base, 16px);
+  color: var(--color-text-secondary, rgba(255, 255, 255, 0.85));
+  line-height: 1.5;
+  padding-top: 2px;
+}
+
+/* iOS Hint */
+.install-prompt__ios-hint {
+  margin-top: var(--spacing-lg, 24px);
+  padding: var(--spacing-md, 16px);
+  background: var(--glass-light, rgba(255, 255, 255, 0.03));
+  border-radius: var(--border-radius-lg, 12px);
+  border: 1px solid var(--glass-heavy, rgba(255, 255, 255, 0.1));
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm, 8px);
+  font-size: var(--font-size-sm, 14px);
+  color: var(--color-text-secondary, rgba(255, 255, 255, 0.7));
+}
+
+.install-prompt__share-icon {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+  vertical-align: middle;
+  margin: 0 4px;
+}
+
+/* Modal Footer */
+.install-prompt__modal-footer {
+  padding: var(--spacing-md, 16px) var(--spacing-lg, 24px) var(--spacing-lg, 24px);
+  border-top: 1px solid var(--glass-heavy, rgba(255, 255, 255, 0.15));
+}
+
+.install-prompt__modal-btn {
+  width: 100%;
+  background: linear-gradient(
+    135deg,
+    var(--color-primary, #ec4899),
+    var(--color-secondary, #06b6d4)
+  );
+  color: white;
+  border: none;
+  border-radius: var(--border-radius-md, 8px);
+  padding: var(--spacing-md, 16px);
+  font-size: var(--font-size-base, 16px);
+  font-weight: var(--font-weight-semibold, 600);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  pointer-events: auto;
+  position: relative;
+  z-index: 10001;
+}
+
+.install-prompt__modal-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-lg, 0 10px 15px -3px rgba(0, 0, 0, 0.4));
+}
+
+.install-prompt__modal-btn:active {
+  transform: translateY(0);
+}
+
+/* ============================================
+   RESPONSIVE DESIGN
+   ============================================ */
+
+/* Desktop adjustments */
+@media (min-width: 768px) {
+  .install-prompt {
+    top: 24px; /* No BottomNav on desktop */
+    left: 24px;
+    right: 24px;
+    padding: var(--spacing-lg, 24px);
+  }
+
+  .install-prompt__icon {
+    width: 56px;
+    height: 56px;
+    font-size: 28px;
+  }
+
+  .install-prompt__title {
+    font-size: var(--font-size-lg, 18px);
+  }
+
+  .install-prompt__description {
+    font-size: var(--font-size-base, 16px);
+  }
+
+  .install-prompt__install-btn {
+    padding: var(--spacing-md, 16px) var(--spacing-lg, 24px);
+    font-size: var(--font-size-base, 16px);
+  }
+}
+
+/* Small mobile screens */
+@media (max-width: 360px) {
+  .install-prompt {
+    left: 12px;
+    right: 12px;
+    padding: var(--spacing-sm, 12px);
+  }
+
+  .install-prompt__content {
+    gap: var(--spacing-sm, 8px);
+  }
+
+  .install-prompt__icon {
+    width: 40px;
+    height: 40px;
+    font-size: 20px;
+  }
+
+  .install-prompt__title {
+    font-size: var(--font-size-sm, 14px);
+  }
+
+  .install-prompt__description {
+    font-size: var(--font-size-xs, 12px);
+  }
+
+  .install-prompt__install-btn {
+    padding: var(--spacing-xs, 8px) var(--spacing-sm, 12px);
+    font-size: var(--font-size-xs, 12px);
+  }
+
+  .install-prompt__dismiss-btn {
+    width: 32px;
+    height: 32px;
+  }
+}
+
+/* Safe area for notched devices */
+@supports (padding-top: env(safe-area-inset-top)) {
+  .install-prompt {
+    padding-top: calc(var(--spacing-md, 16px) + env(safe-area-inset-top));
+  }
+}
+
+/* Reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .install-prompt,
+  .install-prompt__install-btn,
+  .install-prompt__dismiss-btn,
+  .install-prompt__modal-btn {
+    transition: none;
+  }
+
+  .install-prompt__install-btn:hover,
+  .install-prompt__modal-btn:hover {
+    transform: none;
+  }
+}

--- a/src/shared/components/pwa/InstallPrompt.jsx
+++ b/src/shared/components/pwa/InstallPrompt.jsx
@@ -1,0 +1,342 @@
+import { useState, useEffect, useCallback } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import './InstallPrompt.css'
+import {
+  isStandalone,
+  isIOSSafari,
+  isChromeAndroid,
+  isDesktopChrome,
+  canShowNativePrompt,
+  wasPromptDismissed,
+  dismissPrompt,
+  isDismissalExpired,
+  getInstallInstructions,
+} from './pwaUtils'
+
+/**
+ * PWA Install Prompt Component
+ *
+ * Displays an install prompt for users on supported platforms.
+ * - iOS Safari: Shows custom instructions for "Add to Home Screen"
+ * - Chrome/Android & Desktop: Shows native install button or custom instructions
+ * - Dismissible with localStorage persistence
+ * - Hides when app is already installed (standalone mode)
+ */
+export default function InstallPrompt() {
+  const [isVisible, setIsVisible] = useState(false)
+  const [deferredPrompt, setDeferredPrompt] = useState(null)
+  const [showIOSInstructions, setShowIOSInstructions] = useState(false)
+  const [platformInfo, setPlatformInfo] = useState({
+    isIOSSafari: false,
+    isChromeAndroid: false,
+    isDesktopChrome: false,
+    canShowNativePrompt: false,
+  })
+
+  // Detect platform and check if prompt should be shown
+  useEffect(() => {
+    const checkVisibility = () => {
+      console.log('[PWA Install] Checking visibility...')
+
+      // Don't show if already in standalone mode
+      if (isStandalone()) {
+        console.log('[PWA Install] Hidden: Running in standalone mode')
+        setIsVisible(false)
+        return
+      }
+
+      // Don't show if user recently dismissed
+      if (wasPromptDismissed() && !isDismissalExpired()) {
+        console.log('[PWA Install] Hidden: Recently dismissed')
+        setIsVisible(false)
+        return
+      }
+
+      // Detect platform
+      console.log('[PWA Install] Starting platform detection...')
+      const isIOS = isIOSSafari()
+      console.log('[PWA Install] isIOSSafari:', isIOS)
+      const isAndroid = isChromeAndroid()
+      console.log('[PWA Install] isChromeAndroid:', isAndroid)
+      const isDesktop = isDesktopChrome()
+      console.log('[PWA Install] isDesktopChrome result:', isDesktop)
+      const supportsInstall = 'BeforeInstallPromptEvent' in window
+
+      console.log('[PWA Install] Platform detection:', { isIOS, isAndroid, isDesktop })
+      console.log('[PWA Install] User agent:', navigator.userAgent)
+      console.log('[PWA Install] BeforeInstallPromptEvent supported:', supportsInstall)
+
+      setPlatformInfo({
+        isIOSSafari: isIOS,
+        isChromeAndroid: isAndroid,
+        isDesktopChrome: isDesktop,
+        canShowNativePrompt: canShowNativePrompt(),
+      })
+
+      // Show prompt for supported platforms
+      const shouldShow = isIOS || isAndroid || isDesktop
+      console.log('[PWA Install] Should show banner:', shouldShow)
+      setIsVisible(shouldShow)
+    }
+
+    checkVisibility()
+  }, [])
+
+  // Listen for beforeinstallprompt event (Chrome/Edge)
+  useEffect(() => {
+    console.log('[PWA Install] Setting up beforeinstallprompt listener')
+
+    const handleBeforeInstallPrompt = (event) => {
+      console.log('[PWA Install] beforeinstallprompt event fired!')
+      // Prevent the default browser prompt
+      event.preventDefault()
+      // Store the event for later use
+      setDeferredPrompt(event)
+    }
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
+
+    // Check if event was already fired (before this component mounted)
+    console.log('[PWA Install] Component mounted, checking for deferred prompt...')
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
+    }
+  }, [])
+
+  // Handle dismiss
+  const handleDismiss = useCallback(() => {
+    setIsVisible(false)
+    dismissPrompt(30) // Remember dismissal for 30 days
+  }, [])
+
+  // Handle install click
+  const handleInstall = useCallback(async () => {
+    console.log('[PWA Install] Button clicked')
+    console.log('[PWA Install] Platform info:', platformInfo)
+    console.log('[PWA Install] Deferred prompt available:', !!deferredPrompt)
+    console.log('[PWA Install] Native prompt supported:', canShowNativePrompt())
+
+    // iOS Safari - show instructions
+    if (platformInfo.isIOSSafari) {
+      console.log('[PWA Install] iOS Safari detected - showing instructions')
+      setShowIOSInstructions(true)
+      return
+    }
+
+    // Chrome/Edge with deferred prompt
+    if (deferredPrompt) {
+      console.log('[PWA Install] Triggering deferred prompt...')
+      try {
+        // Show the native install prompt
+        deferredPrompt.prompt()
+
+        // Wait for user choice
+        const { outcome } = await deferredPrompt.userChoice
+        console.log('[PWA Install] User choice outcome:', outcome)
+
+        if (outcome === 'accepted') {
+          setIsVisible(false)
+        }
+
+        // Clear the deferred prompt
+        setDeferredPrompt(null)
+      } catch (error) {
+        console.error('[PWA Install] Error showing prompt:', error)
+      }
+      return
+    }
+
+    // Chrome Android without deferred prompt - show manual instructions
+    if (platformInfo.isChromeAndroid) {
+      console.log('[PWA Install] Chrome Android without deferred prompt - showing instructions')
+      setShowIOSInstructions(true) // Reuse the instructions modal
+      return
+    }
+
+    // Desktop Chrome/Edge without deferred prompt (common in dev/localhost)
+    // Show instructions instead of doing nothing
+    if (platformInfo.isDesktopChrome) {
+      console.log('[PWA Install] Desktop Chrome without deferred prompt - showing instructions')
+      console.log(
+        '[PWA Install] Note: beforeinstallprompt may not fire on localhost or in development'
+      )
+      setShowIOSInstructions(true)
+      return
+    }
+
+    console.log('[PWA Install] No matching platform handler - browser may not support PWA install')
+  }, [deferredPrompt, platformInfo])
+
+  // Close instructions modal
+  const handleCloseInstructions = useCallback(() => {
+    console.log('[PWA Install] Closing instructions modal')
+    setShowIOSInstructions(false)
+    setIsVisible(false)
+    dismissPrompt(30)
+    console.log('[PWA Install] Instructions modal closed, banner dismissed for 30 days')
+  }, [])
+
+  // Get appropriate text based on platform
+  const getPromptText = () => {
+    if (platformInfo.isIOSSafari) {
+      return {
+        title: 'Adicione à Tela de Início',
+        description: 'Acesse o Meus Remédios rapidamente como um app nativo',
+        buttonText: 'Ver Como Instalar',
+      }
+    }
+
+    if (platformInfo.isChromeAndroid) {
+      return {
+        title: 'Instale o Meus Remédios',
+        description: 'Acesse rapidamente como um app nativo no seu Android',
+        buttonText: 'Instalar Agora',
+      }
+    }
+
+    return {
+      title: 'Instale o Meus Remédios',
+      description: 'Acesse rapidamente como um app nativo no seu computador',
+      buttonText: 'Instalar Agora',
+    }
+  }
+
+  const promptText = getPromptText()
+  const instructions = getInstallInstructions()
+
+  return (
+    <>
+      {/* Main Install Prompt Banner */}
+      <AnimatePresence>
+        {isVisible && !showIOSInstructions && (
+          <motion.div
+            className="install-prompt"
+            initial={{ y: -100, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: -100, opacity: 0 }}
+            transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+            role="dialog"
+            aria-label="Prompt de instalação do app"
+          >
+            <div className="install-prompt__content">
+              {/* App Icon */}
+              <div className="install-prompt__icon">
+                <span role="img" aria-label="Ícone do app">
+                  💊
+                </span>
+              </div>
+
+              {/* Text Content */}
+              <div className="install-prompt__text">
+                <h3 className="install-prompt__title">{promptText.title}</h3>
+                <p className="install-prompt__description">{promptText.description}</p>
+              </div>
+
+              {/* Actions */}
+              <div className="install-prompt__actions">
+                <button
+                  className="install-prompt__install-btn"
+                  onClick={handleInstall}
+                  type="button"
+                >
+                  {promptText.buttonText}
+                </button>
+                <button
+                  className="install-prompt__dismiss-btn"
+                  onClick={handleDismiss}
+                  type="button"
+                  aria-label="Fechar prompt de instalação"
+                >
+                  ✕
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* iOS/Android Instructions Modal */}
+      <AnimatePresence>
+        {showIOSInstructions && (
+          <motion.div
+            className="install-prompt__modal-overlay"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={handleCloseInstructions}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="install-instructions-title"
+          >
+            <motion.div
+              className="install-prompt__modal"
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.9, opacity: 0 }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="install-prompt__modal-header">
+                <span className="install-prompt__modal-icon" role="img" aria-label="Ícone">
+                  {instructions.icon}
+                </span>
+                <h3 id="install-instructions-title" className="install-prompt__modal-title">
+                  {instructions.title}
+                </h3>
+                <button
+                  className="install-prompt__modal-close"
+                  onClick={handleCloseInstructions}
+                  type="button"
+                  aria-label="Fechar instruções"
+                >
+                  ✕
+                </button>
+              </div>
+
+              <div className="install-prompt__modal-content">
+                <ol className="install-prompt__steps">
+                  {instructions.steps.map((step, index) => (
+                    <li key={index} className="install-prompt__step">
+                      <span className="install-prompt__step-number">{index + 1}</span>
+                      <span className="install-prompt__step-text">{step}</span>
+                    </li>
+                  ))}
+                </ol>
+
+                {platformInfo.isIOSSafari && (
+                  <div className="install-prompt__ios-hint">
+                    <span role="img" aria-label="Dica">
+                      💡
+                    </span>
+                    <span>
+                      Procure o botão
+                      <svg
+                        className="install-prompt__share-icon"
+                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                        aria-hidden="true"
+                      >
+                        <path d="M16 5l-1.42-1.42-4.58 4.59V0h-2v8.17L3.42 3.58 2 5l7 7 7-7zm7 6v8c0 1.1-.9 2-2 2H5c-1.1 0-2-.9-2-2v-8H0v8c0 2.76 2.24 5 5 5h14c2.76 0 5-2.24 5-5v-8h-2z" />
+                      </svg>{' '}
+                      na barra do Safari
+                    </span>
+                  </div>
+                )}
+              </div>
+
+              <div className="install-prompt__modal-footer">
+                <button
+                  className="install-prompt__modal-btn"
+                  onClick={handleCloseInstructions}
+                  type="button"
+                >
+                  Entendi
+                </button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  )
+}

--- a/src/shared/components/pwa/pwaUtils.js
+++ b/src/shared/components/pwa/pwaUtils.js
@@ -1,0 +1,219 @@
+/**
+ * PWA Detection Utilities
+ *
+ * Helper functions to detect PWA installation state, browser capabilities,
+ * and platform-specific behaviors.
+ */
+
+/**
+ * Check if the app is running in standalone mode (installed as PWA)
+ * @returns {boolean} True if running as installed PWA
+ */
+export function isStandalone() {
+  return (
+    window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true
+  )
+}
+
+/**
+ * Check if the browser is iOS Safari
+ * @returns {boolean} True if running on iOS Safari
+ */
+export function isIOSSafari() {
+  const userAgent = window.navigator.userAgent.toLowerCase()
+  const isIOS = /iphone|ipad|ipod/.test(userAgent)
+  const isSafari = /safari/.test(userAgent) && !/chrome/.test(userAgent)
+
+  return isIOS && isSafari
+}
+
+/**
+ * Check if the browser is Chrome on Android
+ * @returns {boolean} True if running on Chrome Android
+ */
+export function isChromeAndroid() {
+  const userAgent = window.navigator.userAgent.toLowerCase()
+  const isAndroid = /android/.test(userAgent)
+  const isChrome = /chrome/.test(userAgent) && /mobile/.test(userAgent)
+
+  return isAndroid && isChrome
+}
+
+/**
+ * Check if the browser supports beforeinstallprompt event (Chrome/Edge)
+ * @returns {boolean} True if beforeinstallprompt is supported
+ */
+export function supportsBeforeInstallPrompt() {
+  return 'BeforeInstallPromptEvent' in window
+}
+
+/**
+ * Check if the browser is desktop Chrome/Edge/Opera (Chromium-based)
+ * @returns {boolean} True if desktop Chromium browser
+ */
+export function isDesktopChrome() {
+  const userAgent = window.navigator.userAgent.toLowerCase()
+
+  console.log('[PWA Utils] isDesktopChrome - User agent:', userAgent)
+
+  // More flexible detection for Chrome on any platform (including macOS)
+  const hasChrome = /chrome|chromium/.test(userAgent)
+  const hasEdge = /edg|edge/.test(userAgent)
+  const hasOpera = /opr|opera/.test(userAgent)
+  const hasBrave = /brave/.test(userAgent)
+  const hasMobile = /mobile|android/.test(userAgent)
+
+  const isChrome = hasChrome && !hasMobile
+  const isEdge = hasEdge && !hasMobile
+  const isOpera = hasOpera && !hasMobile
+  const isBraveBrowser = hasBrave && !hasMobile
+
+  const result = isChrome || isEdge || isOpera || isBraveBrowser
+
+  console.log('[PWA Utils] Detection:', {
+    hasChrome,
+    hasEdge,
+    hasOpera,
+    hasBrave,
+    hasMobile,
+    isChrome,
+    isEdge,
+    isOpera,
+    isBraveBrowser,
+    result,
+  })
+
+  // Show banner for ANY Chromium desktop browser, not just those with beforeinstallprompt
+  return result
+}
+
+/**
+ * Check if the browser supports native beforeinstallprompt event
+ * @returns {boolean} True if BeforeInstallPromptEvent is supported
+ */
+export function canShowNativePrompt() {
+  return supportsBeforeInstallPrompt()
+}
+
+/**
+ * Check if browser is any Chromium-based browser that might support PWA
+ * @returns {boolean} True if Chromium-based desktop browser
+ */
+export function isChromiumDesktop() {
+  const userAgent = window.navigator.userAgent.toLowerCase()
+  const isDesktop = !/mobile|android|iphone|ipad|ipod/.test(userAgent)
+  const isChrome = /chrome|chromium/.test(userAgent)
+  const isEdge = /edg|edge/.test(userAgent)
+  const isOpera = /opr|opera/.test(userAgent)
+  const isBrave = /brave/.test(userAgent)
+
+  return isDesktop && (isChrome || isEdge || isOpera || isBrave)
+}
+
+/**
+ * Check if the prompt was previously dismissed by the user
+ * @returns {boolean} True if user dismissed the prompt
+ */
+export function wasPromptDismissed() {
+  try {
+    const dismissed = localStorage.getItem('pwa-install-dismissed')
+    return dismissed === 'true'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Mark the prompt as dismissed by the user
+ * @param {number} days - Number of days to remember dismissal (default: 30)
+ */
+export function dismissPrompt(days = 30) {
+  try {
+    localStorage.setItem('pwa-install-dismissed', 'true')
+    const expiryDate = new Date()
+    expiryDate.setDate(expiryDate.getDate() + days)
+    localStorage.setItem('pwa-install-dismissed-expiry', expiryDate.toISOString())
+  } catch {
+    // Ignore localStorage errors
+  }
+}
+
+/**
+ * Reset the dismissed state (useful for testing or after expiry)
+ */
+export function resetDismissedState() {
+  try {
+    localStorage.removeItem('pwa-install-dismissed')
+    localStorage.removeItem('pwa-install-dismissed-expiry')
+  } catch {
+    // Ignore localStorage errors
+  }
+}
+
+/**
+ * Check if the dismissal has expired
+ * @returns {boolean} True if dismissal has expired or doesn't exist
+ */
+export function isDismissalExpired() {
+  try {
+    const expiry = localStorage.getItem('pwa-install-dismissed-expiry')
+    if (!expiry) return true
+
+    return new Date() > new Date(expiry)
+  } catch {
+    return true
+  }
+}
+
+/**
+ * Get the appropriate install instructions based on platform
+ * @returns {Object} Install instructions for the current platform
+ */
+export function getInstallInstructions() {
+  if (isIOSSafari()) {
+    return {
+      title: 'Adicionar à Tela de Início',
+      steps: [
+        'Toque no botão Compartilhar no Safari',
+        'Role para baixo e toque em "Adicionar à Tela de Início"',
+        'Toque em "Adicionar" para confirmar',
+      ],
+      icon: '📱',
+    }
+  }
+
+  if (isChromeAndroid()) {
+    return {
+      title: 'Instalar o App',
+      steps: [
+        'Toque no menu (⋮) no Chrome',
+        'Selecione "Adicionar à tela inicial"',
+        'Confirme para instalar',
+      ],
+      icon: '📲',
+    }
+  }
+
+  // Desktop Chrome/Edge
+  return {
+    title: 'Instalar o App',
+    steps: ['Clique em "Instalar" no prompt', 'Ou use o menu (⋮) > Instalar Meus Remédios'],
+    icon: '💻',
+  }
+}
+
+/**
+ * Comprehensive PWA state detection
+ * @returns {Object} Complete PWA state information
+ */
+export function getPWAState() {
+  return {
+    isStandalone: isStandalone(),
+    isIOSSafari: isIOSSafari(),
+    isChromeAndroid: isChromeAndroid(),
+    isDesktopChrome: isDesktopChrome(),
+    supportsBeforeInstallPrompt: supportsBeforeInstallPrompt(),
+    wasDismissed: wasPromptDismissed() && !isDismissalExpired(),
+    canShowPrompt: !isStandalone() && (!wasPromptDismissed() || isDismissalExpired()),
+  }
+}


### PR DESCRIPTION
## Summary

- Cria `src/shared/components/pwa/` como local canônico
- Move `InstallPrompt.jsx`, `InstallPrompt.css` e `pwaUtils.js` para o novo local
- Atualiza `src/App.jsx`: `./components/pwa/InstallPrompt` → `@shared/components/pwa/InstallPrompt`
- O diretório legado `src/components/pwa/` será removido na Fase 3 (após merge desta PR)

## Contexto

`src/components/pwa/` era o único subdiretório legado sem equivalente canônico. Este PR cria esse equivalente antes da remoção em massa dos legados.

## Test plan

- [x] `npm run lint` → 0 erros
- [ ] App carrega normalmente (testar instalação PWA)
- [ ] `InstallPrompt` renderiza sem erros no browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)