### PR TITLE
feat(fase6): Sprint 6.2 — Dispatcher Multicanal e Canais (ADR-029)

### DIFF
--- a/.agent/memory/decisions/mobile_and_platform/ADR-029.md
+++ b/.agent/memory/decisions/mobile_and_platform/ADR-029.md
@@ -44,6 +44,33 @@ Jobs produzem evento de domínio normalizado. Dispatcher resolve canais da prefe
 ⚠️ Custo: ~300 linhas de novo código (dispatcher + 2 canais + utils)  
 ⚠️ Complexidade: N canais × 3 métodos (init, send, result normalize)  
 
+## Gap Identificado: DLQ Multicanal (Sprint 6.2 — 2026-04-17)
+
+O DLQ existente (`server/services/deadLetterQueue.js`) é **exclusivamente Telegram-aware**:
+- `ErrorCategories` mapeia apenas erros HTTP/Telegram (400, 401, 403, 429, etc.)
+- `enqueue()` é chamado em `tasks.js` somente após falha de `bot.sendMessage`
+- `sendDLQDigest()` envia resumo via Telegram para o admin
+
+O `dispatchNotification` implementado no Sprint 6.2 **não integra com o DLQ**:
+- Falhas transitórias de Telegram via canal novo (ex: timeout) → `failed: 1`, sem retry
+- Falhas transitórias de Expo (ex: 5xx do Expo Push Service) → `failed: 1`, sem retry
+- Erros **permanentes** de Expo (ex: `DeviceNotRegistered`) → token desativado imediatamente ✅ (correto)
+
+**Por que não é risco ainda:** O dispatcher ainda não é chamado por nenhum job em produção (isso ocorre no Sprint 6.4). O DLQ atual continua cobrindo o caminho Telegram legado enquanto a feature flag `USE_NOTIFICATION_DISPATCHER` for `false`.
+
+**Caminho de solução para Sprint 6.4 ou 6.4.1:**
+
+Opção 1 — Estender o DLQ atual (recomendado):
+- Adicionar `ErrorCategories.EXPO_RATE_LIMIT`, `EXPO_TRANSIENT`, `EXPO_UNKNOWN`
+- Integrar `enqueue()` no `dispatchNotification` para falhas com `success: false` e erro não-permanente
+- Estender `sendDLQDigest` para incluir falhas de push (já tem acesso ao bot Telegram)
+
+Opção 2 — DLQ separado para push (mais limpo, mais custoso):
+- Criar `failed_push_queue` dedicada com schema próprio para Expo
+- Operacionalizar dois DLQs separados (mais complexo de monitorar)
+
+Decisão pendente: Sprint 6.4 deve escolher entre opções antes de implementar.
+
 ## Linked Rules
 
 - **R-087** (logging estruturado com correlationId)

--- a/.agent/memory/decisions/mobile_and_platform/ADR-029.md
+++ b/.agent/memory/decisions/mobile_and_platform/ADR-029.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-029
 title: Dispatcher Multicanal de Notificações
-status: proposed
+status: accepted
 category: mobile_and_platform
 date: 2026-04-17
 ---

--- a/.agent/memory/decisions/mobile_and_platform/ADR-030.md
+++ b/.agent/memory/decisions/mobile_and_platform/ADR-030.md
@@ -1,7 +1,7 @@
 ---
 id: ADR-030
 title: Feature Flag USE_NOTIFICATION_DISPATCHER para Rollback
-status: proposed
+status: accepted
 category: mobile_and_platform
 date: 2026-04-17
 ---

--- a/.agent/state.json
+++ b/.agent/state.json
@@ -14,32 +14,31 @@
       "expo",
       "react-native"
     ],
-    "phase": "h6-sprint-6.1",
+    "phase": "h6-sprint-6.2",
     "current_sprint": "2026-W16"
   },
   "session": {
-    "id": "session_2026W16_h6_sprint6.1",
-    "started_at": "2026-04-17T00:30:00Z",
+    "id": "session_2026W16_h6_sprint6.2",
+    "started_at": "2026-04-17T06:00:00Z",
     "mode": "coding",
-    "status": "completed",
-    "goal": "Sprint 6.1 — Banco e Contratos: migrations SQL, repositories, resolveChannelsForUser",
+    "status": "analysis",
+    "goal": "Sprint 6.2 — Dispatcher e Canais: dispatchNotification, telegramChannel, expoPushChannel, buildNotificationPayload, normalizeChannelResults, shouldDeactivateDevice",
     "goal_type": "feature",
     "acceptance_criteria": [
-      "Migrations aplicam sem erro em DB local/staging",
-      "Leitura/escrita autenticada de devices funciona via RLS",
-      "resolveChannelsForUser passa todos os 9 casos de teste",
-      "npm run validate:agent verde",
-      "Nenhum arquivo de envio de push criado neste sprint"
+      "Teste 'both' simula coexistência de canais (Telegram + push)",
+      "Falha de expoPushChannel não cancela telegramChannel",
+      "shouldDeactivateDevice('DeviceNotRegistered') retorna true",
+      "Logs de dispatch incluem correlationId, userId, kind, canais tentados/entregues",
+      "npm run validate:agent verde"
     ],
     "active_wave": {
-      "name": "Fase 6 — Push Native e Beta Interno (Sprint 6.1)",
+      "name": "Fase 6 — Push Native e Beta Interno (Sprint 6.2)",
       "phase": 6,
-      "sprint": "6.1",
+      "sprint": "6.2",
       "spec": "plans/backlog-native_app/EXEC_SPEC_HIBRIDO_H6_SPRINT_PLAN.md",
-      "status": "completed",
-      "started_at": "2026-04-17T00:30:00Z",
-      "completed_at": "2026-04-17T05:50:00Z",
-      "notes": "Sprint 6.1 CONCLUÍDO: Banco (migrations + RLS) + Repositórios (Zod validated) + Policy (9 testes). PR #475 merged. Migrations executadas em Supabase. Próximo: Sprint 6.2 (Dispatcher + Canais)"
+      "status": "in_progress",
+      "started_at": "2026-04-17T06:00:00Z",
+      "notes": "Sprint 6.1 CONCLUÍDO (PR #475 merged). Sprint 6.2: Dispatcher Multicanal + Canais. ADR-029 e ADR-030 accepted."
     }
   },
   "memory": {
@@ -71,8 +70,8 @@
     "pending_mutations": []
   },
   "quality_gates": {
-    "index_loaded_at": "2026-04-17T00:30:00Z",
-    "relevant_rules_loaded_at": "2026-04-17T00:30:00Z",
+    "index_loaded_at": "2026-04-17T06:00:00Z",
+    "relevant_rules_loaded_at": "2026-04-17T06:00:00Z",
     "h5_1_sprint_validated": true,
     "h5_5_completed_at": "2026-04-14T16:45:00Z"
   },

--- a/plans/backlog-native_app/EXEC_SPEC_HIBRIDO_FASE6_PUSH_BETA_INTERNO.md
+++ b/plans/backlog-native_app/EXEC_SPEC_HIBRIDO_FASE6_PUSH_BETA_INTERNO.md
@@ -914,7 +914,40 @@ Exemplos:
 - 5xx do provider
 - indisponibilidade temporaria
 
-## 11.4. Deduplicacao
+## 11.4. DLQ Multicanal — Gap Identificado (2026-04-17)
+
+O DLQ existente (`server/services/deadLetterQueue.js`) foi projetado exclusivamente para Telegram:
+- `ErrorCategories` mapeia apenas erros HTTP Telegram (400, 401, 403, 429, etc.)
+- `enqueue()` e chamado em `tasks.js` apos falha de `bot.sendMessage`
+- `sendDLQDigest()` notifica o admin via Telegram
+
+O `dispatchNotification` implementado no Sprint 6.2 **nao integra com o DLQ**. Consequencias:
+
+| Tipo de falha | Tratamento atual | Correto? |
+|---|---|---|
+| `DeviceNotRegistered` (Expo permanente) | Token desativado via `deactivateByToken` | Sim |
+| Timeout de Expo (transitorio) | `failed: 1` no resultado, sem retry | Gap — sem retry |
+| Telegram timeout via canal novo (transitorio) | `failed: 1` no resultado, sem retry | Gap — sem retry |
+| Telegram legado em `tasks.js` | `enqueue()` chamado, retry disponivel | Sim (path legado) |
+
+**O risco nao existe nos Sprints 6.1-6.3** porque o dispatcher nao e chamado por jobs em producao.
+O gap se torna real no Sprint 6.4, quando os jobs forem migrados para o dispatcher.
+
+**Caminhos de solucao — decidir no Sprint 6.4 antes de implementar:**
+
+Opcao A (recomendada): Estender o DLQ atual
+- Adicionar ao `ErrorCategories`: `EXPO_RATE_LIMIT`, `EXPO_TRANSIENT`, `EXPO_UNKNOWN`
+- Integrar `enqueue()` no `dispatchNotification` para resultados com `success: false` e erro nao-permanente
+- Estender `sendDLQDigest` para incluir falhas push (via Telegram admin — ja existente)
+- Custo estimado: ~2h
+
+Opcao B: DLQ separado para push
+- Nova tabela `failed_push_queue` com schema Expo-especifico
+- Operacionaliza dois DLQs distintos
+- Custo estimado: ~4h + nova migration SQL
+- Recomendado apenas se Opcao A criar conflito de schema irreconciliavel
+
+## 11.5. Deduplicacao
 
 Se um mesmo job puder disparar duplicado no mesmo minuto, criar deduplicacao minima por:
 

--- a/plans/backlog-native_app/EXEC_SPEC_HIBRIDO_H6_SPRINT_PLAN.md
+++ b/plans/backlog-native_app/EXEC_SPEC_HIBRIDO_H6_SPRINT_PLAN.md
@@ -410,6 +410,23 @@ export async function dispatchNotification({ userId, kind, payload, channels, co
 - CON-018: `dispatchNotification({userId, kind, payload, channels, context, repositories, expoClient})` → `{success, channels, totalDelivered, totalFailed}`
 - CON-019: `telegramChannel` e `expoPushChannel` → shape de retorno padronizado
 
+### ⚠️ Gap identificado: DLQ Multicanal (não bloqueante para este sprint)
+
+**Situação:** O DLQ existente (`server/services/deadLetterQueue.js`) é exclusivamente Telegram-aware. O `dispatchNotification` implementado neste sprint **não integra com o DLQ** — falhas transitórias de Telegram ou Expo via nova arquitetura se perdem sem retry.
+
+**Por que não é risco neste sprint:** O dispatcher ainda não é chamado por nenhum job em produção. O DLQ atual continua cobrindo o caminho Telegram legado (`tasks.js`) enquanto a feature flag `USE_NOTIFICATION_DISPATCHER` não estiver ativa nos jobs.
+
+**O risco se torna real no Sprint 6.4**, quando os jobs forem migrados. Tratar neste momento.
+
+**Caminhos de solução para Sprint 6.4 (decidir antes de implementar):**
+
+| Opção | Descrição | Custo | Recomendação |
+|-------|-----------|-------|--------------|
+| **A** | Estender o DLQ atual — adicionar `ErrorCategories` Expo, integrar `enqueue()` no `dispatchNotification` para erros não-permanentes | ~2h | ✅ Preferida |
+| **B** | DLQ separado para push — nova tabela `failed_push_queue` com schema Expo-específico | ~4h + nova migration | Alternativa se A criar conflito de schema |
+
+**Erros permanentes Expo** (ex: `DeviceNotRegistered`) são tratados imediatamente via `shouldDeactivateDevice` + `deactivateByToken` — **não precisam de DLQ** ✅
+
 ---
 
 ## Sprint 6.3 — Integração Mobile
@@ -619,6 +636,12 @@ Ligar o cron e os jobs mais importantes ao dispatcher. Telegram continua funcion
 
 Esta é a mudança mais arriscada — jobs em produção que enviam lembretes reais.
 **Obrigatório:** feature flag de rollback ativa antes de qualquer deploy.
+
+### ⚠️ Pré-condição adicional: decidir estratégia do DLQ multicanal
+
+Antes de implementar este sprint, o agente deve escolher e implementar a integração do DLQ com o dispatcher (gap identificado no Sprint 6.2). Ver detalhes na seção "Gap identificado" ao final do Sprint 6.2.
+
+**Decisão mínima obrigatória:** qual `ErrorCategory` usar para falhas transitórias de Expo e como integrar `enqueue()` no `dispatchNotification`.
 
 ### Branch
 

--- a/server/notifications/channels/expoPushChannel.js
+++ b/server/notifications/channels/expoPushChannel.js
@@ -1,0 +1,99 @@
+// Canal de notificação Expo Push
+// Envia push para todos os devices ativos do usuário (provider = 'expo')
+// expoClient é injetado para facilitar testes sem chamadas HTTP reais
+// Desativa tokens com erros permanentes via shouldDeactivateDevice (R-042)
+
+import { shouldDeactivateDevice } from '../utils/shouldDeactivateDevice.js'
+import { normalizeChannelResults } from '../utils/normalizeChannelResults.js'
+
+export async function sendExpoPushNotification({ userId, payload, context, repositories, expoClient }) {
+  const correlationId = context?.correlationId || 'unknown'
+
+  const devices = await repositories.devices.listActiveByUser(userId, 'expo')
+
+  if (devices.length === 0) {
+    console.info('[expoPushChannel] sem devices ativos', { correlationId, userId })
+    return {
+      channel: 'mobile_push',
+      success: true,
+      attempted: 0,
+      delivered: 0,
+      failed: 0,
+      deactivatedTokens: [],
+      errors: [],
+    }
+  }
+
+  const messages = devices.map((device) => ({
+    to: device.push_token,
+    sound: 'default',
+    title: payload.title,
+    body: payload.body,
+    data: payload.metadata ?? {},
+  }))
+
+  let tickets
+  try {
+    tickets = await expoClient.send(messages)
+  } catch (error) {
+    console.error('[expoPushChannel] falha ao enviar para Expo', { correlationId, userId, error: error.message })
+    return {
+      channel: 'mobile_push',
+      success: false,
+      attempted: devices.length,
+      delivered: 0,
+      failed: devices.length,
+      deactivatedTokens: [],
+      errors: [{ message: error.message }],
+    }
+  }
+
+  return normalizeExpoResult({ devices, tickets, repositories, correlationId, userId })
+}
+
+async function normalizeExpoResult({ devices, tickets, repositories, correlationId, userId }) {
+  let delivered = 0
+  let failed = 0
+  const deactivatedTokens = []
+  const errors = []
+
+  for (let i = 0; i < tickets.length; i++) {
+    const ticket = tickets[i]
+    const device = devices[i]
+
+    if (ticket.status === 'ok') {
+      delivered++
+    } else {
+      failed++
+      const errorCode = ticket.details?.error
+      errors.push({ token: device.push_token, code: errorCode, message: ticket.message })
+
+      if (errorCode && shouldDeactivateDevice(errorCode)) {
+        try {
+          await repositories.devices.deactivateByToken(device.push_token)
+          deactivatedTokens.push(device.push_token)
+          console.info('[expoPushChannel] token desativado', { correlationId, userId, token: device.push_token, reason: errorCode })
+        } catch (deactivateError) {
+          console.error('[expoPushChannel] falha ao desativar token', {
+            correlationId,
+            userId,
+            token: device.push_token,
+            error: deactivateError.message,
+          })
+        }
+      }
+    }
+  }
+
+  console.info('[expoPushChannel] resultado', { correlationId, userId, attempted: devices.length, delivered, failed, deactivatedTokens })
+
+  return {
+    channel: 'mobile_push',
+    success: failed === 0,
+    attempted: devices.length,
+    delivered,
+    failed,
+    deactivatedTokens,
+    errors,
+  }
+}

--- a/server/notifications/channels/expoPushChannel.js
+++ b/server/notifications/channels/expoPushChannel.js
@@ -53,8 +53,8 @@ export async function sendExpoPushNotification({ userId, payload, context, repos
 async function normalizeExpoResult({ devices, tickets, repositories, correlationId, userId }) {
   let delivered = 0
   let failed = 0
-  const deactivatedTokens = []
   const errors = []
+  const tokensToDeactivate = []
 
   for (let i = 0; i < tickets.length; i++) {
     const ticket = tickets[i]
@@ -68,21 +68,24 @@ async function normalizeExpoResult({ devices, tickets, repositories, correlation
       errors.push({ token: device.push_token, code: errorCode, message: ticket.message })
 
       if (errorCode && shouldDeactivateDevice(errorCode)) {
-        try {
-          await repositories.devices.deactivateByToken(device.push_token)
-          deactivatedTokens.push(device.push_token)
-          console.info('[expoPushChannel] token desativado', { correlationId, userId, token: device.push_token, reason: errorCode })
-        } catch (deactivateError) {
-          console.error('[expoPushChannel] falha ao desativar token', {
-            correlationId,
-            userId,
-            token: device.push_token,
-            error: deactivateError.message,
-          })
-        }
+        tokensToDeactivate.push(device.push_token)
       }
     }
   }
+
+  // Desativa tokens inválidos em paralelo (permanent errors apenas)
+  const deactivationResults = await Promise.allSettled(
+    tokensToDeactivate.map((token) => repositories.devices.deactivateByToken(token))
+  )
+
+  const deactivatedTokens = tokensToDeactivate.filter((_, i) => {
+    if (deactivationResults[i].status === 'rejected') {
+      console.error('[expoPushChannel] falha ao desativar token', { correlationId, userId, token: tokensToDeactivate[i], error: deactivationResults[i].reason?.message })
+      return false
+    }
+    console.info('[expoPushChannel] token desativado', { correlationId, userId, token: tokensToDeactivate[i] })
+    return true
+  })
 
   console.info('[expoPushChannel] resultado', { correlationId, userId, attempted: devices.length, delivered, failed, deactivatedTokens })
 

--- a/server/notifications/channels/expoPushChannel.js
+++ b/server/notifications/channels/expoPushChannel.js
@@ -4,7 +4,6 @@
 // Desativa tokens com erros permanentes via shouldDeactivateDevice (R-042)
 
 import { shouldDeactivateDevice } from '../utils/shouldDeactivateDevice.js'
-import { normalizeChannelResults } from '../utils/normalizeChannelResults.js'
 
 export async function sendExpoPushNotification({ userId, payload, context, repositories, expoClient }) {
   const correlationId = context?.correlationId || 'unknown'

--- a/server/notifications/channels/expoPushChannel.test.js
+++ b/server/notifications/channels/expoPushChannel.test.js
@@ -1,0 +1,87 @@
+// Testes para expoPushChannel
+// Cobre múltiplos devices, erros permanentes e desativação de token
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { sendExpoPushNotification } from './expoPushChannel.js'
+
+const makePayload = () => ({
+  title: 'Estoque baixo',
+  body: 'Losartana está acabando',
+  deeplink: 'meusremedios://stock',
+  metadata: { medicineId: 'med-1' },
+})
+
+const makeContext = () => ({ correlationId: 'expo-test-001' })
+
+const mockExpoClient = { send: vi.fn() }
+const mockRepositories = {
+  devices: {
+    listActiveByUser: vi.fn(),
+    deactivateByToken: vi.fn(),
+  },
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('expoPushChannel', () => {
+  // Caso 1: 2 devices ativos → 2 mensagens enviadas
+  it('caso 1: 2 devices ativos → 2 mensagens enviadas, 2 entregues', async () => {
+    const devices = [
+      { push_token: 'ExponentPushToken[aaa]' },
+      { push_token: 'ExponentPushToken[bbb]' },
+    ]
+    mockRepositories.devices.listActiveByUser.mockResolvedValue(devices)
+    mockExpoClient.send.mockResolvedValue([{ status: 'ok' }, { status: 'ok' }])
+
+    const result = await sendExpoPushNotification({
+      userId: 'user-1',
+      payload: makePayload(),
+      context: makeContext(),
+      repositories: mockRepositories,
+      expoClient: mockExpoClient,
+    })
+
+    expect(result.channel).toBe('mobile_push')
+    expect(result.attempted).toBe(2)
+    expect(result.delivered).toBe(2)
+    expect(result.failed).toBe(0)
+    expect(result.deactivatedTokens).toHaveLength(0)
+    expect(mockExpoClient.send).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ to: 'ExponentPushToken[aaa]' }),
+        expect.objectContaining({ to: 'ExponentPushToken[bbb]' }),
+      ])
+    )
+  })
+
+  // Caso 2: 1 device com DeviceNotRegistered → desativado, outro entregue
+  it('caso 2: 1 DeviceNotRegistered desativado, 1 entregue', async () => {
+    const devices = [
+      { push_token: 'ExponentPushToken[bad]' },
+      { push_token: 'ExponentPushToken[good]' },
+    ]
+    mockRepositories.devices.listActiveByUser.mockResolvedValue(devices)
+    mockRepositories.devices.deactivateByToken.mockResolvedValue()
+    mockExpoClient.send.mockResolvedValue([
+      { status: 'error', message: 'DeviceNotRegistered', details: { error: 'DeviceNotRegistered' } },
+      { status: 'ok' },
+    ])
+
+    const result = await sendExpoPushNotification({
+      userId: 'user-2',
+      payload: makePayload(),
+      context: makeContext(),
+      repositories: mockRepositories,
+      expoClient: mockExpoClient,
+    })
+
+    expect(result.attempted).toBe(2)
+    expect(result.delivered).toBe(1)
+    expect(result.failed).toBe(1)
+    expect(result.deactivatedTokens).toContain('ExponentPushToken[bad]')
+    expect(mockRepositories.devices.deactivateByToken).toHaveBeenCalledWith('ExponentPushToken[bad]')
+    expect(mockRepositories.devices.deactivateByToken).not.toHaveBeenCalledWith('ExponentPushToken[good]')
+  })
+})

--- a/server/notifications/channels/telegramChannel.js
+++ b/server/notifications/channels/telegramChannel.js
@@ -1,0 +1,87 @@
+// Canal de notificação Telegram
+// Encapsula o adapter Telegram existente (server/bot/)
+// Recebe payload canônico e converte para texto MarkdownV2
+// bot é injetado para facilitar testes sem chamadas HTTP reais
+
+import { createClient } from '@supabase/supabase-js'
+import { escapeMarkdownV2 } from '../../utils/formatters.js'
+
+const supabase = createClient(
+  process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+)
+
+// Retorna telegram_chat_id do usuário ou null se não configurado
+async function getTelegramChatId(userId) {
+  const { data, error } = await supabase
+    .from('user_settings')
+    .select('telegram_chat_id')
+    .eq('user_id', userId)
+    .single()
+
+  if (error) {
+    console.error('[telegramChannel.getTelegramChatId]', { userId, error: error.message })
+    return null
+  }
+
+  return data?.telegram_chat_id || null
+}
+
+// Converte payload canônico em texto MarkdownV2 para Telegram
+function formatMessage(payload) {
+  const title = escapeMarkdownV2(payload.title)
+  const body = escapeMarkdownV2(payload.body)
+  return `*${title}*\n${body}`
+}
+
+// Shape padronizado de retorno de canal
+const EMPTY_RESULT = {
+  channel: 'telegram',
+  success: true,
+  attempted: 0,
+  delivered: 0,
+  failed: 0,
+  deactivatedTokens: [],
+  errors: [],
+}
+
+export async function sendTelegramNotification({ userId, payload, context, bot }) {
+  const correlationId = context?.correlationId || 'unknown'
+
+  const chatId = await getTelegramChatId(userId)
+
+  if (!chatId) {
+    console.info('[telegramChannel] sem telegram_chat_id', { correlationId, userId })
+    return EMPTY_RESULT
+  }
+
+  const message = formatMessage(payload)
+
+  try {
+    await bot.sendMessage(chatId, message, { parse_mode: 'MarkdownV2' })
+
+    console.info('[telegramChannel] entregue', { correlationId, userId, chatId })
+
+    return {
+      channel: 'telegram',
+      success: true,
+      attempted: 1,
+      delivered: 1,
+      failed: 0,
+      deactivatedTokens: [],
+      errors: [],
+    }
+  } catch (error) {
+    console.error('[telegramChannel] falha no envio', { correlationId, userId, chatId, error: error.message })
+
+    return {
+      channel: 'telegram',
+      success: false,
+      attempted: 1,
+      delivered: 0,
+      failed: 1,
+      deactivatedTokens: [],
+      errors: [{ message: error.message }],
+    }
+  }
+}

--- a/server/notifications/channels/telegramChannel.js
+++ b/server/notifications/channels/telegramChannel.js
@@ -3,13 +3,8 @@
 // Recebe payload canônico e converte para texto MarkdownV2
 // bot é injetado para facilitar testes sem chamadas HTTP reais
 
-import { createClient } from '@supabase/supabase-js'
+import { supabase } from '../../services/supabase.js'
 import { escapeMarkdownV2 } from '../../utils/formatters.js'
-
-const supabase = createClient(
-  process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-)
 
 // Retorna telegram_chat_id do usuário ou null se não configurado
 async function getTelegramChatId(userId) {

--- a/server/notifications/channels/telegramChannel.test.js
+++ b/server/notifications/channels/telegramChannel.test.js
@@ -18,17 +18,17 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-// Mock do supabase para controlar telegram_chat_id
+// Mock do supabase centralizado (server/services/supabase.js)
 const mockSingle = vi.fn()
 
-vi.mock('@supabase/supabase-js', () => ({
-  createClient: () => ({
+vi.mock('../../services/supabase.js', () => ({
+  supabase: {
     from: () => ({
       select: () => ({
         eq: () => ({ single: mockSingle }),
       }),
     }),
-  }),
+  },
 }))
 
 describe('telegramChannel', () => {

--- a/server/notifications/channels/telegramChannel.test.js
+++ b/server/notifications/channels/telegramChannel.test.js
@@ -1,0 +1,74 @@
+// Testes para telegramChannel
+// Cobre entrega com sucesso e ausência de telegram_chat_id
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { sendTelegramNotification } from './telegramChannel.js'
+
+const makePayload = () => ({
+  title: 'Hora do remédio',
+  body: 'Tome Losartana agora',
+  deeplink: 'meusremedios://today',
+  metadata: {},
+})
+
+const makeContext = () => ({ correlationId: 'tg-test-001' })
+const mockBot = { sendMessage: vi.fn() }
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+// Mock do supabase para controlar telegram_chat_id
+const mockSingle = vi.fn()
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({ single: mockSingle }),
+      }),
+    }),
+  }),
+}))
+
+describe('telegramChannel', () => {
+  // Caso 1: entrega com sucesso → shape correto retornado
+  it('caso 1: entrega com sucesso retorna shape correto', async () => {
+    mockSingle.mockResolvedValue({ data: { telegram_chat_id: 'chat-123' }, error: null })
+    mockBot.sendMessage.mockResolvedValue({ message_id: 42 })
+
+    const result = await sendTelegramNotification({
+      userId: 'user-1',
+      payload: makePayload(),
+      context: makeContext(),
+      bot: mockBot,
+    })
+
+    expect(result.channel).toBe('telegram')
+    expect(result.success).toBe(true)
+    expect(result.attempted).toBe(1)
+    expect(result.delivered).toBe(1)
+    expect(result.failed).toBe(0)
+    expect(result.deactivatedTokens).toHaveLength(0)
+    expect(result.errors).toHaveLength(0)
+    expect(mockBot.sendMessage).toHaveBeenCalledWith('chat-123', expect.any(String), { parse_mode: 'MarkdownV2' })
+  })
+
+  // Caso 2: sem telegram_chat_id → attempted 0
+  it('caso 2: sem telegram_chat_id retorna attempted 0', async () => {
+    mockSingle.mockResolvedValue({ data: { telegram_chat_id: null }, error: null })
+
+    const result = await sendTelegramNotification({
+      userId: 'user-2',
+      payload: makePayload(),
+      context: makeContext(),
+      bot: mockBot,
+    })
+
+    expect(result.channel).toBe('telegram')
+    expect(result.success).toBe(true)
+    expect(result.attempted).toBe(0)
+    expect(result.delivered).toBe(0)
+    expect(mockBot.sendMessage).not.toHaveBeenCalled()
+  })
+})

--- a/server/notifications/dispatcher/dispatchNotification.js
+++ b/server/notifications/dispatcher/dispatchNotification.js
@@ -1,0 +1,61 @@
+// Dispatcher central de notificações multicanal (ADR-029)
+// Recebe lista de canais resolvidos por resolveChannelsForUser e delega a cada canal
+// Falha de um canal não cancela os demais (isolamento por try/catch por canal)
+// correlationId é obrigatório em todos os logs (R-087)
+
+import { sendTelegramNotification } from '../channels/telegramChannel.js'
+import { sendExpoPushNotification } from '../channels/expoPushChannel.js'
+import { normalizeChannelResults } from '../utils/normalizeChannelResults.js'
+
+export async function dispatchNotification({ userId, kind, payload, channels, context, repositories, bot, expoClient }) {
+  const correlationId = context?.correlationId || `dispatch_${Date.now()}`
+  const ctx = { ...context, correlationId }
+
+  if (!channels || channels.length === 0) {
+    console.info('[dispatchNotification] nenhum canal — skipping', { correlationId, userId, kind })
+    return normalizeChannelResults([])
+  }
+
+  console.info('[dispatchNotification] iniciando', { correlationId, userId, kind, channels })
+
+  const results = []
+
+  for (const channel of channels) {
+    try {
+      if (channel === 'telegram') {
+        const result = await sendTelegramNotification({ userId, payload, context: ctx, bot })
+        results.push(result)
+      } else if (channel === 'mobile_push') {
+        const result = await sendExpoPushNotification({ userId, payload, context: ctx, repositories, expoClient })
+        results.push(result)
+      } else {
+        console.warn('[dispatchNotification] canal desconhecido ignorado', { correlationId, channel })
+      }
+    } catch (error) {
+      // Canal falhou completamente — registra sem cancelar os demais
+      console.error('[dispatchNotification] canal falhou', { correlationId, userId, kind, channel, error: error.message })
+      results.push({
+        channel,
+        success: false,
+        attempted: 0,
+        delivered: 0,
+        failed: 0,
+        deactivatedTokens: [],
+        errors: [{ message: error.message }],
+      })
+    }
+  }
+
+  const normalized = normalizeChannelResults(results)
+
+  console.info('[dispatchNotification] concluído', {
+    correlationId,
+    userId,
+    kind,
+    channels,
+    totalDelivered: normalized.totalDelivered,
+    totalFailed: normalized.totalFailed,
+  })
+
+  return normalized
+}

--- a/server/notifications/dispatcher/dispatchNotification.js
+++ b/server/notifications/dispatcher/dispatchNotification.js
@@ -1,50 +1,74 @@
 // Dispatcher central de notificações multicanal (ADR-029)
 // Recebe lista de canais resolvidos por resolveChannelsForUser e delega a cada canal
-// Falha de um canal não cancela os demais (isolamento por try/catch por canal)
+// Falha de um canal não cancela os demais (Promise.allSettled por canal)
 // correlationId é obrigatório em todos os logs (R-087)
 
+import { z } from 'zod'
 import { sendTelegramNotification } from '../channels/telegramChannel.js'
 import { sendExpoPushNotification } from '../channels/expoPushChannel.js'
 import { normalizeChannelResults } from '../utils/normalizeChannelResults.js'
 
+const dispatchInputSchema = z.object({
+  userId: z.string().min(1),
+  kind: z.enum(['dose_reminder', 'stock_alert', 'daily_digest']),
+  channels: z.array(z.string()).default([]),
+})
+
+async function dispatchChannel({ channel, userId, payload, context, repositories, bot, expoClient }) {
+  const correlationId = context.correlationId
+  try {
+    if (channel === 'telegram') {
+      return await sendTelegramNotification({ userId, payload, context, bot })
+    } else if (channel === 'mobile_push') {
+      return await sendExpoPushNotification({ userId, payload, context, repositories, expoClient })
+    } else {
+      console.warn('[dispatchNotification] canal desconhecido ignorado', { correlationId, channel })
+      return null
+    }
+  } catch (error) {
+    console.error('[dispatchNotification] canal falhou', { correlationId, userId, channel, error: error.message })
+    return {
+      channel,
+      success: false,
+      attempted: 0,
+      delivered: 0,
+      failed: 0,
+      deactivatedTokens: [],
+      errors: [{ message: error.message }],
+    }
+  }
+}
+
 export async function dispatchNotification({ userId, kind, payload, channels, context, repositories, bot, expoClient }) {
+  const parsed = dispatchInputSchema.safeParse({ userId, kind, channels })
+  if (!parsed.success) {
+    throw new Error(`[dispatchNotification] Entrada inválida: ${parsed.error.message}`)
+  }
+
   const correlationId = context?.correlationId || `dispatch_${Date.now()}`
   const ctx = { ...context, correlationId }
+  const validChannels = parsed.data.channels
 
-  if (!channels || channels.length === 0) {
+  if (validChannels.length === 0) {
     console.info('[dispatchNotification] nenhum canal — skipping', { correlationId, userId, kind })
     return normalizeChannelResults([])
   }
 
-  console.info('[dispatchNotification] iniciando', { correlationId, userId, kind, channels })
+  console.info('[dispatchNotification] iniciando', { correlationId, userId, kind, channels: validChannels })
 
-  const results = []
+  const settledResults = await Promise.allSettled(
+    validChannels.map((channel) => dispatchChannel({ channel, userId, payload, context: ctx, repositories, bot, expoClient }))
+  )
 
-  for (const channel of channels) {
-    try {
-      if (channel === 'telegram') {
-        const result = await sendTelegramNotification({ userId, payload, context: ctx, bot })
-        results.push(result)
-      } else if (channel === 'mobile_push') {
-        const result = await sendExpoPushNotification({ userId, payload, context: ctx, repositories, expoClient })
-        results.push(result)
-      } else {
-        console.warn('[dispatchNotification] canal desconhecido ignorado', { correlationId, channel })
+  const results = settledResults
+    .map((r, i) => {
+      if (r.status === 'rejected') {
+        console.error('[dispatchNotification] canal rejeitou promise', { correlationId, channel: validChannels[i], reason: r.reason?.message })
+        return { channel: validChannels[i], success: false, attempted: 0, delivered: 0, failed: 0, deactivatedTokens: [], errors: [{ message: r.reason?.message }] }
       }
-    } catch (error) {
-      // Canal falhou completamente — registra sem cancelar os demais
-      console.error('[dispatchNotification] canal falhou', { correlationId, userId, kind, channel, error: error.message })
-      results.push({
-        channel,
-        success: false,
-        attempted: 0,
-        delivered: 0,
-        failed: 0,
-        deactivatedTokens: [],
-        errors: [{ message: error.message }],
-      })
-    }
-  }
+      return r.value
+    })
+    .filter(Boolean)
 
   const normalized = normalizeChannelResults(results)
 
@@ -52,7 +76,7 @@ export async function dispatchNotification({ userId, kind, payload, channels, co
     correlationId,
     userId,
     kind,
-    channels,
+    channels: validChannels,
     totalDelivered: normalized.totalDelivered,
     totalFailed: normalized.totalFailed,
   })

--- a/server/notifications/dispatcher/dispatchNotification.test.js
+++ b/server/notifications/dispatcher/dispatchNotification.test.js
@@ -1,0 +1,150 @@
+// Testes para dispatchNotification
+// Cobre coexistência de canais, isolamento de falhas e casos-limite
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { dispatchNotification } from './dispatchNotification.js'
+
+const makePayload = () => ({
+  title: 'Hora do seu remédio',
+  body: 'Tome Losartana agora',
+  deeplink: 'meusremedios://today',
+  metadata: {},
+})
+
+const makeContext = () => ({ correlationId: 'test-corr-123' })
+
+const mockBot = { sendMessage: vi.fn() }
+const mockExpoClient = { send: vi.fn() }
+const mockRepositories = {
+  preferences: { getByUserId: vi.fn(), hasTelegramChat: vi.fn() },
+  devices: { listActiveByUser: vi.fn(), deactivateByToken: vi.fn() },
+}
+
+// Supabase é importado internamente em telegramChannel — mockamos o módulo
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: vi.fn().mockResolvedValue({ data: { telegram_chat_id: 'chat-999' }, error: null }),
+        }),
+      }),
+    }),
+  }),
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('dispatchNotification', () => {
+  // Caso 1: both com Telegram OK + push OK → ambos entregues
+  it('caso 1: both — Telegram e push entregues', async () => {
+    mockBot.sendMessage.mockResolvedValue({ message_id: 1 })
+    mockExpoClient.send.mockResolvedValue([{ status: 'ok' }])
+    mockRepositories.devices.listActiveByUser.mockResolvedValue([{ push_token: 'ExponentPushToken[abc]' }])
+
+    const result = await dispatchNotification({
+      userId: 'user-1',
+      kind: 'dose_reminder',
+      payload: makePayload(),
+      channels: ['telegram', 'mobile_push'],
+      context: makeContext(),
+      repositories: mockRepositories,
+      bot: mockBot,
+      expoClient: mockExpoClient,
+    })
+
+    expect(result.totalDelivered).toBe(2)
+    expect(result.totalFailed).toBe(0)
+    expect(result.channels).toHaveLength(2)
+  })
+
+  // Caso 2: both com push falhando → Telegram entrega, push falha sem cancelar Telegram
+  it('caso 2: both — Telegram entregue, push falha isoladamente', async () => {
+    mockBot.sendMessage.mockResolvedValue({ message_id: 2 })
+    mockExpoClient.send.mockRejectedValue(new Error('Expo service unavailable'))
+    mockRepositories.devices.listActiveByUser.mockResolvedValue([{ push_token: 'ExponentPushToken[def]' }])
+
+    const result = await dispatchNotification({
+      userId: 'user-2',
+      kind: 'dose_reminder',
+      payload: makePayload(),
+      channels: ['telegram', 'mobile_push'],
+      context: makeContext(),
+      repositories: mockRepositories,
+      bot: mockBot,
+      expoClient: mockExpoClient,
+    })
+
+    const telegramResult = result.channels.find((c) => c.channel === 'telegram')
+    const pushResult = result.channels.find((c) => c.channel === 'mobile_push')
+
+    expect(telegramResult.delivered).toBe(1)
+    expect(pushResult.success).toBe(false)
+    expect(result.totalDelivered).toBe(1)
+  })
+
+  // Caso 3: mobile_push com DeviceNotRegistered → token desativado
+  it('caso 3: DeviceNotRegistered desativa o token', async () => {
+    mockRepositories.devices.listActiveByUser.mockResolvedValue([{ push_token: 'ExponentPushToken[bad]' }])
+    mockRepositories.devices.deactivateByToken.mockResolvedValue()
+    mockExpoClient.send.mockResolvedValue([
+      { status: 'error', message: 'DeviceNotRegistered', details: { error: 'DeviceNotRegistered' } },
+    ])
+
+    const result = await dispatchNotification({
+      userId: 'user-3',
+      kind: 'dose_reminder',
+      payload: makePayload(),
+      channels: ['mobile_push'],
+      context: makeContext(),
+      repositories: mockRepositories,
+      bot: mockBot,
+      expoClient: mockExpoClient,
+    })
+
+    expect(mockRepositories.devices.deactivateByToken).toHaveBeenCalledWith('ExponentPushToken[bad]')
+    expect(result.channels[0].deactivatedTokens).toContain('ExponentPushToken[bad]')
+  })
+
+  // Caso 4: none (channels=[]) → zero tentativas
+  it('caso 4: channels vazio → nenhuma tentativa', async () => {
+    const result = await dispatchNotification({
+      userId: 'user-4',
+      kind: 'dose_reminder',
+      payload: makePayload(),
+      channels: [],
+      context: makeContext(),
+      repositories: mockRepositories,
+      bot: mockBot,
+      expoClient: mockExpoClient,
+    })
+
+    expect(result.channels).toHaveLength(0)
+    expect(result.totalDelivered).toBe(0)
+    expect(result.totalFailed).toBe(0)
+    expect(mockBot.sendMessage).not.toHaveBeenCalled()
+    expect(mockExpoClient.send).not.toHaveBeenCalled()
+  })
+
+  // Caso 5: usuário sem devices push → attempted 0
+  it('caso 5: mobile_push sem devices → attempted 0', async () => {
+    mockRepositories.devices.listActiveByUser.mockResolvedValue([])
+
+    const result = await dispatchNotification({
+      userId: 'user-5',
+      kind: 'dose_reminder',
+      payload: makePayload(),
+      channels: ['mobile_push'],
+      context: makeContext(),
+      repositories: mockRepositories,
+      bot: mockBot,
+      expoClient: mockExpoClient,
+    })
+
+    expect(result.channels[0].attempted).toBe(0)
+    expect(result.totalDelivered).toBe(0)
+    expect(mockExpoClient.send).not.toHaveBeenCalled()
+  })
+})

--- a/server/notifications/dispatcher/dispatchNotification.test.js
+++ b/server/notifications/dispatcher/dispatchNotification.test.js
@@ -20,9 +20,9 @@ const mockRepositories = {
   devices: { listActiveByUser: vi.fn(), deactivateByToken: vi.fn() },
 }
 
-// Supabase é importado internamente em telegramChannel — mockamos o módulo
-vi.mock('@supabase/supabase-js', () => ({
-  createClient: () => ({
+// Supabase centralizado importado em telegramChannel — mockamos o módulo centralizado
+vi.mock('../../services/supabase.js', () => ({
+  supabase: {
     from: () => ({
       select: () => ({
         eq: () => ({
@@ -30,7 +30,7 @@ vi.mock('@supabase/supabase-js', () => ({
         }),
       }),
     }),
-  }),
+  },
 }))
 
 afterEach(() => {

--- a/server/notifications/payloads/buildNotificationPayload.js
+++ b/server/notifications/payloads/buildNotificationPayload.js
@@ -1,0 +1,37 @@
+// Constrói payload canônico de notificação a partir de evento de domínio
+// Todos os canais (Telegram, Expo) consomem este shape normalizado
+
+const SUPPORTED_KINDS = ['dose_reminder', 'stock_alert', 'daily_digest']
+
+export function buildNotificationPayload({ kind, data }) {
+  switch (kind) {
+    case 'dose_reminder':
+      return {
+        title: 'Hora do seu remédio',
+        body: `Tome ${data.medicineName} agora`,
+        deeplink: `meusremedios://today?protocolId=${data.protocolId}`,
+        metadata: { protocolId: data.protocolId, medicineId: data.medicineId },
+      }
+
+    case 'stock_alert':
+      return {
+        title: 'Estoque baixo',
+        body: `${data.medicineName} está acabando`,
+        deeplink: `meusremedios://stock`,
+        metadata: { medicineId: data.medicineId },
+      }
+
+    case 'daily_digest':
+      return {
+        title: 'Resumo do dia',
+        body: data.summary,
+        deeplink: `meusremedios://today`,
+        metadata: {},
+      }
+
+    default:
+      throw new Error(
+        `[buildNotificationPayload] Unsupported notification kind: "${kind}". Supported: ${SUPPORTED_KINDS.join(', ')}`
+      )
+  }
+}

--- a/server/notifications/payloads/buildNotificationPayload.js
+++ b/server/notifications/payloads/buildNotificationPayload.js
@@ -1,9 +1,18 @@
 // Constrói payload canônico de notificação a partir de evento de domínio
 // Todos os canais (Telegram, Expo) consomem este shape normalizado
 
-const SUPPORTED_KINDS = ['dose_reminder', 'stock_alert', 'daily_digest']
+import { z } from 'zod'
+
+const kindSchema = z.enum(['dose_reminder', 'stock_alert', 'daily_digest'])
 
 export function buildNotificationPayload({ kind, data }) {
+  const parsed = kindSchema.safeParse(kind)
+  if (!parsed.success) {
+    throw new Error(
+      `[buildNotificationPayload] Unsupported notification kind: "${kind}". Supported: ${kindSchema.options.join(', ')}`
+    )
+  }
+
   switch (kind) {
     case 'dose_reminder':
       return {
@@ -28,10 +37,5 @@ export function buildNotificationPayload({ kind, data }) {
         deeplink: `meusremedios://today`,
         metadata: {},
       }
-
-    default:
-      throw new Error(
-        `[buildNotificationPayload] Unsupported notification kind: "${kind}". Supported: ${SUPPORTED_KINDS.join(', ')}`
-      )
   }
 }

--- a/server/notifications/utils/normalizeChannelResults.js
+++ b/server/notifications/utils/normalizeChannelResults.js
@@ -1,0 +1,18 @@
+// Consolida resultados de múltiplos canais em objeto único
+// Cada canal retorna { channel, success, attempted, delivered, failed, deactivatedTokens, errors }
+
+export function normalizeChannelResults(results) {
+  if (!results || results.length === 0) {
+    return { success: true, channels: [], totalDelivered: 0, totalFailed: 0 }
+  }
+
+  const totalDelivered = results.reduce((sum, r) => sum + (r.delivered ?? 0), 0)
+  const totalFailed = results.reduce((sum, r) => sum + (r.failed ?? 0), 0)
+
+  return {
+    success: results.every((r) => r.success),
+    channels: results,
+    totalDelivered,
+    totalFailed,
+  }
+}

--- a/server/notifications/utils/shouldDeactivateDevice.js
+++ b/server/notifications/utils/shouldDeactivateDevice.js
@@ -1,0 +1,8 @@
+// Determina se um token deve ser desativado com base no código de erro do Expo
+// Erros permanentes indicam que o device não pode mais receber notificações
+
+const PERMANENT_ERRORS = ['DeviceNotRegistered', 'InvalidCredentials', 'MessageTooBig']
+
+export function shouldDeactivateDevice(errorCode) {
+  return PERMANENT_ERRORS.includes(errorCode)
+}


### PR DESCRIPTION
## Sumário

Sprint 6.2 — implementação completa do dispatcher multicanal de notificações (ADR-029):

- `server/notifications/dispatcher/dispatchNotification.js` — orquestrador central com Zod validation + Promise.allSettled
- `server/notifications/channels/telegramChannel.js` — canal Telegram com supabase centralizado
- `server/notifications/channels/expoPushChannel.js` — canal Expo Push com deactivação paralela
- `server/notifications/payloads/buildNotificationPayload.js` — payload canônico com z.enum para kind
- `server/notifications/utils/normalizeChannelResults.js` — consolidação de resultados
- `server/notifications/utils/shouldDeactivateDevice.js` — detecção de erros permanentes
- Repositórios: `preferencesRepository.js` + `devicesRepository.js`
- Testes: 5 casos dispatcher + 2 canal Telegram + 2 canal Expo

## Arquivos

| Arquivo | Propósito |
|---------|-----------|
| `dispatcher/dispatchNotification.js` | Orquestrador (z.object input + Promise.allSettled) |
| `channels/telegramChannel.js` | Adapter Telegram (supabase centralizado) |
| `channels/expoPushChannel.js` | Adapter Expo Push (deactivação em paralelo) |
| `payloads/buildNotificationPayload.js` | Normalização de evento → payload (z.enum) |
| `utils/normalizeChannelResults.js` | Consolidação de N resultados de canal |
| `utils/shouldDeactivateDevice.js` | Erros permanentes vs. transitórios |

## Como testar

```bash
npm run validate:agent
```

## ADRs Referenciados

- ADR-029: Dispatcher Multicanal (accepted) — inclui gap do DLQ documentado para Sprint 6.4
- ADR-030: Repositórios de Notificação (accepted)

## AI Review Response

| Sugestão | Prioridade | Decisão | Razão |
|---------|-----------|---------|-------|
| Validação Zod de entrada em dispatchNotification | High | Applied | Commit 7786018 — dispatchInputSchema com z.object |
| z.enum para kind em buildNotificationPayload | High | Applied | Commit c77aabc — kindSchema.safeParse antes do switch |
| Promise.allSettled para canais paralelos | Medium | Applied | Commit 7786018 — isolamento de falha preservado |
| Supabase client centralizado em telegramChannel | Medium | Applied | Commit ac11bfc — importa server/services/supabase.js |
| Promise.allSettled para deactivateByToken | Medium | Applied | Commit c91831b — tokensToDeactivate[] + allSettled |
| Camada dedicada para tradução de erros | Medium | Declined | Over-engineering para único error case developer-facing |

🤖 Generated with Claude Sonnet 4.6