### PR TITLE
refactor(css): move inline styles to CSS Modules in Dashboard and Settings

### DIFF
--- a/src/views/Dashboard.jsx
+++ b/src/views/Dashboard.jsx
@@ -679,13 +679,12 @@ export default function Dashboard({ onNavigate }) {
       {stockBarsItems.length > 0 && (
         <section className={styles.section}>
           <button
-            className={styles.sectionHeader}
-            style={{ width: '100%', background: 'none', border: 'none', cursor: 'pointer', textAlign: 'left', padding: 0 }}
+            className={styles.sectionHeaderButton}
             onClick={() => setIsStockCollapsed((v) => !v)}
             aria-expanded={!isStockCollapsed}
           >
             <h2 className={styles.sectionTitle}>ESTOQUE</h2>
-            <span style={{ marginLeft: 'auto' }}>{isStockCollapsed ? '▼' : '▲'}</span>
+            <span className={styles.collapseToggle}>{isStockCollapsed ? '▼' : '▲'}</span>
           </button>
           {!isStockCollapsed && (
             <StockBars
@@ -719,23 +718,10 @@ export default function Dashboard({ onNavigate }) {
           + REGISTRO MANUAL
         </button>
         <button
-          className="btn-consultation-mode"
+          className={styles.consultationButton}
           onClick={() => {
             analyticsService.track('consultation_mode_opened')
             onNavigate?.('consultation')
-          }}
-          style={{
-            marginTop: 'var(--space-2)',
-            padding: 'var(--space-2) var(--space-4)',
-            background: 'transparent',
-            border: '1px solid var(--primary)',
-            color: 'var(--primary)',
-            borderRadius: 'var(--radius-md)',
-            cursor: 'pointer',
-            fontSize: 'var(--font-size-sm)',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 'var(--space-1)',
           }}
         >
           <span>👨‍⚕️</span>

--- a/src/views/Dashboard.module.css
+++ b/src/views/Dashboard.module.css
@@ -86,7 +86,7 @@
   height: 36px;
   padding: 0;
   background: var(--bg-glass);
-  border: 1px solid var(--border-color);
+  border: var(--border-width-thin) solid var(--border-color);
   border-radius: var(--radius-button);
   cursor: pointer;
   font-size: 1.125rem;
@@ -184,6 +184,53 @@
   gap: var(--space-2);
 }
 
+.sectionHeaderButton {
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  padding: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.collapseToggle {
+  margin-left: auto;
+}
+
+/* ============================================
+   CONSULTATION MODE BUTTON
+   ============================================ */
+
+.consultationButton {
+  margin-top: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  background: transparent;
+  border: var(--border-width-thin) solid var(--color-primary);
+  color: var(--color-primary);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  transition: all var(--transition-fast);
+  font-family: inherit;
+  font-weight: inherit;
+}
+
+.consultationButton:hover {
+  background: var(--color-primary);
+  color: white;
+  transform: translateY(-1px);
+}
+
+.consultationButton:active {
+  transform: translateY(0);
+}
+
 .sectionTitle {
   font-size: var(--text-lg);
   font-weight: var(--font-weight-semibold);
@@ -268,7 +315,7 @@
   min-height: 48px;
   min-width: 200px;
   background: rgba(236, 72, 153, 0.2); /* Magenta semi-transparente */
-  border: 1px solid rgba(236, 72, 153, 0.5); /* Borda translúcida */
+  border: var(--border-width-thin) solid rgba(236, 72, 153, 0.5); /* Borda translúcida */
   border-radius: var(--radius-button);
   color: #fff; /* Texto branco */
   font-size: var(--font-size-sm);

--- a/src/views/Settings.jsx
+++ b/src/views/Settings.jsx
@@ -5,6 +5,7 @@ import Loading from '@shared/components/ui/Loading'
 import Modal from '@shared/components/ui/Modal'
 import ExportDialog from '@features/export/components/ExportDialog'
 import ReportGenerator from '@features/reports/components/ReportGenerator'
+import styles from './Settings.module.css'
 import './Settings.css'
 
 export default function Settings({ onNavigate }) {
@@ -222,7 +223,7 @@ export default function Settings({ onNavigate }) {
           <Button
             variant="outline"
             onClick={() => onNavigate('consultation')}
-            style={{ marginLeft: 'var(--space-2)' }}
+            className={styles.consultationButton}
           >
             Modo Consulta Médica
           </Button>

--- a/src/views/Settings.module.css
+++ b/src/views/Settings.module.css
@@ -1,0 +1,15 @@
+/**
+ * Settings CSS Module
+ *
+ * Estilos scoped para o componente Settings.
+ */
+
+.emergencyButtonGroup {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.consultationButton {
+  margin-left: var(--space-2);
+}


### PR DESCRIPTION
## Resumo
Resolve issues #232, #233, #225 movendo estilos inline para CSS Modules em Dashboard e Settings.

## Mudanças
### Dashboard.jsx
- Remove estilos inline do botão de colapso (marginLeft: auto)
- Remove bloco grande de estilos inline do botão "Modo Consulta Médica"
- Usa classes CSS .sectionHeaderButton, .collapseToggle e .consultationButton

### Settings.jsx
- Remove estilos inline do botão "Modo Consulta Médica"
- Importa Settings.module.css
- Usa classe CSS .consultationButton

### CSS Modules
- **Dashboard.module.css**: Adiciona classes para button styles
  - `.sectionHeaderButton` — button com display flex e sem defaults
  - `.collapseToggle` — span com margin-left auto
  - `.consultationButton` — botão de modo consulta com hover/active states
  
- **Settings.module.css** (novo): Estilos específicos do Settings
  - `.consultationButton` — reutiliza padrão de Dashboard

## Benefícios
✅ CSS organizado e escopado via CSS Modules
✅ Evita conflitos de estilos globais
✅ Melhor manutenibilidade (estilos junto do layout)
✅ Facilita temas e responsive design
✅ Consistência com padrão do projeto

## Testes
- ✅ Lint passou
- ✅ Testes críticos passaram

🤖 Generated with [Claude Code](https://claude.com/claude-code)