### PR TITLE
feat(mobile): implementa resiliência offline e stale states (H5.8)

### DIFF
--- a/.agent/state.json
+++ b/.agent/state.json
@@ -19,7 +19,7 @@
     "id": "session_2026W16_h5_stale_offline",
     "started_at": "2026-04-16T12:50:00Z",
     "mode": "coding",
-    "status": "analysis",
+    "status": "coding",
     "goal": "H5.8: Stale states + offline policy",
     "goal_type": "feature",
     "acceptance_criteria": [

--- a/apps/mobile/jest-setup.js
+++ b/apps/mobile/jest-setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/react-native/extend-expect';

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)',
   ],
-  setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ['<rootDir>/jest-setup.js'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@shared/(.*)$': '<rootDir>/src/shared/$1',
@@ -15,5 +15,6 @@ module.exports = {
     '^@protocols/(.*)$': '<rootDir>/src/features/protocols/$1',
     '^@stock/(.*)$': '<rootDir>/src/features/stock/$1',
     '^@dashboard/(.*)$': '<rootDir>/src/features/dashboard/$1',
+    '^@meus-remedios/core$': '<rootDir>/../../packages/core/src/index.js',
   },
 }

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -1,15 +1,10 @@
 module.exports = {
   preset: 'jest-expo',
-  setupFilesAfterFramework: ['./jest.setup.js'],
-  testMatch: ['**/__tests__/**/*.{js,jsx}', '**/*.test.{js,jsx}'],
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|@meus-remedios/.*)',
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)',
   ],
+  setupFilesAfterEnv: ['@testing-library/jest-dom'],
   moduleNameMapper: {
-    // Mapeia @meus-remedios/* para os packages do monorepo
-    '^@meus-remedios/core(.*)$': '<rootDir>/../../packages/core/src$1',
-    '^@meus-remedios/shared-data(.*)$': '<rootDir>/../../packages/shared-data/src$1',
-    '^@meus-remedios/storage(.*)$': '<rootDir>/../../packages/storage/src$1',
-    '^@meus-remedios/config(.*)$': '<rootDir>/../../packages/config/src$1',
+    '^@/(.*)$': '<rootDir>/src/$1',
   },
 }

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -3,8 +3,17 @@ module.exports = {
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)',
   ],
-  setupFilesAfterEnv: ['@testing-library/jest-dom'],
+  setupFilesAfterEnv: [],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    '^@shared/(.*)$': '<rootDir>/src/shared/$1',
+    '^@features/(.*)$': '<rootDir>/src/features/$1',
+    '^@utils/(.*)$': '<rootDir>/src/utils/$1',
+    '^@schemas/(.*)$': '<rootDir>/src/schemas/$1',
+    '^@adherence/(.*)$': '<rootDir>/src/features/adherence/$1',
+    '^@medications/(.*)$': '<rootDir>/src/features/medications/$1',
+    '^@protocols/(.*)$': '<rootDir>/src/features/protocols/$1',
+    '^@stock/(.*)$': '<rootDir>/src/features/stock/$1',
+    '^@dashboard/(.*)$': '<rootDir>/src/features/dashboard/$1',
   },
 }

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -16,5 +16,12 @@ module.exports = {
     '^@stock/(.*)$': '<rootDir>/src/features/stock/$1',
     '^@dashboard/(.*)$': '<rootDir>/src/features/dashboard/$1',
     '^@meus-remedios/core$': '<rootDir>/../../packages/core/src/index.js',
+    '^@meus-remedios/core/(.*)$': '<rootDir>/../../packages/core/src/$1',
+    '^@meus-remedios/shared-data$': '<rootDir>/../../packages/shared-data/src/index.js',
+    '^@meus-remedios/shared-data/(.*)$': '<rootDir>/../../packages/shared-data/src/$1',
+    '^@meus-remedios/storage$': '<rootDir>/../../packages/storage/src/index.js',
+    '^@meus-remedios/storage/(.*)$': '<rootDir>/../../packages/storage/src/$1',
+    '^@meus-remedios/config$': '<rootDir>/../../packages/config/src/index.js',
+    '^@meus-remedios/config/(.*)$': '<rootDir>/../../packages/config/src/$1',
   },
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "~2.1.2",
+    "@react-native-community/netinfo": "11.4.1",
     "@react-navigation/bottom-tabs": "^7.15.9",
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.3.10",

--- a/apps/mobile/src/features/dashboard/hooks/useTodayData.js
+++ b/apps/mobile/src/features/dashboard/hooks/useTodayData.js
@@ -74,7 +74,8 @@ export function useTodayData() {
         protocols: enrichedProtocols, 
         logs, 
         medicines,
-        capturedAt: new Date().toISOString()
+        capturedAt: new Date().toISOString(),
+        localDay: today // R-114 fix: save explicit local day string
       }
 
       // Salvar em cache para uso offline posterior
@@ -98,11 +99,11 @@ export function useTodayData() {
           // Regra: < 24h
           if (diffHours < 24) {
             const today = getTodayLocal()
-            // R-114 fix: use parseLocalDate for robust comparison
-            const capturedAtIso = parsed.capturedAt ?? ''
-            const snapshotDay = capturedAtIso.split('T')[0]
             
-            // Regra H5.8: Se dia diferente, limpar logs (Agenda Stale)
+            // R-114: Prefer explicit localDay from snapshot, fallback to ISO split
+            const snapshotDay = parsed.localDay || (parsed.capturedAt ?? '').split('T')[0]
+            
+            // Regra H5.8: Se dia diferente (comparação local-local), limpar logs
             if (snapshotDay && snapshotDay !== today) {
               if (__DEV__) console.log('[useTodayData] Day mismatch, segregating logs')
               parsed.logs = Array.isArray(parsed.logs) ? [] : []

--- a/apps/mobile/src/features/dashboard/hooks/useTodayData.js
+++ b/apps/mobile/src/features/dashboard/hooks/useTodayData.js
@@ -4,6 +4,7 @@
 // stale=true quando há snapshot em cache mas a última refresh falhou (R5-008)
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import { getTodayLocal } from '@meus-remedios/core'
 import { calculateAdherenceStats, calculateDosesByDate } from '@meus-remedios/core'
 import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
@@ -13,15 +14,18 @@ import {
   getMedicinesData,
 } from '../services/dashboardService'
 
+const TODAY_CACHE_KEY = '@meus-remedios/today-snapshot'
+
 /**
  * @typedef {{ 
  *   protocols: Array, 
  *   logs: Array, 
  *   medicines: Record<string,Object>,
  *   stats: Object,
- *   zones: Object 
+ *   zones: Object,
+ *   capturedAt?: string
  * }} TodayData
- * @returns {{ data: TodayData|null, loading: boolean, error: string|null, stale: boolean, refresh: Function }}
+ * @returns {{ data: TodayData|null, loading: boolean, error: string|null, stale: boolean, isDaySegregated: boolean, refresh: Function }}
  */
 export function useTodayData() {
   // States primeiro (R-010)
@@ -29,6 +33,8 @@ export function useTodayData() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [stale, setStale] = useState(false)
+  const [isDaySegregated, setIsDaySegregated] = useState(false)
+  
   // Ref para snapshot check sem entrar nos deps do useCallback
   const dataRef = useRef(null)
 
@@ -37,47 +43,85 @@ export function useTodayData() {
     setError(null)
 
     try {
-      if (__DEV__) console.log('[useTodayData] session check start')
+      if (__DEV__) console.log('[useTodayData] fetch start')
+      
       const { data: { session: currentSession }, error: sessionError } = await supabase.auth.getSession()
       
       let user = currentSession?.user
       if (sessionError || !user) {
-        if (__DEV__) console.warn('[useTodayData] getSession failed or null, trying getUser as fallback')
         const { data: { user: verifiedUser }, error: userError } = await supabase.auth.getUser()
-        if (userError || !verifiedUser) {
-          throw new Error('Sessão expirada ou inválida.')
-        }
+        if (userError || !verifiedUser) throw new Error('Sessão expirada')
         user = verifiedUser
       }
 
-      if (__DEV__) console.log('[useTodayData] auth OK — user:', user.id)
-
-      const today = getTodayLocal() // R-020: nunca new Date('YYYY-MM-DD')
+      const today = getTodayLocal()
       
-      // Carregar dados brutos em paralelo
+      // Fetch online (primary)
       const [protocols, logs] = await Promise.all([
         getActiveProtocols(user.id),
         getTodayLogs(user.id, today)
       ])
 
-      // Enriquecer com nomes e dosagens dos medicamentos
       const medicineIds = [...new Set(protocols.map((p) => p.medicine_id))]
       const medicines = await getMedicinesData(medicineIds)
 
-      // Injetar objeto medicine em cada protocolo para o calculateDosesByDate poder enriquecer as doses
       const enrichedProtocols = protocols.map(p => ({
         ...p,
         medicine: medicines[p.medicine_id] || null
       }))
 
-      const newData = { protocols: enrichedProtocols, logs, medicines }
+      const newData = { 
+        protocols: enrichedProtocols, 
+        logs, 
+        medicines,
+        capturedAt: new Date().toISOString()
+      }
+
+      // Salvar em cache para uso offline posterior
+      await AsyncStorage.setItem(TODAY_CACHE_KEY, JSON.stringify(newData))
+
       dataRef.current = newData
       setData(newData)
       setStale(false)
+      setIsDaySegregated(false)
     } catch (err) {
-      if (__DEV__) console.error('[useTodayData] ERRO FINAL:', err?.message)
-      setError(err.message ?? 'Erro ao carregar dados do dia.')
-      if (dataRef.current !== null) setStale(true)
+      if (__DEV__) console.warn('[useTodayData] Fetch failed, trying cache:', err.message)
+      
+      try {
+        const cached = await AsyncStorage.getItem(TODAY_CACHE_KEY)
+        if (cached) {
+          const parsed = JSON.parse(cached)
+          const capturedAt = new Date(parsed.capturedAt)
+          const now = new Date()
+          const diffHours = (now - capturedAt) / (1000 * 60 * 60)
+
+          // Regra: < 24h
+          if (diffHours < 24) {
+            const today = getTodayLocal()
+            const snapshotDay = parsed.capturedAt.split('T')[0]
+            
+            // Regra H5.8: Se dia diferente, limpar logs (Agenda Stale)
+            if (snapshotDay !== today) {
+              if (__DEV__) console.log('[useTodayData] Day mismatch, segregating logs')
+              parsed.logs = []
+              setIsDaySegregated(true)
+            } else {
+              setIsDaySegregated(false)
+            }
+
+            setData(parsed)
+            dataRef.current = parsed
+            setStale(true)
+            setError(null) // Silencia o erro se carregou cache útil
+          } else {
+            throw new Error('Cache expirado (> 24h)')
+          }
+        } else {
+          throw err // Re-throw original se não houver cache
+        }
+      } catch (cacheErr) {
+        setError(err.message ?? 'Erro ao carregar dados.')
+      }
     } finally {
       setLoading(false)
     }

--- a/apps/mobile/src/features/dashboard/hooks/useTodayData.js
+++ b/apps/mobile/src/features/dashboard/hooks/useTodayData.js
@@ -5,7 +5,7 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import { getTodayLocal } from '@meus-remedios/core'
+import { getTodayLocal, parseLocalDate } from '@meus-remedios/core'
 import { calculateAdherenceStats, calculateDosesByDate } from '@meus-remedios/core'
 import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
 import {
@@ -98,21 +98,31 @@ export function useTodayData() {
           // Regra: < 24h
           if (diffHours < 24) {
             const today = getTodayLocal()
-            const snapshotDay = parsed.capturedAt.split('T')[0]
+            // R-114 fix: use parseLocalDate for robust comparison
+            const capturedAtIso = parsed.capturedAt ?? ''
+            const snapshotDay = capturedAtIso.split('T')[0]
             
             // Regra H5.8: Se dia diferente, limpar logs (Agenda Stale)
-            if (snapshotDay !== today) {
+            if (snapshotDay && snapshotDay !== today) {
               if (__DEV__) console.log('[useTodayData] Day mismatch, segregating logs')
-              parsed.logs = []
+              parsed.logs = Array.isArray(parsed.logs) ? [] : []
               setIsDaySegregated(true)
             } else {
               setIsDaySegregated(false)
             }
 
-            setData(parsed)
-            dataRef.current = parsed
+            // Safety gate: garantir que parsed tem o formato esperado
+            const safeData = {
+              protocols: Array.isArray(parsed.protocols) ? parsed.protocols : [],
+              logs: Array.isArray(parsed.logs) ? parsed.logs : [],
+              medicines: parsed.medicines || {},
+              capturedAt: parsed.capturedAt
+            }
+
+            setData(safeData)
+            dataRef.current = safeData
             setStale(true)
-            setError(null) // Silencia o erro se carregou cache útil
+            setError(null) 
           } else {
             throw new Error('Cache expirado (> 24h)')
           }
@@ -204,6 +214,7 @@ export function useTodayData() {
     loading, 
     error, 
     stale, 
+    isDaySegregated,
     refresh: load 
   }
 }

--- a/apps/mobile/src/features/dashboard/screens/TodayScreen.jsx
+++ b/apps/mobile/src/features/dashboard/screens/TodayScreen.jsx
@@ -10,12 +10,13 @@ import UpcomingDosesList from '../components/UpcomingDosesList'
 import PriorityActionCard from '../components/PriorityActionCard'
 import StockAlertInline from '../components/StockAlertInline'
 import DoseRegisterModal from '../../dose/components/DoseRegisterModal'
+import StaleBanner from '../../../shared/components/feedback/StaleBanner'
 
 export default function TodayScreen() {
   const [modalProtocol, setModalProtocol] = useState(null)
   const [modalScheduledTime, setModalScheduledTime] = useState(null)
 
-  const { data, loading, error, stale, refresh } = useTodayData()
+  const { data, loading, error, stale, isDaySegregated, refresh } = useTodayData()
 
   if (loading && !data) return <LoadingState message="A carregar o seu dia..." />
   if (error && !data) return <ErrorState message={error} onRetry={refresh} />
@@ -42,11 +43,7 @@ export default function TodayScreen() {
 
   return (
     <ScreenContainer>
-      {stale && (
-        <View style={styles.staleBanner}>
-          <Text style={styles.staleText}>⚠️ Sem ligação — a mostrar dados anteriores</Text>
-        </View>
-      )}
+      {stale && <StaleBanner isDaySegregated={isDaySegregated} />}
 
       <ScrollView
         contentContainerStyle={styles.scroll}

--- a/apps/mobile/src/features/dose/components/DoseRegisterModal.jsx
+++ b/apps/mobile/src/features/dose/components/DoseRegisterModal.jsx
@@ -18,6 +18,7 @@ import {
 import { getTodayLocal } from '@meus-remedios/core'
 import { registerDose } from '../services/doseService'
 import { colors, spacing, borderRadius } from '../../../shared/styles/tokens'
+import { useOnlineStatus } from '../../../shared/hooks/useOnlineStatus'
 
 /**
  * @param {{
@@ -41,12 +42,19 @@ export default function DoseRegisterModal({
   const [quantity, setQuantity] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
+  
+  const { isOnline } = useOnlineStatus()
 
   if (!protocol) return null
 
   const defaultQty = String(protocol.dosage_per_intake ?? 1)
 
   async function handleConfirm() {
+    if (!isOnline) {
+      setError('Não é possível registar sem ligação à internet.')
+      return
+    }
+
     setLoading(true)
     setError(null)
 

--- a/apps/mobile/src/features/stock/hooks/useStock.js
+++ b/apps/mobile/src/features/stock/hooks/useStock.js
@@ -65,6 +65,10 @@ export function useStock() {
           status = 'NORMAL'
           statusLabel = 'Normal'
           color = '#22c55e'
+        } else {
+          status = 'HIGH'
+          statusLabel = 'Bom'
+          color = '#3b82f6'
         }
 
         return {

--- a/apps/mobile/src/features/stock/hooks/useStock.js
+++ b/apps/mobile/src/features/stock/hooks/useStock.js
@@ -1,6 +1,9 @@
 import { useState, useEffect, useCallback } from 'react'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
 import { getStockData } from '../services/stockService'
+
+const STOCK_CACHE_KEY = '@meus-remedios/stock-snapshot'
 
 /**
  * Hook para gerenciar e calcular dados de estoque conforme ADR-018.
@@ -10,12 +13,13 @@ export function useStock() {
     data: null,
     loading: true,
     error: null,
+    stale: false,
     refreshing: false
   })
 
   const loadStock = useCallback(async (isRefreshing = false) => {
-    if (isRefreshing) setState(prev => ({ ...prev, refreshing: true }))
-    else setState(prev => ({ ...prev, loading: true }))
+    if (isRefreshing) setState(prev => ({ ...prev, refreshing: true, error: null }))
+    else setState(prev => ({ ...prev, loading: true, error: null }))
 
     try {
       const { data: { session: currentSession }, error: sessionError } = await supabase.auth.getSession()
@@ -23,9 +27,7 @@ export function useStock() {
       let user = currentSession?.user
       if (sessionError || !user) {
         const { data: { user: verifiedUser }, error: userError } = await supabase.auth.getUser()
-        if (userError || !verifiedUser) {
-          throw new Error('Sessão expirada')
-        }
+        if (userError || !verifiedUser) throw new Error('Sessão expirada')
         user = verifiedUser
       }
 
@@ -36,8 +38,6 @@ export function useStock() {
       // 1. Processamento base e cálculo ADR-018
       const processed = result.data.map(item => {
         const totalQuantity = item.medicine_stock_summary?.[0]?.total_quantity || 0
-        
-        // Protocolos ativos vinculados
         const activeProtocols = (item.protocols || []).filter(p => p.active)
         
         const dailyConsumption = activeProtocols.reduce((acc, p) => {
@@ -49,23 +49,13 @@ export function useStock() {
           ? totalQuantity / dailyConsumption 
           : Infinity
 
-        // Classificação conforme ADR-018
-        let status = 'HIGH'
-        let statusLabel = 'Bom'
-        let color = '#3b82f6'
-
+        let status = 'HIGH', statusLabel = 'Bom', color = '#3b82f6'
         if (daysRemaining < 7) {
-          status = 'CRITICAL'
-          statusLabel = 'Crítico'
-          color = '#ef4444'
+          status = 'CRITICAL'; statusLabel = 'Crítico'; color = '#ef4444'
         } else if (daysRemaining < 14) {
-          status = 'LOW'
-          statusLabel = 'Baixo'
-          color = '#f59e0b'
+          status = 'LOW'; statusLabel = 'Baixo'; color = '#f59e0b'
         } else if (daysRemaining < 30) {
-          status = 'NORMAL'
-          statusLabel = 'Normal'
-          color = '#22c55e'
+          status = 'NORMAL'; statusLabel = 'Normal'; color = '#22c55e'
         }
 
         return {
@@ -80,32 +70,58 @@ export function useStock() {
         }
       })
 
-      // 2. Filtragem: Remover quem não tem estoque E não tem protocolo ativo
       const filtered = processed.filter(item => item.totalQuantity > 0 || item.hasActiveProtocol)
+      const active = filtered.filter(item => item.hasActiveProtocol).sort((a, b) => a.daysRemaining - b.daysRemaining)
+      const inactive = filtered.filter(item => !item.hasActiveProtocol).sort((a, b) => a.name.localeCompare(b.name))
 
-      // 3. Categorização e Ordenação
-      const active = filtered
-        .filter(item => item.hasActiveProtocol)
-        .sort((a, b) => a.daysRemaining - b.daysRemaining) // Urgência primeiro
+      const newData = { active, inactive }
+      const snapshot = {
+        data: newData,
+        capturedAt: new Date().toISOString()
+      }
 
-      const inactive = filtered
-        .filter(item => !item.hasActiveProtocol)
-        .sort((a, b) => a.name.localeCompare(b.name))
+      await AsyncStorage.setItem(STOCK_CACHE_KEY, JSON.stringify(snapshot))
 
       setState({
-        data: { active, inactive },
+        data: newData,
         loading: false,
         error: null,
+        stale: false,
         refreshing: false
       })
     } catch (err) {
-      console.error('[useStock] Erro:', err)
-      setState(prev => ({
-        ...prev,
-        loading: false,
-        refreshing: false,
-        error: err.message
-      }))
+      if (__DEV__) console.warn('[useStock] Fetch failed, checking cache:', err.message)
+      
+      try {
+        const cached = await AsyncStorage.getItem(STOCK_CACHE_KEY)
+        if (cached) {
+          const parsed = JSON.parse(cached)
+          const capturedAt = new Date(parsed.capturedAt)
+          const now = new Date()
+          const diffHours = (now - capturedAt) / (1000 * 60 * 60)
+
+          if (diffHours < 24) {
+            setState({
+              data: parsed.data,
+              loading: false,
+              error: null,
+              stale: true,
+              refreshing: false
+            })
+          } else {
+            throw new Error('Cache expirado')
+          }
+        } else {
+          throw err
+        }
+      } catch (cacheErr) {
+        setState(prev => ({
+          ...prev,
+          loading: false,
+          refreshing: false,
+          error: err.message
+        }))
+      }
     }
   }, [])
 

--- a/apps/mobile/src/features/stock/hooks/useStock.js
+++ b/apps/mobile/src/features/stock/hooks/useStock.js
@@ -49,13 +49,22 @@ export function useStock() {
           ? totalQuantity / dailyConsumption 
           : Infinity
 
-        let status = 'HIGH', statusLabel = 'Bom', color = '#3b82f6'
+        let status = 'HIGH'
+        let statusLabel = 'Bom'
+        let color = '#3b82f6'
+
         if (daysRemaining < 7) {
-          status = 'CRITICAL'; statusLabel = 'Crítico'; color = '#ef4444'
+          status = 'CRITICAL'
+          statusLabel = 'Crítico'
+          color = '#ef4444'
         } else if (daysRemaining < 14) {
-          status = 'LOW'; statusLabel = 'Baixo'; color = '#f59e0b'
+          status = 'LOW'
+          statusLabel = 'Baixo'
+          color = '#f59e0b'
         } else if (daysRemaining < 30) {
-          status = 'NORMAL'; statusLabel = 'Normal'; color = '#22c55e'
+          status = 'NORMAL'
+          statusLabel = 'Normal'
+          color = '#22c55e'
         }
 
         return {

--- a/apps/mobile/src/features/stock/screens/StockScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockScreen.jsx
@@ -6,12 +6,13 @@ import LoadingState from '../../../shared/components/states/LoadingState'
 import EmptyState from '../../../shared/components/states/EmptyState'
 import ErrorState from '../../../shared/components/states/ErrorState'
 import StockItem from '../components/StockItem'
+import StaleBanner from '../../../shared/components/feedback/StaleBanner'
 
 /**
  * Tela principal de Gerenciamento de Estoque (H5.5).
  */
 export default function StockScreen() {
-  const { data, loading, error, refreshing, refresh } = useStock()
+  const { data, loading, error, stale, refreshing, refresh } = useStock()
 
   // Formata os dados no formato esperado pelo SectionList
   const sections = useMemo(() => {
@@ -56,6 +57,7 @@ export default function StockScreen() {
 
   return (
     <ScreenContainer>
+      {stale && <StaleBanner />}
       <SectionList
         sections={sections}
         keyExtractor={(item) => item.id}

--- a/apps/mobile/src/features/treatments/hooks/useTreatments.js
+++ b/apps/mobile/src/features/treatments/hooks/useTreatments.js
@@ -2,8 +2,11 @@
 // Padrão: { data, loading, error, stale, refresh }
 
 import { useState, useEffect, useCallback, useRef } from 'react'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
 import { getActiveTreatments } from '../services/treatmentsService'
+
+const TREATMENTS_CACHE_KEY = '@meus-remedios/treatments-snapshot'
 
 /**
  * @typedef {{ id: string, name: string, frequency: string, time_schedule: string[], dosage_per_intake: number, titration_status: string, medicine: { name: string, type: string } }} Treatment
@@ -21,23 +24,50 @@ export function useTreatments() {
     setError(null)
 
     try {
-      const { data, error: authError } = await supabase.auth.getUser()
-      const user = data?.user
+      const { data: authData, error: authError } = await supabase.auth.getUser()
+      const user = authData?.user
       if (authError || !user) throw new Error('Sessão expirada.')
 
       const result = await getActiveTreatments(user.id)
       
-      if (!result.success) {
-        throw new Error(result.error)
+      if (!result.success) throw new Error(result.error)
+
+      const newData = result.data
+      const snapshot = {
+        data: newData,
+        capturedAt: new Date().toISOString()
       }
 
-      dataRef.current = result.data
-      setData(result.data)
+      await AsyncStorage.setItem(TREATMENTS_CACHE_KEY, JSON.stringify(snapshot))
+
+      dataRef.current = newData
+      setData(newData)
       setStale(false)
     } catch (err) {
-      if (__DEV__) console.error('[useTreatments] Erro:', err.message)
-      setError(err.message ?? 'Erro ao carregar tratamentos.')
-      if (dataRef.current !== null) setStale(true)
+      if (__DEV__) console.warn('[useTreatments] Fetch failed, checking cache:', err.message)
+      
+      try {
+        const cached = await AsyncStorage.getItem(TREATMENTS_CACHE_KEY)
+        if (cached) {
+          const parsed = JSON.parse(cached)
+          const capturedAt = new Date(parsed.capturedAt)
+          const now = new Date()
+          const diffHours = (now - capturedAt) / (1000 * 60 * 60)
+
+          if (diffHours < 24) {
+            setData(parsed.data)
+            dataRef.current = parsed.data
+            setStale(true)
+            setError(null)
+          } else {
+            throw new Error('Cache expirado')
+          }
+        } else {
+          throw err
+        }
+      } catch (cacheErr) {
+        setError(err.message ?? 'Erro ao carregar tratamentos.')
+      }
     } finally {
       setLoading(false)
     }

--- a/apps/mobile/src/features/treatments/screens/TreatmentsScreen.jsx
+++ b/apps/mobile/src/features/treatments/screens/TreatmentsScreen.jsx
@@ -9,9 +9,10 @@ import EmptyState from '../../../shared/components/states/EmptyState'
 import TreatmentCard from '../components/TreatmentCard'
 import { useTreatments } from '../hooks/useTreatments'
 import { colors, spacing } from '../../../shared/styles/tokens'
+import StaleBanner from '../../../shared/components/feedback/StaleBanner'
 
 export default function TreatmentsScreen() {
-  const { data, loading, error, refresh } = useTreatments()
+  const { data, loading, error, stale, refresh } = useTreatments()
 
   if (loading && !data) {
     return (
@@ -31,6 +32,7 @@ export default function TreatmentsScreen() {
 
   return (
     <ScreenContainer>
+      {stale && <StaleBanner />}
       <FlatList
         data={data}
         keyExtractor={(item) => item.id}

--- a/apps/mobile/src/navigation/Navigation.jsx
+++ b/apps/mobile/src/navigation/Navigation.jsx
@@ -17,6 +17,7 @@ import SmokeScreen from '../screens/SmokeScreen'
 import LoginScreen from '../screens/LoginScreen'
 import RootTabs from './RootTabs'
 import { supabase } from '../platform/supabase/nativeSupabaseClient'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 
 const Stack = createNativeStackNavigator()
 
@@ -36,12 +37,21 @@ export default function Navigation() {
       })
 
     // Actualizar em tempo real quando auth muda (login/logout)
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, s) => {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(async (event, s) => {
+      if (event === 'SIGNED_OUT') {
+        if (__DEV__) console.log('[Navigation] User signed out, clearing caches...')
+        await AsyncStorage.multiRemove([
+          '@meus-remedios/today-snapshot',
+          '@meus-remedios/treatments-snapshot',
+          '@meus-remedios/stock-snapshot'
+        ])
+      }
       setSession(s ?? null)
     })
 
     return () => subscription.unsubscribe()
   }, [])
+
 
   // Aguarda verificação inicial — evita flash de ecrã errado
   if (session === undefined) {

--- a/apps/mobile/src/shared/components/feedback/StaleBanner.jsx
+++ b/apps/mobile/src/shared/components/feedback/StaleBanner.jsx
@@ -1,0 +1,50 @@
+import { View, Text, StyleSheet } from 'react-native'
+import { colors, spacing } from '../../styles/tokens'
+import { AlertCircle } from 'lucide-react-native'
+
+/**
+ * Banner informativo para indicar que o app está em modo offline
+ * e exibindo dados em cache (stale).
+ * 
+ * @param {Object} props
+ * @param {string} [props.message] - Mensagem customizada
+ * @param {boolean} [props.isDaySegregated] - Se verdadeiro, indica que logs são de ontem
+ */
+export default function StaleBanner({ 
+  message, 
+  isDaySegregated = false 
+}) {
+  const defaultMessage = isDaySegregated
+    ? "Sem conexão. Mostrando agenda (logs de hoje não disponíveis)."
+    : "Sem conexão. Mostrando última sincronização disponível."
+
+  return (
+    <View style={styles.container}>
+      <AlertCircle size={16} color={colors.status.warning} style={styles.icon} />
+      <Text style={styles.text}>{message || defaultMessage}</Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: 'rgba(144, 77, 0, 0.08)', // colors.status.warning com alpha
+    paddingVertical: spacing[2],
+    paddingHorizontal: spacing[4],
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(144, 77, 0, 0.12)',
+  },
+  icon: {
+    marginRight: spacing[2],
+  },
+  text: {
+    fontSize: 12,
+    color: colors.status.warning,
+    fontWeight: '600',
+    textAlign: 'center',
+    flexShrink: 1,
+  },
+})

--- a/apps/mobile/src/shared/hooks/useOnlineStatus.js
+++ b/apps/mobile/src/shared/hooks/useOnlineStatus.js
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react'
+import NetInfo from '@react-native-community/netinfo'
+
+/**
+ * Hook para monitorar o estado de conectividade global do dispositivo.
+ * @returns {{ isOnline: boolean, isInternetReachable: boolean }}
+ */
+export function useOnlineStatus() {
+  const [status, setStatus] = useState({
+    isOnline: true, // Default otimista
+    isInternetReachable: true,
+  })
+
+  useEffect(() => {
+    // Inscreve para mudanças no estado da rede
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      setStatus({
+        isOnline: !!state.isConnected,
+        isInternetReachable: !!state.isInternetReachable,
+      })
+    })
+
+    // Fetch inicial para garantir que temos o estado atual
+    NetInfo.fetch().then((state) => {
+      setStatus({
+        isOnline: !!state.isConnected,
+        isInternetReachable: !!state.isInternetReachable,
+      })
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [])
+
+  return status
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "~2.1.2",
+        "@react-native-community/netinfo": "11.4.1",
         "@react-navigation/bottom-tabs": "^7.15.9",
         "@react-navigation/native": "^7.2.2",
         "@react-navigation/native-stack": "^7.3.10",
@@ -3584,6 +3585,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-native-community/netinfo": {
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-11.4.1.tgz",
+      "integrity": "sha512-B0BYAkghz3Q2V09BF88RA601XursIEA111tnc2JOaN7axJWmNefmfjZqw/KdSxKZp7CZUuPpjBmz/WCR9uaHYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native": ">=0.59"
       }
     },
     "node_modules/@react-native/assets-registry": {


### PR DESCRIPTION
# 📦 feat(mobile): implementa resiliência offline e stale states (H5.8)

## 🎯 Resumo

Esta PR implementa a política de "Online-first com leitura resiliente" (OS-001) para o MVP Mobile. O objetivo é garantir que o utilizador consiga visualizar a sua agenda de medicamentos e níveis de estoque mesmo sem ligação ativa à internet, utilizando snapshots persistidos no dispositivo, enquanto bloqueia acções que exijam sincronização (como o registo de doses).

---

## 📋 Tarefas Implementadas

### ✅ Infraestrutura & Monitoramento
- [x] Implementação do hook `useOnlineStatus` utilizando `@react-native-community/netinfo`.
- [x] Criação do componente `StaleBanner` para feedback visual de dados obsoletos.
- [x] Integração de limpeza de cache (`AsyncStorage`) no fluxo de logout em `Navigation.jsx`.

### ✅ Caching Persistente (Resiliência)
- [x] Implementação de snapshots persistentes em `AsyncStorage` nos hooks `useTodayData`, `useTreatments` e `useStock`.
- [x] **Regra de 24h:** Filtro de validade para snapshots salvos, garantindo segurança clínica.
- [x] **Segregação Diária:** Lógica para mostrar apenas protocolos (Agenda) e ocultar logs de doses de dias anteriores quando em modo offline num novo dia.

### ✅ Interface e Segurança
- [x] Inclusão do `StaleBanner` nas telas Hoje, Tratamentos e Estoque.
- [x] Bloqueio de confirmação de dose no `DoseRegisterModal` com mensagem de erro clara quando offline.

---

## 🔧 Arquivos Principais

```
apps/mobile/src/
├── shared/
│   ├── hooks/
│   │   └── useOnlineStatus.js         # Monitoramento de conectividade
│   └── components/feedback/
│       └── StaleBanner.jsx            # Banner de aviso offline
├── features/
│   ├── dashboard/hooks/useTodayData.js # Cache persistente + Segregação
│   ├── treatments/hooks/useTreatments.js
│   ├── stock/hooks/useStock.js
│   └── dose/components/DoseRegisterModal.jsx # Bloqueio offline
└── navigation/Navigation.jsx           # Limpeza de cache no logout
```

---

## ✅ Checklist de Verificação

### Código
- [x] Todos os testes passam (`npm run validate:agent`)
- [x] Lint sem erros (`npm run lint`)
- [x] Build web bem-sucedido (`npm run build`)

### Funcionalidade
- [x] App carrega dados offline de snapshots salvos há menos de 24h.
- [x] Agenda (protocolos) é exibida em novo dia offline, mas logs de tomadas são zerados.
- [x] Botão de confirmar dose é bloqueado e exibe erro quando offline.
- [x] Logout remove todos os snapshots do AsyncStorage.

---

## 🚀 Como Testar

```bash
# 1. Instalar as novas dependências em mobile
cd apps/mobile && npx expo install @react-native-community/netinfo

# 2. Executar validação de negócio (core)
cd ../.. && npm run validate:agent

# 3. Teste Manual (Simulador/Emulator)
# - Abrir app online e navegar para Today, Treatments e Stock para popular cache.
# - Ativar Modo Avião.
# - Validar aparecimento do banner "Sem conexão".
# - Tentar registar dose e validar o bloqueio.
# - Deslogar e validar que os snapshots foram limpos do AsyncStorage.
```

---

## 🔗 Issues Relacionadas

- Closes #H5.8 (Sprint de Resiliência Offline)
- Related to #H5 (MVP Mobile de Produto)

---

## 📝 Notas para Reviewers

1. **Day Segregation:** Em `useTodayData`, optei por manter o snapshot dos protocolos mesmo se o dia for diferente, pois ajudamos o utilizador a saber *o que* tomar se estiver totalmente offline, mas ocultamos os logs de conformidade de ontem para evitar risco clínico.
2. **NetInfo Mock:** Recomendado cuidado ao rodar testes `jest` em mobile, pois o mock do `NetInfo` pode precisar de configurações adicionais de transform dependendo do ambiente.

---

/cc @reviewers
/cc @gemini-code-assist\n\n## AI Review Response\n\n| Suggestion | Priority | Decision | Reason |\n|------------|----------|----------|--------|\n| Jest config incorrect | Critical | Applied | Commit b164918 |\n| Dashboard TypeError | Critical | Applied | Commit b164918 |\n| Timezone logic bug | High | Applied | Commit b164918 |\n| Stock readability | Medium | Applied | Commit b164918 |