### PR TITLE
refactor(mobile): migrar identidade Expo para Dosiq (Fase 2)

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,4 +1,4 @@
-# @meus-remedios/mobile
+# @dosiq/mobile
 
 Placeholder da Fase 1 (Wave H1).
 

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -13,22 +13,22 @@ const VERSION_CODE = major * 10000 + minor * 100 + patch
 
 const variants = {
   development: {
-    name: 'Meus Remedios Dev',
-    slug: 'meus-remedios-dev',
-    iosBundleIdentifier: 'com.coelhotv.meusremedios.dev',
-    androidPackage: 'com.coelhotv.meusremedios.dev',
+    name: 'Dosiq Dev',
+    slug: 'dosiq-app',
+    iosBundleIdentifier: 'com.coelhotv.dosiq.development',
+    androidPackage: 'com.coelhotv.dosiq.development',
   },
   preview: {
-    name: 'Meus Remedios Preview',
-    slug: 'meus-remedios-dev',
-    iosBundleIdentifier: 'com.coelhotv.meusremedios.preview',
-    androidPackage: 'com.coelhotv.meusremedios.preview',
+    name: 'Dosiq Preview',
+    slug: 'dosiq-app',
+    iosBundleIdentifier: 'com.coelhotv.dosiq.preview',
+    androidPackage: 'com.coelhotv.dosiq.preview',
   },
   production: {
-    name: 'Meus Remedios',
-    slug: 'meus-remedios-dev',
-    iosBundleIdentifier: 'com.coelhotv.meusremedios',
-    androidPackage: 'com.coelhotv.meusremedios',
+    name: 'Dosiq',
+    slug: 'dosiq-app',
+    iosBundleIdentifier: 'com.coelhotv.dosiq',
+    androidPackage: 'com.coelhotv.dosiq',
   },
 }
 
@@ -40,7 +40,7 @@ module.exports = {
     owner: 'coelhotv',
     slug: current.slug,
     // DL-001: scheme canônico do projeto
-    scheme: 'meusremedios',
+    scheme: 'dosiq',
     version: APP_VERSION,
     cli: {
       appVersionSource: 'local',

--- a/apps/mobile/build-android.sh
+++ b/apps/mobile/build-android.sh
@@ -4,7 +4,7 @@
 
 PROFILE="${1:-preview}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ICLOUD_MOBILE="$SCRIPT_DIR"
+APP_DIR="$SCRIPT_DIR"
 
 # production usa google-services.json (sem sufixo), demais usam google-services-{profile}.json
 if [ "$PROFILE" = "production" ]; then

--- a/apps/mobile/build-android.sh
+++ b/apps/mobile/build-android.sh
@@ -3,7 +3,8 @@
 # Uso: bash build-android.sh [preview|development|production]
 
 PROFILE="${1:-preview}"
-ICLOUD_MOBILE="/Users/coelhotv/git-icloud/meus-remedios/apps/mobile"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ICLOUD_MOBILE="$SCRIPT_DIR"
 
 # production usa google-services.json (sem sufixo), demais usam google-services-{profile}.json
 if [ "$PROFILE" = "production" ]; then

--- a/apps/mobile/src/__tests__/polyfills.test.js
+++ b/apps/mobile/src/__tests__/polyfills.test.js
@@ -58,8 +58,8 @@ describe('Hermes Polyfills Implementation', () => {
     });
 
     it('should correctly parsing and return hostname', () => {
-      const url = new URL('https://api.meus-remedios.com/v1');
-      expect(url.hostname).toBe('api.meus-remedios.com');
+      const url = new URL('https://api.dosiq.com/v1');
+      expect(url.hostname).toBe('api.dosiq.com');
     });
 
     it('should handle URL with port in toString() correctly', () => {

--- a/apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx
+++ b/apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx
@@ -270,7 +270,7 @@ export default function NotificationPreferencesScreen({ navigation }) {
               <Text style={styles.settingsButtonText}>Abrir Configurações do Dispositivo</Text>
             </TouchableOpacity>
             <Text style={styles.settingsHint}>
-              Navegue para Aplicativos › Meus Remédios › Notificações e ative as notificações.
+              Navegue para Aplicativos › Dosiq › Notificações e ative as notificações.
             </Text>
           </View>
         )}

--- a/apps/mobile/src/features/profile/screens/TelegramLinkScreen.jsx
+++ b/apps/mobile/src/features/profile/screens/TelegramLinkScreen.jsx
@@ -27,7 +27,7 @@ export default function TelegramLinkScreen({ navigation }) {
   }
 
   const handleOpenBot = async () => {
-    const url = `https://t.me/meus_remedios_bot?start=${token || ''}`
+    const url = `https://t.me/dosiq_bot?start=${token || ''}`
     const supported = await Linking.canOpenURL(url)
     if (supported) {
       await Linking.openURL(url)

--- a/apps/mobile/src/screens/LoginScreen.jsx
+++ b/apps/mobile/src/screens/LoginScreen.jsx
@@ -56,7 +56,7 @@ export default function LoginScreen({ navigation }) {
         style={styles.container}
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       >
-        <Text style={styles.title}>Meus Remédios</Text>
+        <Text style={styles.title}>Dosiq</Text>
         <Text style={styles.subtitle}>Entre na sua conta</Text>
 
         <TextInput


### PR DESCRIPTION
# 📦 refactor(mobile): migrar identidade Expo do app para Dosiq (Fase 2)

## 🎯 Resumo

Esta PR executa a Fase 2 da migração Dosiq no app mobile.
Atualiza identidade canônica do Expo (name/slug/scheme/bundle IDs), remove branding legado em telas-chave e ajusta referências auxiliares para manter consistência com as novas configurações de loja/Expo.

---

## 📋 Tarefas Implementadas

### Mobile Expo Config
- [x] Atualizado `apps/mobile/app.config.js` com identidade `Dosiq` por variante
- [x] Atualizado `scheme` para `dosiq`
- [x] Preservado `extra.eas.projectId` sem alterações
- [x] Aplicadas as variações de `slug`/`bundle` para o novo cenário de lojas/Expo

### Branding e referências legadas
- [x] Atualizado título da tela de login para `Dosiq`
- [x] Atualizado texto de configuração de notificações para `Dosiq`
- [x] Atualizado bot link para `dosiq_bot`
- [x] Atualizado package name no `apps/mobile/README.md`
- [x] Ajustado `build-android.sh` para remover path fixo legado
- [x] Atualizado teste de URL legado em `apps/mobile/src/__tests__/polyfills.test.js`

---

## 🔧 Arquivos Principais

```text
apps/mobile/
├── app.config.js                                              # identidade canônica Expo (name/slug/scheme/bundle IDs)
├── build-android.sh                                           # path dinâmico do diretório do script
├── README.md                                                  # scope @dosiq/mobile
└── src/
    ├── screens/LoginScreen.jsx                               # título de marca
    ├── features/profile/screens/NotificationPreferencesScreen.jsx  # copy com Dosiq
    ├── features/profile/screens/TelegramLinkScreen.jsx       # link do bot
    └── __tests__/polyfills.test.js                           # URL de teste atualizada
```

---

## ✅ Checklist de Verificação

### Código
- [x] Todos os testes passam (`npm run test:critical`)
- [x] Lint sem erros (`npm run lint`)
- [x] Build bem-sucedido (`npx expo config --type public` sem erro de parse)

### Funcionalidade
- [x] `app.config.js` refletindo identidade `Dosiq` nas variantes
- [x] `scheme` nativo atualizado para `dosiq`
- [x] Sem resíduos legados no escopo mobile da fase

### Documentação
- [x] README mobile atualizado para o novo scope

---

## 🚀 Como Testar

```bash
# 1. Checkout da branch
 git checkout feat/dosiq-migration-fase-2-mobile-identity

# 2. Validar lint
 npm run lint

# 3. Validar config Expo (mobile)
 cd apps/mobile
 npx expo config --type public | head -30

# 4. Validar testes críticos
 cd ../..
 npm run test:critical
```

**Resultado esperado:**
- Config Expo renderiza sem erro com `name: Dosiq Dev`, `slug: dosiq-app`, `scheme: dosiq`
- Lint e testes críticos verdes
- Textos e links mobile sem marca legada

---

## 🔗 Issues Relacionadas

- Related to `plans/dosiq-migration/EXEC_SPEC_DOSIQ_MIGRATION_MASTER.md`
- Related to `plans/dosiq-migration/EXEC_SPEC_DOSIQ_MIGRATION_FASE_2.md`

---

## 📝 Notas para Reviewers

1. **Config nativa:** revisar principalmente `apps/mobile/app.config.js` (slug/scheme/bundle IDs).
2. **Segurança de deploy:** confirmar que `extra.eas.projectId` permaneceu intacto.
3. **Escopo:** PR intencionalmente focado em Fase 2 (mobile identity + branding).

---

/cc @reviewers
/cc @gemini-code-assist
