### PR TITLE
feat(mobile): implementa tela de estoque H5.5 com badges ADR-018

### DIFF
--- a/.agent/state.json
+++ b/.agent/state.json
@@ -16,10 +16,10 @@
     "current_sprint": "H5.5"
   },
   "session": {
-    "id": "session_2026W16_h5_4_treatments",
-    "started_at": "2026-04-14T04:32:00Z",
-    "mode": "waiting",
-    "status": "reviewing",
+    "id": "session_2026W16_h5_5_stock",
+    "started_at": "2026-04-14T15:55:00Z",
+    "mode": "coding",
+    "status": "analysis",
     "goal": "PR 4 - H5.5: Estoque",
     "goal_type": "feature",
     "acceptance_criteria": [

--- a/apps/mobile/src/features/stock/components/StockItem.jsx
+++ b/apps/mobile/src/features/stock/components/StockItem.jsx
@@ -13,7 +13,8 @@ export default function StockItem({ medicine }) {
     totalQuantity, 
     dosage_unit, 
     status, 
-    daysRemaining 
+    daysRemaining,
+    hasActiveProtocol
   } = medicine
 
   return (
@@ -29,13 +30,15 @@ export default function StockItem({ medicine }) {
             </Text>
           </View>
           
-          <StockLevelBadge 
-            status={status} 
-            daysRemaining={daysRemaining} 
-          />
+          {hasActiveProtocol && (
+            <StockLevelBadge 
+              status={status} 
+              daysRemaining={daysRemaining} 
+            />
+          )}
         </View>
 
-        {daysRemaining !== Infinity && (
+        {hasActiveProtocol && daysRemaining !== Infinity && (
           <Text style={styles.helperText}>
             Estimativa baseada nos seus protocolos ativos.
           </Text>

--- a/apps/mobile/src/features/stock/components/StockItem.jsx
+++ b/apps/mobile/src/features/stock/components/StockItem.jsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { View, Text, StyleSheet } from 'react-native'
+import SectionCard from '../../../shared/components/ui/SectionCard'
+import StockLevelBadge from './StockLevelBadge'
+
+/**
+ * Item de lista para exibição de estoque.
+ */
+export default function StockItem({ medicine }) {
+  const { 
+    name, 
+    laboratory, 
+    totalQuantity, 
+    dosage_unit, 
+    status, 
+    daysRemaining 
+  } = medicine
+
+  return (
+    <SectionCard title={name}>
+      <View style={styles.container}>
+        <View style={styles.infoRow}>
+          <View style={styles.mainInfo}>
+            {laboratory ? (
+              <Text style={styles.lab}>{laboratory}</Text>
+            ) : null}
+            <Text style={styles.quantity}>
+              Saldo: <Text style={styles.bold}>{totalQuantity} unidades</Text>
+            </Text>
+          </View>
+          
+          <StockLevelBadge 
+            status={status} 
+            daysRemaining={daysRemaining} 
+          />
+        </View>
+
+        {daysRemaining !== Infinity && (
+          <Text style={styles.helperText}>
+            Estimativa baseada nos seus protocolos ativos.
+          </Text>
+        )}
+      </View>
+    </SectionCard>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingTop: 4
+  },
+  infoRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start'
+  },
+  mainInfo: {
+    flex: 1,
+    marginRight: 10
+  },
+  lab: {
+    fontSize: 13,
+    color: '#666',
+    marginBottom: 4
+  },
+  quantity: {
+    fontSize: 14,
+    color: '#333'
+  },
+  bold: {
+    fontWeight: '700'
+  },
+  helperText: {
+    fontSize: 11,
+    color: '#999',
+    marginTop: 12,
+    fontStyle: 'italic'
+  }
+})

--- a/apps/mobile/src/features/stock/components/StockItem.jsx
+++ b/apps/mobile/src/features/stock/components/StockItem.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { View, Text, StyleSheet } from 'react-native'
 import SectionCard from '../../../shared/components/ui/SectionCard'
 import StockLevelBadge from './StockLevelBadge'
+import { colors, spacing } from '../../../shared/styles/tokens'
 
 /**
  * Item de lista para exibição de estoque.
@@ -12,13 +13,27 @@ export default function StockItem({ medicine }) {
     laboratory, 
     totalQuantity, 
     dosage_unit, 
+    dosage_per_pill,
     status, 
     daysRemaining,
     hasActiveProtocol
   } = medicine
 
   return (
-    <SectionCard title={name}>
+    <SectionCard 
+      title={
+        <View style={styles.titleWrapper}>
+          <Text style={styles.titleText}>{name}</Text>
+          {dosage_per_pill && (
+            <View style={styles.dosagePill}>
+              <Text style={styles.dosagePillText}>
+                {dosage_per_pill}{dosage_unit}
+              </Text>
+            </View>
+          )}
+        </View>
+      }
+    >
       <View style={styles.container}>
         <View style={styles.infoRow}>
           <View style={styles.mainInfo}>
@@ -49,6 +64,29 @@ export default function StockItem({ medicine }) {
 }
 
 const styles = StyleSheet.create({
+  titleWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  titleText: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.text.primary,
+  },
+  dosagePill: {
+    backgroundColor: colors.neutral[100],
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    borderRadius: 4,
+    borderWidth: 0.5,
+    borderColor: colors.neutral[300],
+  },
+  dosagePillText: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: colors.neutral[700],
+  },
   container: {
     paddingTop: 4
   },
@@ -63,19 +101,20 @@ const styles = StyleSheet.create({
   },
   lab: {
     fontSize: 13,
-    color: '#666',
+    color: colors.text.secondary,
     marginBottom: 4
   },
   quantity: {
     fontSize: 14,
-    color: '#333'
+    color: colors.text.primary
   },
   bold: {
-    fontWeight: '700'
+    fontWeight: '700',
+    color: colors.text.primary
   },
   helperText: {
     fontSize: 11,
-    color: '#999',
+    color: colors.neutral[500],
     marginTop: 12,
     fontStyle: 'italic'
   }

--- a/apps/mobile/src/features/stock/components/StockLevelBadge.jsx
+++ b/apps/mobile/src/features/stock/components/StockLevelBadge.jsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { View, Text, StyleSheet } from 'react-native'
+import { AlertCircle, AlertTriangle, CheckCircle, TrendingUp } from 'lucide-react-native'
+
+/**
+ * Badge visual para nível de estoque conforme ADR-018.
+ * 
+ * @param {string} status - Tier de estoque (CRITICAL, LOW, NORMAL, HIGH)
+ * @param {number} daysRemaining - Dias calculados restantes
+ */
+export default function StockLevelBadge({ status, daysRemaining }) {
+  const getLevelConfig = () => {
+    switch (status) {
+      case 'CRITICAL':
+        return {
+          color: '#ef4444',
+          bg: '#fee2e2',
+          icon: AlertCircle,
+          label: 'Crítico'
+        }
+      case 'LOW':
+        return {
+          color: '#f59e0b',
+          bg: '#fef3c7',
+          icon: AlertTriangle,
+          label: 'Baixo'
+        }
+      case 'NORMAL':
+        return {
+          color: '#22c55e',
+          bg: '#dcfce7',
+          icon: CheckCircle,
+          label: 'Normal'
+        }
+      case 'HIGH':
+      default:
+        return {
+          color: '#3b82f6',
+          bg: '#dbeafe',
+          icon: TrendingUp,
+          label: 'Bom'
+        }
+    }
+  }
+
+  const { color, bg, icon: Icon, label } = getLevelConfig()
+  const daysText = daysRemaining === Infinity 
+    ? '-- dias' 
+    : `${Math.floor(daysRemaining)} dias`
+
+  return (
+    <View style={[styles.container, { backgroundColor: bg }]}>
+      <Icon size={14} color={color} strokeWidth={2.5} />
+      <Text style={[styles.label, { color }]}>{label}</Text>
+      <View style={[styles.separator, { backgroundColor: color }]} />
+      <Text style={[styles.days, { color }]}>{daysText}</Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 12,
+    alignSelf: 'flex-start'
+  },
+  label: {
+    fontSize: 11,
+    fontWeight: '700',
+    marginLeft: 4,
+    textTransform: 'uppercase'
+  },
+  separator: {
+    width: 1,
+    height: 10,
+    marginHorizontal: 8,
+    opacity: 0.3
+  },
+  days: {
+    fontSize: 11,
+    fontWeight: '600'
+  }
+})

--- a/apps/mobile/src/features/stock/hooks/useStock.js
+++ b/apps/mobile/src/features/stock/hooks/useStock.js
@@ -25,13 +25,14 @@ export function useStock() {
       
       if (!result.success) throw new Error(result.error)
 
-      // Processamento dos dados para ADR-018
-      const processedData = result.data.map(item => {
+      // 1. Processamento base e cálculo ADR-018
+      const processed = result.data.map(item => {
         const totalQuantity = item.medicine_stock_summary?.[0]?.total_quantity || 0
         
-        // Cálculo do consumo diário baseado nos protocolos ativos
-        // Nota: Assumindo frequência diária conforme simplificação atual (H5.5)
-        const dailyConsumption = (item.protocols || []).reduce((acc, p) => {
+        // Protocolos ativos vinculados
+        const activeProtocols = (item.protocols || []).filter(p => p.active)
+        
+        const dailyConsumption = activeProtocols.reduce((acc, p) => {
           const intakesPerDay = (p.time_schedule || []).length || 1
           return acc + (Number(p.dosage_per_intake) * intakesPerDay)
         }, 0)
@@ -43,20 +44,20 @@ export function useStock() {
         // Classificação conforme ADR-018
         let status = 'HIGH'
         let statusLabel = 'Bom'
-        let color = '#3b82f6' // Blue
+        let color = '#3b82f6'
 
         if (daysRemaining < 7) {
           status = 'CRITICAL'
           statusLabel = 'Crítico'
-          color = '#ef4444' // Red
+          color = '#ef4444'
         } else if (daysRemaining < 14) {
           status = 'LOW'
           statusLabel = 'Baixo'
-          color = '#f59e0b' // Orange
+          color = '#f59e0b'
         } else if (daysRemaining < 30) {
           status = 'NORMAL'
           statusLabel = 'Normal'
-          color = '#22c55e' // Green
+          color = '#22c55e'
         }
 
         return {
@@ -66,12 +67,25 @@ export function useStock() {
           daysRemaining,
           status,
           statusLabel,
-          color
+          color,
+          hasActiveProtocol: activeProtocols.length > 0
         }
       })
 
+      // 2. Filtragem: Remover quem não tem estoque E não tem protocolo ativo
+      const filtered = processed.filter(item => item.totalQuantity > 0 || item.hasActiveProtocol)
+
+      // 3. Categorização e Ordenação
+      const active = filtered
+        .filter(item => item.hasActiveProtocol)
+        .sort((a, b) => a.daysRemaining - b.daysRemaining) // Urgência primeiro
+
+      const inactive = filtered
+        .filter(item => !item.hasActiveProtocol)
+        .sort((a, b) => a.name.localeCompare(b.name))
+
       setState({
-        data: processedData,
+        data: { active, inactive },
         loading: false,
         error: null,
         refreshing: false

--- a/apps/mobile/src/features/stock/hooks/useStock.js
+++ b/apps/mobile/src/features/stock/hooks/useStock.js
@@ -1,0 +1,98 @@
+import { useState, useEffect, useCallback } from 'react'
+import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
+import { getStockData } from '../services/stockService'
+
+/**
+ * Hook para gerenciar e calcular dados de estoque conforme ADR-018.
+ */
+export function useStock() {
+  const [state, setState] = useState({
+    data: null,
+    loading: true,
+    error: null,
+    refreshing: false
+  })
+
+  const loadStock = useCallback(async (isRefreshing = false) => {
+    if (isRefreshing) setState(prev => ({ ...prev, refreshing: true }))
+    else setState(prev => ({ ...prev, loading: true }))
+
+    try {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) throw new Error('Sessão expirada')
+
+      const result = await getStockData(user.id)
+      
+      if (!result.success) throw new Error(result.error)
+
+      // Processamento dos dados para ADR-018
+      const processedData = result.data.map(item => {
+        const totalQuantity = item.medicine_stock_summary?.[0]?.total_quantity || 0
+        
+        // Cálculo do consumo diário baseado nos protocolos ativos
+        // Nota: Assumindo frequência diária conforme simplificação atual (H5.5)
+        const dailyConsumption = (item.protocols || []).reduce((acc, p) => {
+          const intakesPerDay = (p.time_schedule || []).length || 1
+          return acc + (Number(p.dosage_per_intake) * intakesPerDay)
+        }, 0)
+
+        const daysRemaining = dailyConsumption > 0 
+          ? totalQuantity / dailyConsumption 
+          : Infinity
+
+        // Classificação conforme ADR-018
+        let status = 'HIGH'
+        let statusLabel = 'Bom'
+        let color = '#3b82f6' // Blue
+
+        if (daysRemaining < 7) {
+          status = 'CRITICAL'
+          statusLabel = 'Crítico'
+          color = '#ef4444' // Red
+        } else if (daysRemaining < 14) {
+          status = 'LOW'
+          statusLabel = 'Baixo'
+          color = '#f59e0b' // Orange
+        } else if (daysRemaining < 30) {
+          status = 'NORMAL'
+          statusLabel = 'Normal'
+          color = '#22c55e' // Green
+        }
+
+        return {
+          ...item,
+          totalQuantity,
+          dailyConsumption,
+          daysRemaining,
+          status,
+          statusLabel,
+          color
+        }
+      })
+
+      setState({
+        data: processedData,
+        loading: false,
+        error: null,
+        refreshing: false
+      })
+    } catch (err) {
+      console.error('[useStock] Erro:', err)
+      setState(prev => ({
+        ...prev,
+        loading: false,
+        refreshing: false,
+        error: err.message
+      }))
+    }
+  }, [])
+
+  useEffect(() => {
+    loadStock()
+  }, [loadStock])
+
+  return {
+    ...state,
+    refresh: () => loadStock(true)
+  }
+}

--- a/apps/mobile/src/features/stock/screens/StockScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockScreen.jsx
@@ -1,39 +1,89 @@
-// StockScreen.jsx — tela "Estoque" do MVP mobile
-// Sprint H5.5 irá implementar lista com 4 níveis de risco (ADR-018)
+import React from 'react'
+import { FlatList, RefreshControl, StyleSheet, Text, View } from 'react-native'
+import { useStock } from '../hooks/useStock'
+import ScreenContainer from '../../../shared/components/ui/ScreenContainer'
+import LoadingState from '../../../shared/components/states/LoadingState'
+import EmptyState from '../../../shared/components/states/EmptyState'
+import ErrorState from '../../../shared/components/states/ErrorState'
+import StockItem from '../components/StockItem'
 
-import { View, Text, StyleSheet } from 'react-native'
-import { SafeAreaView } from 'react-native-safe-area-context'
-
+/**
+ * Tela principal de Gerenciamento de Estoque (H5.5).
+ */
 export default function StockScreen() {
+  const { data, loading, error, refreshing, refresh } = useStock()
+
+  if (loading && !refreshing) {
+    return (
+      <ScreenContainer>
+        <LoadingState />
+      </ScreenContainer>
+    )
+  }
+
+  if (error && !data) {
+    return (
+      <ScreenContainer>
+        <ErrorState 
+          message="Não foi possível carregar seu estoque." 
+          onRetry={refresh} 
+        />
+      </ScreenContainer>
+    )
+  }
+
   return (
-    <SafeAreaView style={styles.container} edges={['top']}>
-      <View style={styles.content}>
-        <Text style={styles.title}>Estoque</Text>
-        <Text style={styles.subtitle}>Níveis de stock — em breve</Text>
-      </View>
-    </SafeAreaView>
+    <ScreenContainer>
+      <FlatList
+        data={data}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <StockItem medicine={item} />}
+        contentContainerStyle={styles.listContent}
+        refreshControl={
+          <RefreshControl 
+            refreshing={refreshing} 
+            onRefresh={refresh} 
+            tintColor="#6366f1"
+          />
+        }
+        ListHeaderComponent={
+          <View style={styles.header}>
+            <Text style={styles.title}>Meu Estoque</Text>
+            <Text style={styles.subtitle}>
+              Acompanhe a disponibilidade dos seus medicamentos
+            </Text>
+          </View>
+        }
+        ListEmptyComponent={
+          <EmptyState 
+            message="Você não possui medicamentos cadastrados ou estoque registrado." 
+          />
+        }
+      />
+    </ScreenContainer>
   )
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#f8fafc',
+  listContent: {
+    paddingBottom: 20
   },
-  content: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 24,
+  header: {
+    padding: 20,
+    backgroundColor: '#fff',
+    borderBottomWidth: 1,
+    borderBottomColor: '#f0f0f0',
+    marginBottom: 10
   },
   title: {
-    fontSize: 28,
-    fontWeight: '700',
-    color: '#1e293b',
-    marginBottom: 8,
+    fontSize: 24,
+    fontWeight: '800',
+    color: '#1a1a1a',
+    marginBottom: 4
   },
   subtitle: {
-    fontSize: 15,
-    color: '#64748b',
-  },
+    fontSize: 14,
+    color: '#666',
+    lineHeight: 20
+  }
 })

--- a/apps/mobile/src/features/stock/screens/StockScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockScreen.jsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { FlatList, RefreshControl, StyleSheet, Text, View } from 'react-native'
+import React, { useMemo } from 'react'
+import { SectionList, RefreshControl, StyleSheet, Text, View } from 'react-native'
 import { useStock } from '../hooks/useStock'
 import ScreenContainer from '../../../shared/components/ui/ScreenContainer'
 import LoadingState from '../../../shared/components/states/LoadingState'
@@ -12,6 +12,28 @@ import StockItem from '../components/StockItem'
  */
 export default function StockScreen() {
   const { data, loading, error, refreshing, refresh } = useStock()
+
+  // Formata os dados no formato esperado pelo SectionList
+  const sections = useMemo(() => {
+    if (!data) return []
+    const list = []
+    
+    if (data.active.length > 0) {
+      list.push({
+        title: 'Estoque em Uso',
+        data: data.active
+      })
+    }
+    
+    if (data.inactive.length > 0) {
+      list.push({
+        title: 'Sem tratamento ativo',
+        data: data.inactive
+      })
+    }
+    
+    return list
+  }, [data])
 
   if (loading && !refreshing) {
     return (
@@ -34,10 +56,15 @@ export default function StockScreen() {
 
   return (
     <ScreenContainer>
-      <FlatList
-        data={data}
+      <SectionList
+        sections={sections}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => <StockItem medicine={item} />}
+        renderSectionHeader={({ section: { title } }) => (
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>{title}</Text>
+          </View>
+        )}
         contentContainerStyle={styles.listContent}
         refreshControl={
           <RefreshControl 
@@ -66,14 +93,11 @@ export default function StockScreen() {
 
 const styles = StyleSheet.create({
   listContent: {
-    paddingBottom: 20
+    paddingBottom: 40
   },
   header: {
     padding: 20,
-    backgroundColor: '#fff',
-    borderBottomWidth: 1,
-    borderBottomColor: '#f0f0f0',
-    marginBottom: 10
+    backgroundColor: '#fff'
   },
   title: {
     fontSize: 24,
@@ -85,5 +109,17 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#666',
     lineHeight: 20
+  },
+  sectionHeader: {
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    backgroundColor: '#f9fafb'
+  },
+  sectionTitle: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#6b7280',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5
   }
 })

--- a/apps/mobile/src/features/stock/services/stockService.js
+++ b/apps/mobile/src/features/stock/services/stockService.js
@@ -1,0 +1,57 @@
+// ADR-029: thin local service — chama Supabase directamente via nativeSupabaseClient
+// R-125: validação Zod na camada de serviço (R-NNN sugerido em review PR #467)
+
+import { z } from 'zod'
+import { supabase as nativeSupabaseClient } from '../../../platform/supabase/nativeSupabaseClient'
+
+/**
+ * Busca a lista de medicamentos com seu estoque e protocolos ativos para cálculo de consumo.
+ * 
+ * @param {string} userId - UUID do usuário
+ * @returns {Promise<{success: boolean, data?: Array, error?: string}>}
+ */
+export async function getStockData(userId) {
+  try {
+    // Validação de entrada conforme R-125
+    z.string().uuid().parse(userId)
+
+    if (__DEV__) console.log('[stockService] Buscando dados de estoque para:', userId)
+
+    // Buscamos medicamentos com: 
+    // 1. Quantidade total (da view medicine_stock_summary)
+    // 2. Protocolos ativos (para calcular consumo diário)
+    // Nota: O join com medicine_stock_summary usa a relação automática baseada em medicine_id
+    const { data, error } = await nativeSupabaseClient
+      .from('medicines')
+      .select(`
+        id,
+        name,
+        laboratory,
+        dosage_unit,
+        dosage_per_pill,
+        medicine_stock_summary!left (
+          total_quantity
+        ),
+        protocols (
+          id,
+          dosage_per_intake,
+          time_schedule,
+          frequency,
+          active
+        )
+      `)
+      .eq('user_id', userId)
+      .eq('protocols.active', true)
+      .order('name')
+
+    if (error) {
+      console.error('[stockService] Erro na query:', error)
+      return { success: false, error: 'Erro ao carregar dados de estoque' }
+    }
+
+    return { success: true, data }
+  } catch (err) {
+    console.error('[stockService] Erro inesperado:', err)
+    return { success: false, error: err.message }
+  }
+}


### PR DESCRIPTION
# 📦 feat(mobile): implementa tela de estoque H5.5 com badges ADR-018

## 🎯 Resumo

Esta PR implementa a funcionalidade completa de Gerenciamento de Estoque para o MVP Mobile (H5.5). A solução utiliza a lógica de tiers estabelecida na **ADR-018** para calcular a durabilidade do estoque baseada nos protocolos ativos do usuário.

---

## 📋 Tarefas Implementadas

### ✅ Gerenciamento de Estoque (Mobile)
- [x] Implementação do `stockService.js` com query consolidada (Medicamentos + Saldo + Consumo).
- [x] Hook `useStock.js` com lógica de cálculo de `days_remaining` e status ADR-018.
- [x] Componente `StockLevelBadge` com suporte a ícones Lucide e 4 níveis de cores.
- [x] Componente `StockItem` integrado à identidade visual mobile.
- [x] Tela `StockScreen` funcional com suporte a RefreshControl e estados de Loading/Empty/Error.

### ✅ Qualidade e Padronização
- [x] Validação Zod na camada de serviço (R-125).
- [x] Conformidade com paridade de linguagem pt-BR (R-166).
- [x] Uso obrigatório do `ScreenContainer` (R-169).
- [x] Lint verificado e crítico aprovado.

---

## 🔧 Arquivos Principais

```
apps/mobile/src/features/stock/
├── components/
│   ├── StockItem.jsx           # Item de lista com saldo e badges
│   └── StockLevelBadge.jsx     # Badge inteligente (ADR-018)
├── hooks/
│   └── useStock.js             # Lógica de cálculo (total / consumo_diario)
├── screens/
│   └── StockScreen.jsx         # Tela principal H5.5
└── services/
    └── stockService.js         # Fetch consolidado Supabase + Zod
```

---

## ✅ Checklist de Verificação

### Código
- [x] Todos os testes passam (`npm run test:critical`)
- [x] Lint sem erros (`npm run lint`)
- [x] Build bem-sucedido via Expo CLI

### Funcionalidade
- [x] Listagem exibe medicamentos com saldo real
- [x] Badges mudam de cor dinamicamente (Crítico < 7d, Baixo < 14d, Normal < 30d, Bom >= 30d)
- [x] Estabilidade garantida via ScreenContainer

---

## 🚀 Como Testar

```bash
# 1. Mudar para a branch
git checkout feature/hybrid-h5/stock

# 2. Iniciar o Expo (iOS simulator ou Android Emulator)
cd apps/mobile && npx expo start

# 3. Navegar até a aba "Estoque"
```

**Resultado esperado:**
- Ver listagem de medicamentos com saldo atual.
- Observar badges inteligentes baseadas no consumo dos protocolos ativos na aba Hoje.

---

## 📝 Notas para Reviewers

1. **ADR-018**: A classificação de status respeita rigorosamente os limites de dias definidos no documento de arquitetura.
2. **Performance**: O fetch é realizado via Supabase utilizando o join com o `medicine_stock_summary` para evitar fetches excessivos no client.

/cc @coelhotv
/cc @reviewers
/cc @gemini-code-assist
