### PR TITLE
fix(workflow): atualiza comentario de bloqueio quando issues sao resolvidas

### DIFF
--- a/.github/scripts/check-critical-issues.cjs
+++ b/.github/scripts/check-critical-issues.cjs
@@ -256,6 +256,62 @@ async function postAlertComment(github, context, prNumber, blockingIssues) {
 }
 
 /**
+ * Encontra e Remove/Atualiza o comentário de bloqueio quando issues são resolvidas
+ * @param {Object} github - Cliente GitHub Actions
+ * @param {Object} context - Contexto do GitHub Actions
+ * @param {number} prNumber - Número do PR
+ * @returns {Promise<boolean>} True se removeu/atualizou o comentário
+ */
+async function clearBlockingComment(github, context, prNumber) {
+  try {
+    const alertMarker = '🛑 Workflow Bloqueado';
+
+    // Buscar todos os comentários do PR
+    const comments = await github.paginate(github.rest.issues.listComments, {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: prNumber,
+      per_page: 100
+    });
+
+    // Encontrar o comentário de bloqueio
+    const blockingComment = comments.find(comment =>
+      comment.body?.includes(alertMarker) &&
+      comment.user.login === 'github-actions[bot]'
+    );
+
+    if (!blockingComment) {
+      logInfo('Nenhum comentário de bloqueio encontrado para remover', { prNumber });
+      return false;
+    }
+
+    // Atualizar o comentário para indicar resolução
+    const resolutionBody = `## ✅ Issues Resolvidas - PR Aprovado pelo Gemini
+
+O Gemini Code Assist revisou as correções aplicadas e **não foram encontradas mais issues bloqueantes**. O PR está aprovado para merge.
+
+---
+*Este comentário foi automaticamente atualizado. O resumo de review está disponível abaixo.*`;
+
+    await github.rest.issues.updateComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: blockingComment.id,
+      body: resolutionBody
+    });
+
+    logInfo('Comentário de bloqueio atualizado para resolução', { prNumber, commentId: blockingComment.id });
+    return true;
+  } catch (error) {
+    logError('Erro ao remover/atualizar comentário de bloqueio', {
+      prNumber,
+      error: error.message
+    });
+    return false;
+  }
+}
+
+/**
  * Define os outputs para o GitHub Actions
  * @param {Object} core - Objeto core do GitHub Actions
  * @param {Object} result - Resultado da verificação
@@ -364,6 +420,12 @@ async function checkCriticalIssues(options = {}) {
     process.exitCode = 1;
   } else {
     logInfo('✅ Nenhum issue bloqueante encontrado - Workflow pode continuar');
+
+    // Se temos acesso à API, verificar e remover comentário de bloqueio antigo
+    if (github && context && (prNumber || reviewData.pr_number)) {
+      await clearBlockingComment(github, context, prNumber || reviewData.pr_number);
+    }
+
     process.exitCode = 0;
   }
 
@@ -379,6 +441,7 @@ module.exports = {
   isBlockingIssue,
   extractBlockingIssues,
   generateAlertComment,
+  clearBlockingComment,
   BLOCKING_PRIORITIES,
   BLOCKING_CATEGORIES
 };

--- a/.memory/journal/2026-W11.md
+++ b/.memory/journal/2026-W11.md
@@ -1,0 +1,73 @@
+# Journal — 2026 Week 11 (Mar 8-14)
+
+---
+
+### 2026-03-07 — Gemini Workflow Blocking Comment Fix (BUG FIX)
+**Type:** BUG FIX
+**Files:**
+- `.github/scripts/check-critical-issues.cjs` (editado)
+- `docs/archive/GEMINI_WORKFLOW_BLOCKING_COMMENT_FIX.md` (novo)
+**Status:** [DELIVERED — branch pushada para PR]
+
+**Context:**
+PR #264 estava mostrando como "bloqueado" mesmo após o desenvolvedor corrigir os issues e marcar as threads como resolvidas. Runs do workflow mostravam "success" mas o comentário antigo "🛑 Workflow Bloqueado" permanecia visível.
+
+**Problema Identificado:**
+A função `postAlertComment()` criava o comentário de bloqueio quando issues eram encontradas, mas não havia lógica para atualizar/remover esse comentário quando as issues eram resolvidas. Apenas logava "✅ Nenhum issue bloqueante encontrado" sem atualizar o estado.
+
+**Solução Implementada:**
+Adicionada nova função `clearBlockingComment()` que:
+1. Busca comentários existentes do PR com marcador "🛑 Workflow Bloqueado"
+2. Atualiza para "✅ Issues Resolvidas - PR Aprovado pelo Gemini"
+3. Mantém histórico na timeline mas indica claramente que issues foram resolvidas
+
+**Lição aprendida:**
+Em sistemas de automação com flags de estado (bloqueado/aprovado), SEMPRE garantir que o estado seja atualizado quando as condições mudam. Comentários no PR funcionam como estado implícito — quando o sistema depende deles para indicar status, deve haver lógica para atualizá-los.
+
+---
+
+### 2026-03-05 — Wave 1 UX Evolution (PR pendente) [FEATURE]
+**Type:** FEATURE
+**Files:**
+- `src/shared/styles/animations.css` (novo)
+- `src/features/dashboard/components/RingGauge.jsx` + `RingGauge.css` (novo)
+- `src/features/dashboard/components/StockBars.jsx` + `StockBars.css` (novo)
+- `src/features/stock/components/CostChart.jsx` + `CostChart.css` (novo)
+- `src/features/dashboard/components/SparklineAdesao.jsx` (evoluído)
+- `src/features/dashboard/components/SwipeRegisterItem.jsx` (editado)
+- `src/shared/components/ui/Calendar.jsx` (evoluído)
+- 5 arquivos de teste novos
+**Status:** [DELIVERED — aguarda review]
+
+**Context:**
+Onda 1 da UX Evolution: criar componentes visuais isolados (puros, dados via props) que serão integrados nas Ondas 2 e 3. Filosofia: "transformar números em histórias visuais".
+
+**Resultado:**
+- 7/8 tasks entregues (W1-07 bloqueada por F5.9)
+- 59 novos testes, todos passando
+- lint 0 erros, build OK
+
+---
+
+**Lições aprendidas desta sessão:**
+
+#### L-01: Spec pode referenciar path errado — sempre verificar com `find`
+A spec do W1-04 dizia `src/shared/components/log/SwipeRegisterItem.jsx`, mas o arquivo real está em `src/features/dashboard/components/SwipeRegisterItem.jsx`. O `find src -name "*SwipeRegisterItem*"` confirmou antes de editar. **Sempre executar `find` antes de editar qualquer arquivo referenciado em spec.**
+
+#### L-02: ESLint `varsIgnorePattern` deste projeto não cobre aliases como `_trend`
+A config ESLint usa `varsIgnorePattern: /^(motion|AnimatePresence|[A-Z_])/u`. Na prática, variáveis prefixadas com `_` (ex: `_trend`) AINDA geraram erro. A solução correta é simplesmente **remover props não utilizadas da desestruturação** (ou usá-las) ao invés de tentar "marcar como intencionalmente não usada" com prefixo.
+
+#### L-03: `screen.getByText()` falha quando o texto aparece em múltiplos elementos
+Em SparklineAdesao, "80%" aparecia tanto nos labels do tooltip quanto no stats badge. Usar `screen.getByText('80%')` lança "Found multiple elements". A solução: `container.querySelector('.sparkline-average').textContent`. **Regra: para texto que pode aparecer em múltiplos locais, usar seletores CSS específicos em vez de `getByText()`.**
+
+#### L-04: Tooltip SVG com `<g>` + `<rect>` + `<text>` evita complexidade de posicionamento CSS
+Ao criar tooltips dentro de um `<svg>`, usar elementos SVG nativos (`<rect>` para fundo, `<text>` para conteúdo) é mais simples que `foreignObject` ou elementos HTML sobrepostos. Clampar x/y dentro dos limites do viewBox previne overflow.
+
+#### L-05: `color-mix()` CSS para heat map com fallback `@supports`
+Para aplicar transparência semântica nas cores de adesão do Calendar, usar `color-mix(in srgb, var(--heat-color) 25%, transparent)` é elegante. Mas Safari < 16.2 não suporta — adicionar `@supports not (background: color-mix(...))` com fallback via `border: 1px solid var(--heat-color)` garante degradação graciosa.
+
+#### L-06: Framer Motion `motion.circle` com `strokeDashoffset` — definir nos dois lugares
+Para evitar "flash" do ring cheio antes da animação, definir `strokeDashoffset` tanto em `style` (render estático) quanto em `initial`/`animate`. Sem o `style`, o navegador renderiza o valor padrão (0 = anel cheio) antes do Framer Motion assumir o controle.
+
+#### L-07: Componentes Onda 1 são PUROS — nunca importar context
+Guardrail crítico: componentes da Onda 1 recebem dados APENAS por props. Nunca importar `useDashboardContext`, `DashboardProvider`, ou qualquer context. A integração acontece na Onda 2 (Dashboard.jsx recebe dados do context e passa como props para os componentes).

--- a/docs/archive/GEMINI_WORKFLOW_BLOCKING_COMMENT_FIX.md
+++ b/docs/archive/GEMINI_WORKFLOW_BLOCKING_COMMENT_FIX.md
@@ -1,0 +1,104 @@
+# Análise e Correção: Workflow Bloqueado Mesmo Após Issues Resolvidas
+
+## Contexto
+
+O PR #264 estava mostrando como "bloqueado" pelo Gemini Code Review mesmo após:
+1. O desenvolvedor aplicar correções nos arquivos
+2. O Gemini revisar e confirmar a solução
+3. O desenvolvedor marcar as threads como resolvidas
+
+## Análise do Problema
+
+### Sintomas Observados
+- Runs do workflow mostram "success" (sucesso)
+- Último comentário do summary mostra "Total de Issues: 0"
+- Comentário antigo "🛑 Workflow Bloqueado" ainda visível no PR
+
+### Causa Raiz
+
+Analisando o script [`check-critical-issues.cjs`](../../.github/scripts/check-critical-issues.cjs), identifiquei a lógica:
+
+1. **Quando issues bloqueantes são encontradas** (linhas 347-361):
+   - Chama `postAlertComment()` que cria comentário "🛑 Workflow Bloqueado"
+   - Usa `hasExistingAlertComment()` para evitar duplicatas (apenas cria se não existir)
+
+2. **Quando NÃO há issues bloqueantes** (linha 366):
+   - Apenas loga "✅ Nenhum issue bloqueante encontrado"
+   - **NÃO remove ou atualiza** o comentário de bloqueio antigo
+
+O problema: O comentário antigo permanecia na timeline do PR, criando a impressão de que ainda havia issues bloqueantes.
+
+### Possibilidades Consideradas
+
+| Opção | Descrição | Prós | Contras |
+|-------|-----------|------|---------|
+| 1. Deletar comentário | Remover completamente o comentário de bloqueio | Timeline limpa | Perde histórico |
+| 2. Atualizar para "resolvido" | Substituir por mensagem de resolução | Mantém histórico, clara mensagem | Requer API call adicional |
+| 3. Adicionar reaction | Adicionar ✅ no comentário existente | Simples | Pouco visível |
+| 4. Postar novo comentário | Criar novo comentário "aprovado" | 明快 | Duplicação de info |
+
+## Solução Implementada
+
+Opção 2: **Atualizar para "resolvido"**
+
+### Mudanças em [`check-critical-issues.cjs`](../../.github/scripts/check-critical-issues.cjs)
+
+1. **Nova função `clearBlockingComment()`** (linhas 258-313):
+   ```javascript
+   async function clearBlockingComment(github, context, prNumber) {
+     // 1. Busca comentários existentes do PR
+     // 2. Encontra comentário com marcador '🛑 Workflow Bloqueado'
+     // 3. Atualiza para '✅ Issues Resolvidas - PR Aprovado'
+   }
+   ```
+
+2. **Chamada no else branch** (linhas 424-427):
+   ```javascript
+   } else {
+     logInfo('✅ Nenhum issue bloqueante encontrado - Workflow pode continuar');
+     
+     // Se temos acesso à API, verificar e remover comentário de bloqueio antigo
+     if (github && context && (prNumber || reviewData.pr_number)) {
+       await clearBlockingComment(github, context, prNumber || reviewData.pr_number);
+     }
+     
+     process.exitCode = 0;
+   }
+   ```
+
+3. **Export atualizado** (linha 444):
+   ```javascript
+   clearBlockingComment,
+   ```
+
+### Fluxo Após a Correção
+
+```
+1. Workflow encontra issues bloqueantes
+   → Posta "🛑 Workflow Bloqueado" (comentário A)
+   → Bloqueia workflow
+
+2. Desenvolvedor corrige código
+   → Push novo commit
+   → Workflow dispara novamente
+
+3. Workflow NÃO encontra issues bloqueantes
+   → Loga "✅ Nenhum issue bloqueante encontrado"
+   → Chama clearBlockingComment()
+   → Atualiza comentário A para "✅ Issues Resolvidas"
+   → Workflow continua com sucesso
+```
+
+## Lições Aprendidas
+
+1. **Importância de limpar estado**: Em sistemas de automação, sempre que houver uma flag de estado (bloqueado/aprovado), garantir que ela seja atualizada/removida quando as condições mudam.
+
+2. **Comentários como estado**: Comentários no PR funcionam como estado implícito. Quando o sistema depende deles para indicar status, deve haver lógica para atualizá-los.
+
+3. **Teste de integração limitado**: Esse bug só aparece em cenários reais com múltiplas execuções de workflow. Testes unitários não capturam esse tipo de issue.
+
+## Referências
+
+- PR Original: #264
+- Script modificado: [`.github/scripts/check-critical-issues.cjs`](../../.github/scripts/check-critical-issues.cjs)
+- Branch: `fix/gemini-workflow-clear-blocking-comment`


### PR DESCRIPTION
## Descrição

Adiciona função `clearBlockingComment()` que atualiza o comentário '🛑 Workflow Bloqueado' para '✅ Issues Resolvidas' quando não há mais issues bloqueantes.

## Problema

O PR #264 estava mostrando como "bloqueado" mesmo após o desenvolvedor corrigir os issues e marcar as threads como resolvidas. Runs do workflow mostravam "success" mas o comentário antigo permanecia visível.

## Solução

- Nova função `clearBlockingComment()` que busca e atualiza o comentário de bloqueio
- Chamada no else branch quando não há issues bloqueantes

## Arquivos Modificados

- `.github/scripts/check-critical-issues.cjs`
- `docs/archive/GEMINI_WORKFLOW_BLOCKING_COMMENT_FIX.md` (novo)
- `.memory/journal/2026-W11.md` (novo)

## Testes

- Syntax OK
- Lint: 0 erros

## Fix #264