### PR TITLE
hotfix(schema): corrige z.record Zod v4 — falha crítica ao persistir notification_log

### DIFF
--- a/packages/core/src/schemas/notificationLogSchema.js
+++ b/packages/core/src/schemas/notificationLogSchema.js
@@ -8,7 +8,7 @@ const baseSchema = {
   sent_at: z.string().datetime().optional(),
   telegram_message_id: z.number().nullable().optional(),
   mensagem_erro: z.string().nullable().optional(),
-  provider_metadata: z.record(z.any()).default({}),
+  provider_metadata: z.record(z.string(), z.any()).default({}),
 };
 
 export const notificationLogSchema = z.object({

--- a/packages/core/src/schemas/notificationLogSchema.js
+++ b/packages/core/src/schemas/notificationLogSchema.js
@@ -8,7 +8,7 @@ const baseSchema = {
   sent_at: z.string().datetime().optional(),
   telegram_message_id: z.number().nullable().optional(),
   mensagem_erro: z.string().nullable().optional(),
-  provider_metadata: z.record(z.string(), z.any()).default({}),
+  provider_metadata: z.record(z.string(), z.unknown()).default({}),
 };
 
 export const notificationLogSchema = z.object({


### PR DESCRIPTION
## Problema

`[dispatchNotification] Falha crítica ao persistir log no DB — Cannot read properties of undefined (reading '_zod')`

Ocorrendo em **produção** a cada disparo de push mobile desde Sprint 8.2. Notificações são entregues mas nunca registradas no banco — Central de Avisos fica sempre vazia.

## Causa Raiz

Em **Zod v4**, `z.record(valueType)` com argumento único define o argumento como `keyType` e deixa `valueType = undefined`. O parse funciona para `{}` (objeto vazio) mas explode com `_zod` quando `provider_metadata` contém dados reais (`{ tickets: [...] }`).

```js
// ❌ Zod v4 — valueType=undefined → explode com non-empty objects
provider_metadata: z.record(z.any()).default({})

// ✅ Fix
provider_metadata: z.record(z.string(), z.any()).default({})
```

## Mudança

`packages/core/src/schemas/notificationLogSchema.js` — 1 linha.

## Impacto

Zero regressões possíveis — único uso de `z.record()` no projeto. Schemas existentes não afetados.

## Teste

Próximo disparo do cron `/api/notify` deve persistir o log sem erro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)