### PR TITLE
feat(notifications/n1.3): dedup grouped + fix dispatcher enum + expo navigation payload

### DIFF
--- a/server/bot/tasks.js
+++ b/server/bot/tasks.js
@@ -7,7 +7,7 @@ import {
   getUserSettings,
   getAllUsersWithTelegram
 } from '../services/protocolCache.js';
-import { shouldSendNotification, logSuccessfulNotification } from '../services/notificationDeduplicator.js';
+import { shouldSendNotification, logSuccessfulNotification, shouldSendGroupedNotification } from '../services/notificationDeduplicator.js';
 import {
   getCurrentTimeInTimezone,
   getCurrentDateInTimezone,
@@ -409,6 +409,21 @@ async function checkRemindersViaDispatcher(dispatcher, correlationId) {
         });
 
         for (const block of blocks) {
+          // Verificar deduplicação para blocos agrupados
+          if (block.kind === 'by_plan') {
+            const shouldSend = await shouldSendGroupedNotification(userId, 'dose_reminder_by_plan', { planId: block.planId });
+            if (!shouldSend) {
+              logger.debug('Dose reminder by_plan suprimido por deduplicação', { userId, correlationId, planId: block.planId });
+              continue;
+            }
+          } else if (block.kind === 'misc') {
+            const shouldSend = await shouldSendGroupedNotification(userId, 'dose_reminder_misc', {});
+            if (!shouldSend) {
+              logger.debug('Dose reminder misc suprimido por deduplicação', { userId, correlationId });
+              continue;
+            }
+          }
+
           let kind, data;
 
           if (block.kind === 'by_plan') {

--- a/server/bot/tasks.js
+++ b/server/bot/tasks.js
@@ -410,16 +410,17 @@ async function checkRemindersViaDispatcher(dispatcher, correlationId) {
 
         for (const block of blocks) {
           // Verificar deduplicação para blocos agrupados
-          if (block.kind === 'by_plan') {
-            const shouldSend = await shouldSendGroupedNotification(userId, 'dose_reminder_by_plan', { planId: block.planId });
+          const normalizedKind = block.kind?.toLowerCase();
+          if (['by_plan', 'misc'].includes(normalizedKind)) {
+            const notificationType = 'dose_reminder_' + normalizedKind;
+            const options = normalizedKind === 'by_plan' ? { planId: block.planId } : {};
+            const shouldSend = await shouldSendGroupedNotification(userId, notificationType, options);
             if (!shouldSend) {
-              logger.debug('Dose reminder by_plan suprimido por deduplicação', { userId, correlationId, planId: block.planId });
-              continue;
-            }
-          } else if (block.kind === 'misc') {
-            const shouldSend = await shouldSendGroupedNotification(userId, 'dose_reminder_misc', {});
-            if (!shouldSend) {
-              logger.debug('Dose reminder misc suprimido por deduplicação', { userId, correlationId });
+              const logContext = { userId, correlationId };
+              if (block.planId) {
+                logContext.planId = block.planId;
+              }
+              logger.debug('Dose reminder ' + normalizedKind + ' suprimido por deduplicação', logContext);
               continue;
             }
           }

--- a/server/notifications/channels/expoPushChannel.js
+++ b/server/notifications/channels/expoPushChannel.js
@@ -28,7 +28,10 @@ export async function sendExpoPushNotification({ userId, payload, context, repos
     sound: 'default',
     title: payload.title,
     body: payload.body,
-    data: payload.metadata ?? {},
+    data: {
+      ...(payload.metadata ?? {}),
+      notificationLogId: payload.metadata?.notificationLogId ?? null,
+    },
   }))
 
   let tickets

--- a/server/notifications/dispatcher/dispatchNotification.js
+++ b/server/notifications/dispatcher/dispatchNotification.js
@@ -11,7 +11,7 @@ import { notificationLogRepository } from '../repositories/notificationLogReposi
 
 const dispatchInputSchema = z.object({
   userId: z.string().min(1),
-  kind: z.enum(['dose_reminder', 'stock_alert', 'daily_digest']),
+  kind: z.enum(['dose_reminder', 'dose_reminder_by_plan', 'dose_reminder_misc', 'stock_alert', 'daily_digest']),
   channels: z.array(z.string()).default([]),
 })
 
@@ -81,7 +81,8 @@ export async function dispatchNotification({ userId, kind, payload, channels, co
       const activeResults = results.filter(r => r.attempted > 0 || r.errors.length > 0)
       if (activeResults.length === 0) return
 
-      const protocolId = payload.metadata?.protocolId ?? null
+      const isGroupedKind = kind === 'dose_reminder_by_plan' || kind === 'dose_reminder_misc'
+      const protocolId = isGroupedKind ? null : (payload.metadata?.protocolId ?? null)
       if (!protocolId && kind === 'dose_reminder') {
         console.warn('[dispatchNotification] dose_reminder sem protocolId no metadata', { correlationId, kind })
       }
@@ -111,7 +112,10 @@ export async function dispatchNotification({ userId, kind, payload, channels, co
           channels,
           telegram_message_id: channels.find(c => c.channel === 'telegram')?.message_id ?? null,
           mensagem_erro:     firstError,
-          provider_metadata: {},
+          provider_metadata: {
+            ...(payload.metadata?.protocolIds ? { protocol_ids: payload.metadata.protocolIds } : {}),
+            ...(payload.metadata?.planId ? { treatment_plan_id: payload.metadata.planId } : {}),
+          },
         })
       } catch (logErr) {
         console.error('[dispatchNotification] Falha ao persistir log no DB', {

--- a/server/services/notificationDeduplicator.js
+++ b/server/services/notificationDeduplicator.js
@@ -144,3 +144,52 @@ export async function cleanupOldNotificationLogs() {
     console.log('[Deduplicator] Limpeza concluída');
   }
 }
+
+/**
+ * Verifica deduplicação para notificações agrupadas (dose_reminder_by_plan / dose_reminder_misc).
+ * Para by_plan: discrimina por treatment_plan_id no provider_metadata.
+ * Para misc: só verifica tipo + user + janela de 5min.
+ * @param {string} userId - UUID do usuário
+ * @param {string} notificationType - 'dose_reminder_by_plan' | 'dose_reminder_misc'
+ * @param {object} [options] - { planId?: string }
+ * @returns {Promise<boolean>} true se deve enviar, false se duplicado
+ */
+export async function shouldSendGroupedNotification(userId, notificationType, { planId } = {}) {
+  if (!userId) {
+    console.error('[Deduplicator] shouldSendGroupedNotification chamado sem userId');
+    return true; // Fail open
+  }
+
+  const cutoffTime = new Date(Date.now() - DEDUP_WINDOW_MINUTES * 60 * 1000).toISOString();
+
+  try {
+    let query = supabase
+      .from('notification_log')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('notification_type', notificationType)
+      .gte('sent_at', cutoffTime)
+      .limit(1);
+
+    if (planId) {
+      query = query.filter('provider_metadata->>treatment_plan_id', 'eq', planId);
+    }
+
+    const { data, error } = await query.single();
+
+    if (error && error.code !== 'PGRST116') {
+      console.error('[Deduplicator] Erro ao verificar grouped notification:', error);
+      return true; // Fail open
+    }
+
+    if (data) {
+      console.log(`[Deduplicator] Ignorando duplicata grouped ${notificationType} para userId ${userId}${planId ? ` planId ${planId}` : ''}`);
+      return false;
+    }
+
+    return true;
+  } catch (err) {
+    console.error('[Deduplicator] Erro inesperado em shouldSendGroupedNotification:', err);
+    return true; // Fail open
+  }
+}


### PR DESCRIPTION
## Resumo

Sprint N1.3 da Wave N1 (Notifications Revamp). Três entregas principais + 1 bug crítico descoberto durante planning:

### 🔴 Fix crítico: dispatcher Zod enum incompleto
- `dispatchInputSchema.kind` não incluía `dose_reminder_by_plan` nem `dose_reminder_misc`
- Causa: todos os blocos grouped de N1.1/N1.2 eram rejeitados silenciosamente pelo Zod antes de chegar aos canais
- Fix: enum estendido com os dois novos kinds

### ✅ Dedup para notificações agrupadas (`notificationDeduplicator.js`)
- Nova função `shouldSendGroupedNotification(userId, notificationType, { planId })`:
  - `dose_reminder_by_plan`: discrimina por `treatment_plan_id` no `provider_metadata` via JSONB filter
  - `dose_reminder_misc`: discrimina só por `notification_type` + `user_id` dentro da janela 5min
- Mantém semântica de "fail open" (retorna `true` em caso de erro na query)

### ✅ Dedup integrado em `tasks.js`
- Import de `shouldSendGroupedNotification` adicionado
- Verificação de dedup antes de cada `dispatcher.dispatch()` para blocos `by_plan` e `misc`
- `continue` via bloco `for` para blocos suprimidos, com `logger.debug` rastreável

### ✅ `provider_metadata` populado no log (`dispatchNotification.js`)
- `protocol_id: null` para kinds grouped (sem protocolo individual)
- `provider_metadata` agora inclui `protocol_ids[]` e `treatment_plan_id` do `payload.metadata`
- Necessário para que Sprint N1.6 (Inbox) consiga cruzar `protocol_ids` com dose logs

### ✅ Expo push payload enriquecido (`expoPushChannel.js`)
- `data` do payload agora inclui spread do `payload.metadata` (que já contém `navigation.screen/params` para grouped, gerado em `api/notify.js`) + `notificationLogId` null (placeholder para Wave N3)

## Arquivos modificados

| Arquivo | Tipo |
|---------|------|
| `server/services/notificationDeduplicator.js` | feat |
| `server/notifications/dispatcher/dispatchNotification.js` | fix + feat |
| `server/bot/tasks.js` | feat |
| `server/notifications/channels/expoPushChannel.js` | feat |

## Critérios de aceite (spec N1.3)

- [x] Dedup retorna `false` para chave repetida em 5min, `true` para chave nova
- [x] Push Expo enviado contém `data.navigation` (via `payload.metadata.navigation` já populado em `api/notify.js`)
- [x] `provider_metadata` no log contém `protocol_ids` e `treatment_plan_id` para grouped
- [x] Dispatcher aceita `dose_reminder_by_plan` e `dose_reminder_misc` sem rejeição Zod

## Test plan

- [ ] Verificar que lint passa (✅ passou localmente)
- [ ] Testar dedup: enviar 2 notificações `dose_reminder_by_plan` para o mesmo `planId` no mesmo minuto → segunda deve ser suprimida
- [ ] Verificar no sandbox Expo que `data.navigation` chega ao device para cenários D (2 planos) e A (misc)
- [ ] Verificar que `notification_log.provider_metadata` contém `protocol_ids` após envio grouped

🤖 Generated with [Claude Code](https://claude.com/claude-code)