### PR TITLE
refactor(web): implementa arquitetura tonal Santuario Terapeutico e expurga legados neon/glass

### DIFF
--- a/apps/web/src/shared/styles/index.css
+++ b/apps/web/src/shared/styles/index.css
@@ -239,11 +239,6 @@ body {
     --opacity-backdrop: 1;
   }
 
-  .glass-card {
-    backdrop-filter: none;
-    background: var(--bg-card);
-  }
-
   [data-theme='dark'] body::before {
     display: none;
   }
@@ -447,49 +442,6 @@ body {
    COMPONENT STYLES
    ============================================ */
 
-/* Glass-morphism card */
-.glass-card {
-  background: var(--bg-glass);
-  backdrop-filter: blur(10px);
-  border: var(--border-width) var(--border-style-solid) var(--border-color);
-  border-radius: var(--radius-lg);
-  padding: var(--card-padding);
-  box-shadow: var(--shadow-md);
-  transition:
-    transform var(--transition-base),
-    box-shadow var(--transition-base);
-}
-
-.glass-card:hover {
-  transform: translateY(calc(var(--space-1) * -1));
-  box-shadow: var(--shadow-lg);
-}
-
-/* Glow effects — Using Sanctuary color tokens */
-.glow-cyan {
-  box-shadow: var(--glow-hover-secondary);
-}
-
-.glow-magenta {
-  box-shadow: var(--glow-hover-primary);
-}
-
-.glow-pink {
-  box-shadow: var(--glow-hover-primary);
-}
-
-.glow-success {
-  box-shadow: var(--glow-hover-success);
-}
-
-.glow-warning {
-  box-shadow: var(--glow-hover-warning);
-}
-
-.glow-error {
-  box-shadow: var(--glow-hover-critical);
-}
-
 /* Gradient text — Using Sanctuary colors */
 .gradient-text {
   background: linear-gradient(135deg, var(--color-secondary), var(--color-primary));
@@ -531,9 +483,6 @@ body {
     padding: 0 var(--space-3);
   }
 
-  .glass-card {
-    padding: var(--space-4);
-  }
 }
 
 /* ============================================

--- a/apps/web/src/shared/styles/themes/dark.css
+++ b/apps/web/src/shared/styles/themes/dark.css
@@ -92,10 +92,7 @@
    ============================================ */
 
 [data-theme='dark'] body::before {
-  background:
-    radial-gradient(circle at 20% 50%, rgba(144, 244, 227, 0.15) 0%, transparent 50%),
-    radial-gradient(circle at 80% 80%, rgba(214, 227, 255, 0.15) 0%, transparent 50%),
-    radial-gradient(circle at 40% 20%, rgba(144, 244, 227, 0.15) 0%, transparent 50%);
+  background: none;
 }
 
 /* ============================================

--- a/apps/web/src/shared/styles/themes/dark.css
+++ b/apps/web/src/shared/styles/themes/dark.css
@@ -15,13 +15,11 @@
 
 [data-theme='dark'] {
   /* Background Colors */
-  --bg-primary: #111827;
-  --bg-secondary: #1f2937;
-  --bg-tertiary: #374151;
-  --bg-card: #1f2937;
+  --bg-primary: #191c1d;
+  --bg-secondary: #202425;
+  --bg-tertiary: #2a2e2f;
+  --bg-card: #202425;
   --bg-overlay: rgba(0, 0, 0, 0.7);
-  --bg-glass: rgba(31, 41, 55, 0.8);
-  --bg-glass-dark: rgba(17, 24, 39, 0.9);
 
   /* Aliases */
   --color-bg-primary: var(--bg-primary);
@@ -32,11 +30,11 @@
 
 /* Text Colors */
 [data-theme='dark'] {
-  --text-primary: #f9fafb;
-  --text-secondary: #d1d5db;
-  --text-tertiary: #9ca3af;
-  --text-inverse: #ffffff;
-  --text-link: #f472b6;
+  --text-primary: #e0e3e3;
+  --text-secondary: #bfc8c9;
+  --text-tertiary: #899394;
+  --text-inverse: #191c1d;
+  --text-link: #90f4e3;
 
   /* Aliases */
   --color-text-primary: var(--text-primary);
@@ -48,9 +46,9 @@
 
 /* Border Colors */
 [data-theme='dark'] {
-  --border-light: #1f2937;
-  --border-default: #374151;
-  --border-dark: #4b5563;
+  --border-light: #202425;
+  --border-default: #3f484a;
+  --border-dark: #6f797a;
 
   /* Aliases */
   --color-border-light: var(--border-light);
@@ -58,18 +56,6 @@
   --color-border-dark: var(--border-dark);
   --border: var(--border-default);
   --border-color: var(--border);
-}
-
-/* Glow Effects - More intense in dark mode */
-[data-theme='dark'] {
-  --glow-cyan: 0 0 15px rgba(34, 211, 238, 0.6);
-  --glow-pink: 0 0 15px rgba(244, 114, 182, 0.6);
-  --glow-magenta: 0 0 15px rgba(232, 121, 249, 0.6);
-  --glow-green: 0 0 15px rgba(52, 211, 153, 0.6);
-  --glow-success: var(--glow-green);
-  --glow-warning: 0 0 15px rgba(251, 191, 36, 0.6);
-  --glow-error: 0 0 15px rgba(248, 113, 113, 0.6);
-  --glow-info: 0 0 15px rgba(96, 165, 250, 0.6);
 }
 
 /* Shadows - Darker for dark mode */
@@ -82,11 +68,11 @@
 
 /* State Colors - Brighter in dark mode */
 [data-theme='dark'] {
-  --state-hover: rgba(244, 114, 182, 0.15);
-  --state-active: rgba(244, 114, 182, 0.25);
-  --state-focus: rgba(244, 114, 182, 0.35);
+  --state-hover: rgba(144, 244, 227, 0.15);
+  --state-active: rgba(144, 244, 227, 0.25);
+  --state-focus: rgba(144, 244, 227, 0.35);
   --state-disabled: rgba(255, 255, 255, 0.1);
-  --state-loading: rgba(244, 114, 182, 0.7);
+  --state-loading: rgba(144, 244, 227, 0.7);
 }
 
 /* Toggle Colors */
@@ -107,9 +93,9 @@
 
 [data-theme='dark'] body::before {
   background:
-    radial-gradient(circle at 20% 50%, rgba(34, 211, 238, 0.15) 0%, transparent 50%),
-    radial-gradient(circle at 80% 80%, rgba(244, 114, 182, 0.15) 0%, transparent 50%),
-    radial-gradient(circle at 40% 20%, rgba(232, 121, 249, 0.15) 0%, transparent 50%);
+    radial-gradient(circle at 20% 50%, rgba(144, 244, 227, 0.15) 0%, transparent 50%),
+    radial-gradient(circle at 80% 80%, rgba(214, 227, 255, 0.15) 0%, transparent 50%),
+    radial-gradient(circle at 40% 20%, rgba(144, 244, 227, 0.15) 0%, transparent 50%);
 }
 
 /* ============================================

--- a/apps/web/src/shared/styles/themes/light.css
+++ b/apps/web/src/shared/styles/themes/light.css
@@ -15,13 +15,11 @@
 
 /* Background Colors */
 :root {
-  --bg-primary: #ffffff;
-  --bg-secondary: #f9fafb;
-  --bg-tertiary: #f3f4f6;
+  --bg-primary: #f8fafb;
+  --bg-secondary: #f2f4f5;
+  --bg-tertiary: #e9ecef;
   --bg-card: #ffffff;
   --bg-overlay: rgba(0, 0, 0, 0.5);
-  --bg-glass: rgba(255, 255, 255, 0.8);
-  --bg-glass-dark: rgba(17, 24, 39, 0.8);
 
   /* Aliases */
   --color-bg-primary: var(--bg-primary);
@@ -32,11 +30,11 @@
 
 /* Text Colors */
 :root {
-  --text-primary: #111827;
+  --text-primary: #191c1d;
   --text-secondary: #4b5563;
   --text-tertiary: #6b7280;
   --text-inverse: #ffffff;
-  --text-link: #ec4899;
+  --text-link: #005db6;
 
   /* Aliases */
   --color-text-primary: var(--text-primary);
@@ -60,18 +58,6 @@
   --border-color: var(--border);
 }
 
-/* Glow Effects */
-:root {
-  --glow-cyan: 0 0 10px rgba(6, 182, 212, 0.5);
-  --glow-pink: 0 0 10px rgba(236, 72, 153, 0.5);
-  --glow-magenta: 0 0 10px rgba(217, 70, 239, 0.5);
-  --glow-green: 0 0 10px rgba(16, 185, 129, 0.5);
-  --glow-success: var(--glow-green);
-  --glow-warning: 0 0 10px rgba(245, 158, 11, 0.5);
-  --glow-error: 0 0 10px rgba(239, 68, 68, 0.5);
-  --glow-info: 0 0 10px rgba(59, 130, 246, 0.5);
-}
-
 /* Shadows */
 :root {
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
@@ -82,11 +68,11 @@
 
 /* State Colors */
 :root {
-  --state-hover: rgba(236, 72, 153, 0.1);
-  --state-active: rgba(236, 72, 153, 0.2);
-  --state-focus: rgba(236, 72, 153, 0.3);
+  --state-hover: rgba(0, 106, 94, 0.1);
+  --state-active: rgba(0, 106, 94, 0.2);
+  --state-focus: rgba(0, 106, 94, 0.3);
   --state-disabled: rgba(0, 0, 0, 0.1);
-  --state-loading: rgba(236, 72, 153, 0.5);
+  --state-loading: rgba(0, 106, 94, 0.5);
 }
 
 /* Toggle Colors */

--- a/apps/web/src/shared/styles/tokens/colors.css
+++ b/apps/web/src/shared/styles/tokens/colors.css
@@ -8,14 +8,16 @@
  */
 
 /* ============================================
-   BRAND COLORS - Primary (Pink/Rosa)
+   BRAND COLORS - Primary (Verde Saúde)
    ============================================ */
 :root {
-  --color-primary: #ec4899;
-  --color-primary-light: #f472b6;
-  --color-primary-dark: #db2777;
-  --color-primary-bg: #fdf2f8;
-  --color-primary-hover: #be185d;
+  --color-primary: #006a5e;
+  --color-primary-container: #008577;
+  --color-primary-fixed: #90f4e3;
+  --color-primary-light: #4db6ac;
+  --color-primary-dark: #004d40;
+  --color-primary-bg: #e0f2f1;
+  --color-primary-hover: #005047;
 
   /* Aliases for compatibility */
   --brand-primary: var(--color-primary);
@@ -24,18 +26,29 @@
 }
 
 /* ============================================
-   BRAND COLORS - Secondary (Cyan)
+   BRAND COLORS - Secondary (Azul Clínico)
    ============================================ */
 :root {
-  --color-secondary: #06b6d4;
-  --color-secondary-light: #22d3ee;
-  --color-secondary-dark: #0891b2;
-  --color-secondary-bg: #ecfeff;
+  --color-secondary: #005db6;
+  --color-secondary-fixed: #d6e3ff;
+  --color-secondary-light: #42a5f5;
+  --color-secondary-dark: #003c8f;
+  --color-secondary-bg: #e3f2fd;
 
   /* Aliases for compatibility */
   --brand-secondary: var(--color-secondary);
   --brand-secondary-light: var(--color-secondary-light);
   --brand-secondary-dark: var(--color-secondary-dark);
+}
+
+/* ============================================
+   BRAND COLORS - Tertiary (Warm Sun)
+   ============================================ */
+:root {
+  --color-tertiary: #ffdea8;
+  --color-tertiary-light: #fff3e0;
+  --color-tertiary-dark: #ffb74d;
+  --color-tertiary-bg: #fff8e1;
 }
 
 /* ============================================
@@ -50,26 +63,24 @@
   --color-warning-light: #fbbf24;
   --color-warning-bg: #fffbeb;
 
-  --color-error: #ef4444;
-  --color-error-light: #f87171;
-  --color-error-bg: #fef2f2;
+  --color-error: #ba1a1a;
+  --color-error-light: #ff897d;
+  --color-error-bg: #ffdad6;
 
-  --color-info: #3b82f6;
-  --color-info-light: #60a5fa;
+  --color-info: #005db6;
+  --color-info-light: #d6e3ff;
   --color-info-bg: #eff6ff;
 }
 
 /* ============================================
-   BACKGROUND COLORS
+   BACKGROUND COLORS (Surfaces)
    ============================================ */
 :root {
-  --bg-primary: #ffffff;
-  --bg-secondary: #f9fafb;
-  --bg-tertiary: #f3f4f6;
+  --bg-primary: #f8fafb;
+  --bg-secondary: #f2f4f5;
+  --bg-tertiary: #e9ecef;
   --bg-card: #ffffff;
   --bg-overlay: rgba(0, 0, 0, 0.5);
-  --bg-glass: rgba(255, 255, 255, 0.8);
-  --bg-glass-dark: rgba(17, 24, 39, 0.8);
 
   /* Aliases for compatibility */
   --color-bg-primary: var(--bg-primary);
@@ -82,11 +93,11 @@
    TEXT COLORS
    ============================================ */
 :root {
-  --text-primary: #111827;
+  --text-primary: #191c1d;
   --text-secondary: #4b5563;
   --text-tertiary: #6b7280;
   --text-inverse: #ffffff;
-  --text-link: #ec4899;
+  --text-link: #005db6;
 
   /* Aliases for compatibility */
   --color-text-primary: var(--text-primary);
@@ -140,57 +151,17 @@
   --color-score-excellent: var(--score-excellent);
 }
 
-/* ============================================
-   GLOW EFFECTS
-   ============================================ */
-:root {
-  --glow-cyan: 0 0 10px rgba(6, 182, 212, 0.5);
-  --glow-pink: 0 0 10px rgba(236, 72, 153, 0.5);
-  --glow-magenta: 0 0 10px rgba(217, 70, 239, 0.5);
-  --glow-green: 0 0 10px rgba(16, 185, 129, 0.5);
-  --glow-success: var(--glow-green);
-  --glow-warning: 0 0 10px rgba(245, 158, 11, 0.5);
-  --glow-error: 0 0 10px rgba(239, 68, 68, 0.5);
-  --glow-info: 0 0 10px rgba(59, 130, 246, 0.5);
-}
-
-/* ============================================
-   CONTEXTUAL GLOW EFFECTS - P2
-   ============================================ */
-:root {
-  /* Hover glow - Para elementos interativos */
-  --glow-hover-primary: 0 0 20px rgba(236, 72, 153, 0.3);
-  --glow-hover-secondary: 0 0 20px rgba(6, 182, 212, 0.3);
-  --glow-hover-success: 0 0 20px rgba(16, 185, 129, 0.3);
-  --glow-hover-warning: 0 0 20px rgba(245, 158, 11, 0.3);
-  --glow-hover-critical: 0 0 25px rgba(239, 68, 68, 0.4);
-
-  /* Focus glow - Para acessibilidade */
-  --glow-focus-primary: 0 0 15px rgba(236, 72, 153, 0.4);
-  --glow-focus-secondary: 0 0 15px rgba(6, 182, 212, 0.4);
-  --glow-focus-success: 0 0 15px rgba(16, 185, 129, 0.4);
-
-  /* Active glow - Para elementos pressionados */
-  --glow-active-primary: 0 0 10px rgba(236, 72, 153, 0.3);
-  --glow-active-secondary: 0 0 10px rgba(6, 182, 212, 0.3);
-  --glow-active-success: 0 0 10px rgba(16, 185, 129, 0.3);
-
-  /* State-specific glow - Para estados especiais */
-  --glow-critical: 0 0 25px rgba(239, 68, 68, 0.4);
-  --glow-success: 0 0 20px rgba(16, 185, 129, 0.4);
-  --glow-warning: 0 0 20px rgba(245, 158, 11, 0.3);
-  --glow-info: 0 0 20px rgba(6, 182, 212, 0.3);
-}
+/* GLOW EFFECTS REMOVIDOS - Santuário Terapêutico não usa Glow */
 
 /* ============================================
    STATE COLORS
    ============================================ */
 :root {
-  --state-hover: rgba(236, 72, 153, 0.1);
-  --state-active: rgba(236, 72, 153, 0.2);
-  --state-focus: rgba(236, 72, 153, 0.3);
+  --state-hover: rgba(0, 106, 94, 0.1);
+  --state-active: rgba(0, 106, 94, 0.2);
+  --state-focus: rgba(0, 106, 94, 0.3);
   --state-disabled: rgba(0, 0, 0, 0.1);
-  --state-loading: rgba(236, 72, 153, 0.5);
+  --state-loading: rgba(0, 106, 94, 0.5);
 }
 
 /* ============================================
@@ -206,52 +177,40 @@
 
 /* ============================================
    GLASSMORPHISM LEVELS
+   (Removido: O Santuário Terapêutico usa glass apenas em elementos flutuantes
+    cujas variáveis estão definidas em sanctuary.css)
    ============================================ */
-:root {
-  /* Glass leve - Para elementos secundários */
-  --glass-bg-light: rgba(255, 255, 255, 0.03);
-  --glass-border-light: rgba(255, 255, 255, 0.05);
-  --glass-blur-light: blur(8px);
-
-  /* Glass padrão - Para cards comuns */
-  --glass-bg: rgba(255, 255, 255, 0.05);
-  --glass-border: rgba(255, 255, 255, 0.1);
-  --glass-blur: blur(12px);
-
-  /* Glass intenso - Para elementos destacados */
-  --glass-bg-heavy: rgba(255, 255, 255, 0.08);
-  --glass-border-heavy: rgba(255, 255, 255, 0.15);
-  --glass-blur-heavy: blur(16px);
-
-  /* Glass hero - Para seções principais */
-  --glass-bg-hero: rgba(255, 255, 255, 0.1);
-  --glass-border-hero: rgba(255, 255, 255, 0.2);
-  --glass-blur-hero: blur(20px);
-}
 
 /* ============================================
    GRADIENT BACKGROUNDS
    ============================================ */
 :root {
+  /* Gradiente Primary - Para botões e CTAs */
+  --gradient-primary: linear-gradient(
+    135deg,
+    var(--color-primary) 0%,
+    var(--color-primary-container) 100%
+  );
+
   /* Gradiente sutil - Para cards de insight */
   --gradient-insight: linear-gradient(
     135deg,
-    rgba(6, 182, 212, 0.1) 0%,
-    rgba(176, 0, 255, 0.1) 100%
+    rgba(0, 93, 182, 0.1) 0%,
+    rgba(0, 106, 94, 0.1) 100%
   );
 
   /* Gradiente hero - Para seções principais */
   --gradient-hero: linear-gradient(
     135deg,
-    rgba(236, 72, 153, 0.15) 0%,
-    rgba(6, 182, 212, 0.15) 100%
+    rgba(0, 106, 94, 0.15) 0%,
+    rgba(0, 93, 182, 0.15) 100%
   );
 
   /* Gradiente alert - Para alertas críticos */
   --gradient-alert-critical: linear-gradient(
     135deg,
-    rgba(239, 68, 68, 0.1) 0%,
-    rgba(239, 68, 68, 0.05) 100%
+    rgba(186, 26, 26, 0.1) 0%,
+    rgba(186, 26, 26, 0.05) 100%
   );
 
   /* Gradiente success - Para elementos positivos */
@@ -267,13 +226,11 @@
    ============================================ */
 [data-theme='dark'] {
   /* Background Colors */
-  --bg-primary: #111827;
-  --bg-secondary: #1f2937;
-  --bg-tertiary: #374151;
-  --bg-card: #1f2937;
+  --bg-primary: #191c1d;
+  --bg-secondary: #202425;
+  --bg-tertiary: #2a2e2f;
+  --bg-card: #202425;
   --bg-overlay: rgba(0, 0, 0, 0.7);
-  --bg-glass: rgba(31, 41, 55, 0.8);
-  --bg-glass-dark: rgba(17, 24, 39, 0.9);
 
   /* Aliases */
   --color-bg-primary: var(--bg-primary);
@@ -282,11 +239,11 @@
   --color-bg-card: var(--bg-card);
 
   /* Text Colors - Enhanced Contrast for Dark Mode */
-  --text-primary: #f9fafb; /* Enhanced from #f3f4f6 */
-  --text-secondary: #d1d5db; /* Enhanced from #e5e7eb */
-  --text-tertiary: #9ca3af; /* Enhanced from #9ca3af */
-  --text-muted: #6b7280; /* Enhanced from #6b7280 */
-  --text-link: #f472b6;
+  --text-primary: #e0e3e3;
+  --text-secondary: #bfc8c9;
+  --text-tertiary: #899394;
+  --text-muted: #6f797a;
+  --text-link: #90f4e3;
 
   /* Aliases */
   --color-text-primary: var(--text-primary);
@@ -296,9 +253,9 @@
   --color-text-link: var(--text-link);
 
   /* Border Colors */
-  --border-light: #1f2937;
-  --border-default: #374151;
-  --border-dark: #4b5563;
+  --border-light: #202425;
+  --border-default: #3f484a;
+  --border-dark: #6f797a;
 
   /* Aliases */
   --color-border-light: var(--border-light);
@@ -307,66 +264,29 @@
   --border: var(--border-default);
   --border-color: var(--border);
 
-  /* Glow Effects - More intense in dark mode */
-  --glow-cyan: 0 0 15px rgba(34, 211, 238, 0.6);
-  --glow-pink: 0 0 15px rgba(244, 114, 182, 0.6);
-  --glow-magenta: 0 0 15px rgba(232, 121, 249, 0.6);
-  --glow-green: 0 0 15px rgba(52, 211, 153, 0.6);
-  --glow-success: var(--glow-green);
-  --glow-warning: 0 0 15px rgba(251, 191, 36, 0.6);
-  --glow-error: 0 0 15px rgba(248, 113, 113, 0.6);
-  --glow-info: 0 0 15px rgba(96, 165, 250, 0.6);
-
-  /* Contextual Glow Effects - Dark Mode - P2 */
-  --glow-hover-primary: 0 0 25px rgba(244, 114, 182, 0.4);
-  --glow-hover-secondary: 0 0 25px rgba(34, 211, 238, 0.4);
-  --glow-hover-success: 0 0 25px rgba(52, 211, 153, 0.4);
-  --glow-hover-warning: 0 0 25px rgba(251, 191, 36, 0.4);
-  --glow-hover-critical: 0 0 30px rgba(248, 113, 113, 0.5);
-
-  --glow-focus-primary: 0 0 20px rgba(244, 114, 182, 0.5);
-  --glow-focus-secondary: 0 0 20px rgba(34, 211, 238, 0.5);
-  --glow-focus-success: 0 0 20px rgba(52, 211, 153, 0.5);
-
-  --glow-active-primary: 0 0 15px rgba(244, 114, 182, 0.4);
-  --glow-active-secondary: 0 0 15px rgba(34, 211, 238, 0.4);
-  --glow-active-success: 0 0 15px rgba(52, 211, 153, 0.4);
-
-  --glow-critical: 0 0 30px rgba(248, 113, 113, 0.5);
-  --glow-success: 0 0 25px rgba(52, 211, 153, 0.5);
-  --glow-warning: 0 0 25px rgba(251, 191, 36, 0.4);
-  --glow-info: 0 0 25px rgba(34, 211, 238, 0.4);
-
   /* State Colors - Brighter in dark mode */
-  --state-hover: rgba(244, 114, 182, 0.15);
-  --state-active: rgba(244, 114, 182, 0.25);
-  --state-focus: rgba(244, 114, 182, 0.35);
+  --state-hover: rgba(144, 244, 227, 0.15);
+  --state-active: rgba(144, 244, 227, 0.25);
+  --state-focus: rgba(144, 244, 227, 0.35);
   --state-disabled: rgba(255, 255, 255, 0.1);
-  --state-loading: rgba(244, 114, 182, 0.7);
-
-  /* Glassmorphism Levels - Dark Mode */
-  --glass-bg-light: rgba(255, 255, 255, 0.02);
-  --glass-border-light: rgba(255, 255, 255, 0.03);
-
-  --glass-bg: rgba(255, 255, 255, 0.05);
-  --glass-border: rgba(255, 255, 255, 0.1);
-
-  --glass-bg-heavy: rgba(255, 255, 255, 0.08);
-  --glass-border-heavy: rgba(255, 255, 255, 0.15);
-
-  --glass-bg-hero: rgba(255, 255, 255, 0.1);
-  --glass-border-hero: rgba(255, 255, 255, 0.2);
+  --state-loading: rgba(144, 244, 227, 0.7);
 
   /* Gradient Backgrounds - Dark Mode */
+  --gradient-primary: linear-gradient(
+    135deg,
+    var(--color-primary-fixed) 0%,
+    var(--color-primary-container) 100%
+  );
+
   --gradient-insight: linear-gradient(
     135deg,
-    rgba(34, 211, 238, 0.15) 0%,
-    rgba(232, 121, 249, 0.15) 100%
+    rgba(214, 227, 255, 0.15) 0%,
+    rgba(144, 244, 227, 0.15) 100%
   );
 
   --gradient-hero: linear-gradient(
     135deg,
-    rgba(244, 114, 182, 0.2) 0%,
-    rgba(34, 211, 238, 0.2) 100%
+    rgba(144, 244, 227, 0.2) 0%,
+    rgba(214, 227, 255, 0.2) 100%
   );
 }

--- a/apps/web/src/shared/styles/tokens/colors.css
+++ b/apps/web/src/shared/styles/tokens/colors.css
@@ -16,8 +16,8 @@
   --color-primary-container: #008577;
   --color-primary-fixed: #90f4e3;
   --color-primary-light: #4db6ac;
-  --color-primary-dark: #004d40;
-  --color-primary-bg: #e0f2f1;
+  --color-primary-dark: #005047;
+  --color-primary-bg: rgba(0, 106, 94, 0.05);
   --color-primary-hover: #005047;
 
   /* Aliases for compatibility */
@@ -181,7 +181,14 @@
    GLASSMORPHISM LEVELS
    (Removido: O Santuário Terapêutico usa glass apenas em elementos flutuantes
     cujas variáveis estão definidas em sanctuary.css)
+   Aliases temporários para evitar quebra de views antigas:
    ============================================ */
+:root {
+  --glass-bg-light: var(--bg-secondary);
+  --glass-bg-heavy: var(--bg-tertiary);
+  --glass-border-light: var(--border-light);
+  --glass-border-heavy: var(--border-default);
+}
 
 /* ============================================
    GRADIENT BACKGROUNDS
@@ -276,7 +283,7 @@
   /* Gradient Backgrounds - Dark Mode */
   --gradient-primary: linear-gradient(
     135deg,
-    var(--color-primary-fixed) 0%,
+    var(--color-primary) 0%,
     var(--color-primary-container) 100%
   );
 

--- a/apps/web/src/shared/styles/tokens/colors.css
+++ b/apps/web/src/shared/styles/tokens/colors.css
@@ -12,6 +12,7 @@
    ============================================ */
 :root {
   --color-primary: #006a5e;
+  --primary-rgb: 0, 106, 94;
   --color-primary-container: #008577;
   --color-primary-fixed: #90f4e3;
   --color-primary-light: #4db6ac;
@@ -30,6 +31,7 @@
    ============================================ */
 :root {
   --color-secondary: #005db6;
+  --secondary-rgb: 0, 93, 182;
   --color-secondary-fixed: #d6e3ff;
   --color-secondary-light: #42a5f5;
   --color-secondary-dark: #003c8f;

--- a/apps/web/src/shared/styles/tokens/sanctuary.css
+++ b/apps/web/src/shared/styles/tokens/sanctuary.css
@@ -94,8 +94,8 @@
   --color-error-container: #ffdad6;
   --color-on-error-container: #93000a;
 
-  --color-info: #3b82f6;
-  --color-info-light: #60a5fa;
+  --color-info: #005db6;
+  --color-info-light: #d6e3ff;
   --color-info-bg: #eff6ff;
 
   /* ============================================

--- a/apps/web/src/shared/styles/tokens/shadows.css
+++ b/apps/web/src/shared/styles/tokens/shadows.css
@@ -180,48 +180,6 @@
 }
 
 /* ============================================
-   GLOW EFFECTS (using box-shadow for neon effects)
+   GLOW EFFECTS 
+   (Removido: O Santuário Terapêutico descarta o uso de neon. Usar elevação de shadows.)
    ============================================ */
-:root {
-  /* Colored glows */
-  --glow-cyan: 0 0 10px rgba(6, 182, 212, 0.5);
-  --glow-pink: 0 0 10px rgba(236, 72, 153, 0.5);
-  --glow-magenta: 0 0 10px rgba(217, 70, 239, 0.5);
-  --glow-green: 0 0 10px rgba(16, 185, 129, 0.5);
-  --glow-success: var(--glow-green);
-  --glow-warning: 0 0 10px rgba(245, 158, 11, 0.5);
-  --glow-error: 0 0 10px rgba(239, 68, 68, 0.5);
-  --glow-info: 0 0 10px rgba(59, 130, 246, 0.5);
-  --glow-primary: var(--glow-pink);
-  --glow-secondary: var(--glow-cyan);
-
-  /* Intense glows */
-  --glow-cyan-intense: 0 0 20px rgba(6, 182, 212, 0.7);
-  --glow-pink-intense: 0 0 20px rgba(236, 72, 153, 0.7);
-  --glow-magenta-intense: 0 0 20px rgba(217, 70, 239, 0.7);
-  --glow-green-intense: 0 0 20px rgba(16, 185, 129, 0.7);
-
-  /* Subtle glows */
-  --glow-cyan-subtle: 0 0 5px rgba(6, 182, 212, 0.3);
-  --glow-pink-subtle: 0 0 5px rgba(236, 72, 153, 0.3);
-  --glow-magenta-subtle: 0 0 5px rgba(217, 70, 239, 0.3);
-}
-
-/* ============================================
-   DARK MODE GLOW EFFECTS
-   ============================================ */
-[data-theme='dark'] {
-  --glow-cyan: 0 0 15px rgba(34, 211, 238, 0.6);
-  --glow-pink: 0 0 15px rgba(244, 114, 182, 0.6);
-  --glow-magenta: 0 0 15px rgba(232, 121, 249, 0.6);
-  --glow-green: 0 0 15px rgba(52, 211, 153, 0.6);
-  --glow-success: var(--glow-green);
-  --glow-warning: 0 0 15px rgba(251, 191, 36, 0.6);
-  --glow-error: 0 0 15px rgba(248, 113, 113, 0.6);
-  --glow-info: 0 0 15px rgba(96, 165, 250, 0.6);
-  --glow-primary: var(--glow-pink);
-  --glow-secondary: var(--glow-cyan);
-
-  --glow-cyan-intense: 0 0 30px rgba(34, 211, 238, 0.8);
-  --glow-pink-intense: 0 0 30px rgba(244, 114, 182, 0.8);
-}

--- a/apps/web/src/views/Medicines.css
+++ b/apps/web/src/views/Medicines.css
@@ -41,7 +41,6 @@
 
 .success-banner:hover {
   transform: scale(var(--scale-hover));
-  box-shadow: var(--glow-success);
 }
 
 .error-banner {
@@ -58,7 +57,6 @@
 
 .error-banner:hover {
   transform: scale(var(--scale-hover));
-  box-shadow: var(--glow-critical);
 }
 
 .medicines-grid {
@@ -80,14 +78,12 @@
 
 .empty-state:hover {
   transform: scale(var(--scale-hover));
-  box-shadow: var(--glow-hover-secondary);
 }
 
 .empty-icon {
   font-size: 4rem;
   margin-bottom: var(--space-4);
   opacity: 0.5;
-  filter: drop-shadow(0 0 10px rgba(6, 182, 212, 0.3));
 }
 
 .empty-state h3 {

--- a/apps/web/src/views/Protocols.css
+++ b/apps/web/src/views/Protocols.css
@@ -55,7 +55,6 @@
 .section-title.active {
   color: var(--color-success);
   border-color: var(--color-success);
-  text-shadow: var(--glow-success);
 }
 
 .section-title.inactive {
@@ -66,7 +65,6 @@
 .section-title.plans {
   color: var(--color-secondary);
   border-color: var(--color-secondary);
-  text-shadow: var(--glow-hover-secondary);
 }
 
 .plans-grid {
@@ -88,7 +86,6 @@
 
 .treatment-plan-card:hover {
   transform: scale(var(--scale-hover));
-  box-shadow: var(--glow-hover-secondary);
   border-color: var(--glass-border-heavy);
 }
 
@@ -109,7 +106,6 @@
   font-size: var(--font-size-xs);
   color: var(--color-warning);
   margin-top: 2px;
-  filter: drop-shadow(0 0 5px rgba(245, 158, 11, 0.3));
 }
 
 .plan-desc {
@@ -187,14 +183,12 @@
 
 .empty-state:hover {
   transform: scale(var(--scale-hover));
-  box-shadow: var(--glow-hover-secondary);
 }
 
 .empty-icon {
   font-size: 4rem;
   margin-bottom: var(--space-4);
   opacity: 0.5;
-  filter: drop-shadow(0 0 10px rgba(217, 70, 239, 0.3));
 }
 
 .empty-state h3 {

--- a/apps/web/src/views/Settings.css
+++ b/apps/web/src/views/Settings.css
@@ -25,7 +25,6 @@
 
 .settings-section:hover {
   transform: scale(var(--scale-hover));
-  box-shadow: var(--glow-hover-primary);
   border-color: var(--glass-border-heavy);
 }
 
@@ -101,7 +100,6 @@
 
 .settings-input:focus {
   border-color: var(--color-primary);
-  box-shadow: var(--glow-focus-primary);
 }
 
 .section-desc {
@@ -136,7 +134,6 @@
   background: rgba(16, 185, 129, 0.2);
   color: var(--color-success);
   border: 1px solid var(--color-success);
-  box-shadow: var(--glow-success);
 }
 
 .status-badge.disconnected {
@@ -168,20 +165,12 @@
   transition: var(--transition-hover);
 }
 
-.code-box:hover {
-  box-shadow: var(--glow-hover-secondary);
-}
-
 .telegram-link {
   display: inline-block;
   margin-top: var(--space-2);
   color: var(--color-primary);
   font-size: var(--font-size-sm);
   transition: var(--transition-hover);
-}
-
-.telegram-link:hover {
-  text-shadow: var(--glow-hover-primary);
 }
 
 .settings-message {
@@ -196,14 +185,12 @@
   background: var(--gradient-success);
   color: var(--color-success);
   border: 1px solid var(--color-success);
-  box-shadow: var(--glow-success);
 }
 
 .settings-message.error {
   background: var(--gradient-alert-critical);
   color: var(--color-error);
   border: 1px solid var(--color-error);
-  box-shadow: var(--glow-critical);
 }
 
 .btn-disconnect {
@@ -217,7 +204,6 @@
 .btn-disconnect:hover {
   background: rgba(239, 68, 68, 0.1);
   border-color: #ff453a;
-  box-shadow: var(--glow-critical);
   transform: scale(var(--scale-hover));
 }
 
@@ -254,6 +240,5 @@
 .logout-btn:hover {
   background: rgba(239, 68, 68, 0.1);
   border-color: #ff453a;
-  box-shadow: var(--glow-critical);
   transform: scale(var(--scale-hover));
 }

--- a/apps/web/src/views/Settings.jsx
+++ b/apps/web/src/views/Settings.jsx
@@ -133,7 +133,7 @@ export default function Settings({ onNavigate }) {
     <div className="settings-container">
       <h2 className="page-title">Configurações</h2>
 
-      <div className="settings-section glass-card">
+      <div className="settings-section">
         <h3>Minha Conta</h3>
         <div className="profile-info">
           <div className="info-row">
@@ -163,7 +163,7 @@ export default function Settings({ onNavigate }) {
         </form>
       </div>
 
-      <div className="settings-section glass-card">
+      <div className="settings-section">
         <h3>Integração Telegram</h3>
         <p className="section-desc">Receba notificações e gerencie seus remédios pelo Telegram.</p>
 
@@ -212,7 +212,7 @@ export default function Settings({ onNavigate }) {
         )}
       </div>
 
-      <div className="settings-section glass-card">
+      <div className="settings-section">
         <h3>Saúde e Emergência</h3>
         <p className="section-desc">Informações médicas críticas para situações de emergência.</p>
 
@@ -230,7 +230,7 @@ export default function Settings({ onNavigate }) {
         </div>
       </div>
 
-      <div className="settings-section glass-card">
+      <div className="settings-section">
         <h3>Exportar Dados</h3>
         <p className="section-desc">
           Exporte seus dados em formato CSV ou JSON para backup ou análise.
@@ -243,7 +243,7 @@ export default function Settings({ onNavigate }) {
         </div>
       </div>
 
-      <div className="settings-section glass-card">
+      <div className="settings-section">
         <h3>Relatórios</h3>
         <p className="section-desc">
           Gere relatórios em PDF com seu histórico de medicamentos e adesão.
@@ -256,7 +256,7 @@ export default function Settings({ onNavigate }) {
         </div>
       </div>
 
-      <div className="settings-section glass-card">
+      <div className="settings-section">
         <h3>Administração</h3>
         <p className="section-desc">Ferramentas administrativas do sistema.</p>
 

--- a/docs/architecture/CSS.md
+++ b/docs/architecture/CSS.md
@@ -18,7 +18,7 @@ src/
 │   │   ├── typography.css    # Tokens de tipografia (fontes, tamanhos, pesos)
 │   │   ├── spacing.css       # Tokens de espaçamento e breakpoints
 │   │   ├── borders.css       # Tokens de bordas e bordas-radius
-│   │   ├── shadows.css       # Tokens de sombras e efeitos glow
+│   │   ├── shadows.css       # Tokens de sombras e elevação estrutural
 │   │   ├── transitions.css   # Tokens de transições e animações
 │   │   └── z-index.css      # Tokens de z-index (camadas)
 │   ├── themes/
@@ -148,7 +148,7 @@ src/
 | `--text-*` | Texto | `--text-primary`, `--text-lg` |
 | `--bg-*` | Fundo | `--bg-primary`, `--bg-card` |
 | `--border-*` | Bordas | `--border-default`, `--radius-lg` |
-| `--shadow-*` | Sombras | `--shadow-md`, `--glow-cyan` |
+| `--shadow-*` | Sombras | `--shadow-md`, `--shadow-lg` |
 | `--spacing-*` | Espaçamento | `--spacing-md`, `--space-4` |
 | `--font-*` | Tipografia | `--font-size-base`, `--font-weight-bold` |
 | `--z-*` | Camadas | `--z-modal`, `--z-dropdown` |
@@ -278,14 +278,21 @@ function Dashboard() {
 
 ```css
 @media (prefers-reduced-transparency: reduce) {
-  .glass-card {
-    backdrop-filter: none;
-    background: var(--bg-card);
+  :root {
+    --bg-glass: var(--bg-primary);
+    --opacity-overlay: 1;
   }
 }
 ```
 
 ## Atualizações Recentes
+
+### v1.3 - Santuário Terapêutico (2026-04-26)
+
+Adotada a nova linguagem visual **Santuário Terapêutico**, com as seguintes diretrizes absolutas para a arquitetura CSS:
+- **Zero Neon (No-Glow):** É estritamente proibido o uso de `box-shadow` ou `text-shadow` com intenção de simular neon/brilho colorido. Toda hierarquia e destaque devem ser conquistados através de elevação tonal (sombras de profundidade neutras) e tipografia.
+- **Glassmorphism Restrito:** Efeitos de vidro/translucidez (`backdrop-filter`) são restritos única e exclusivamente a elementos que flutuam sobre a interface (modais, sidebars, bottom sheets). A classe global genérica `.glass-card` foi removida da base de código.
+- **Sólido e Tangível:** Cards e containers regulares devem possuir fundos sólidos e bordas simples.
 
 ### v1.2 - Component Consolidation Patterns (2026-02-11)
 


### PR DESCRIPTION
## Descrição
Refatoração da arquitetura CSS para implementar as diretrizes do "Santuário Terapêutico" e expurgar os legados da identidade anterior (neon, glassmorphism excessivo, glows).

### Modificações Realizadas
- **Tokens**: Limpeza total das cores neon e pink/cyan. Implementação das cores *Verde Saúde* e *Azul Clínico*.
- **Arquitetura Tonal**: Implementação do sistema de superfícies (`surface`, `surface_container_low`, etc.) substituindo dependência de bordas/brilhos.
- **Temas**: `light.css` e `dark.css` foram atualizados para refletir as novas cores. Gradientes radiais do tema dark que usavam neons foram removidos.
- **Views**: Limpeza de classes `glass-card`, `.glow-*` e estilos ad-hoc em `Settings`, `Medicines` e `Protocols`.
- **Documentação**: `CSS.md` atualizada formalmente para proibir neons e documentar o novo padrão.

### Validação
- `npm run validate:agent` rodou com sucesso (543 testes).

Por favor, faça a revisão final e o merge.

## AI Review Response
| Suggestion | Priority | Decision | Reason |
|------------|----------|----------|--------|
| Remocao total causa quebras visuais em legacy views | Critical | Applied | Commit eead6fd5 - Aliases mantidos |
| Radial gradients manterao glow em dark mode | Medium | Applied | Commit eead6fd5 - Gradients removidos |
| Tokens primary dark e bg divergem de sanctuary | Medium | Applied | Commit eead6fd5 - Sincronizado com master tokens |
| Gradiente primary no dark mode mantem contraste neon | Medium | Applied | Commit eead6fd5 - Contraste suavizado |
| color-info inconsistente com sanctuary | Medium | Applied | Commit eead6fd5 - Atualizado sanctuary.css |