### PR TITLE
feat(notifications): Wave N2 — Quiet Hours, Digest Mode e redesign UX nativo

### DIFF
--- a/.agent/state.json
+++ b/.agent/state.json
@@ -18,9 +18,9 @@
     "current_sprint": "2026-W17"
   },
   "session": {
-    "mode": "planning",
-    "status": "planned",
-    "goal": "Wave 2 — Quiet Hours + redesign UX de notificações nativas",
+    "mode": "coding",
+    "status": "analysis",
+    "goal": "Wave N2 — Quiet Hours + redesign UX de notificações nativas",
     "goal_type": "feature"
   },
   "memory": {

--- a/.agent/wave-n2-c1-extraction.md
+++ b/.agent/wave-n2-c1-extraction.md
@@ -1,0 +1,199 @@
+# Wave N2 — C1 Extraction (DEVFLOW)
+
+> **Gerado em:** 2026-04-27  
+> **Spec origem:** `plans/backlog-notifications/EXEC_SPEC_WAVE_N2_QUIET_HOURS.md`  
+> **Branch:** `feature/wave-n2/quiet-hours-redesign`  
+> **PR alvo:** PR #2 do Notifications Revamp
+
+---
+
+## 1. Arquivos — Caminhos Canônicos Verificados
+
+### CRIAR (5 novos arquivos)
+
+| # | Caminho | Sprint | Verificação |
+|---|---------|--------|-------------|
+| 1 | `docs/migrations/20260427_notification_quiet_hours.sql` | 2.1 | Diretório existe; arquivo não existe |
+| 2 | `packages/core/src/schemas/userSettingsSchema.js` | 2.1 | Diretório existe; arquivo não existe |
+| 3 | `apps/web/src/schemas/userSettingsSchema.js` | 2.1 | Diretório existe; arquivo não existe |
+| 4 | `server/bot/utils/notificationGate.js` | 2.2 | Diretório existe; arquivo não existe |
+| 5 | `server/bot/__tests__/notificationGate.test.js` | 2.2 | Padrão confirmado (ver `partitionDoses.test.js` no mesmo dir) |
+
+> `apps/web/src/services/userSettingsService.js` — criar somente se necessário na implementação do 2.8 (hoje não existe)
+
+### MODIFICAR (12 arquivos)
+
+| # | Caminho | Sprint | Verificação |
+|---|---------|--------|-------------|
+| 6 | `server/bot/tasks.js` | 2.2 + 2.3 | `find` confirmado em `./server/bot/tasks.js` |
+| 7 | `server/notifications/policies/resolveChannelsForUser.js` | 2.2 | `find` confirmado |
+| 8 | `server/notifications/policies/resolveChannelsForUser.test.js` | 2.2 | `find` confirmado |
+| 9 | `apps/mobile/src/features/profile/screens/ProfileScreen.jsx` | 2.4 | `find` confirmado |
+| 10 | `apps/mobile/src/features/notifications/screens/NotificationInboxScreen.jsx` | 2.5 | `find` confirmado |
+| 11 | `apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx` | 2.6 | `find` confirmado |
+| 12 | `apps/mobile/src/features/profile/services/profileService.js` | 2.6 | `find` confirmado |
+| 13 | `apps/mobile/src/features/profile/screens/TelegramLinkScreen.jsx` | 2.7 | `find` confirmado |
+| 14 | `apps/web/src/views/redesign/Settings.jsx` | 2.8 | `find` confirmado (existe também `apps/web/src/views/Settings.jsx` — NÃO é esse) |
+| 15 | `apps/web/src/views/redesign/settings/SettingsRedesign.css` | 2.8 | `find` confirmado |
+| 16 | `apps/web/src/shared/services/webpushService.js` | 2.8 | `find` confirmado (entregue em N1.7 / PR #502) |
+
+> **Atenção:** Existem DOIS `Settings.jsx`:
+> - `apps/web/src/views/Settings.jsx` — view antiga (NÃO tocar)
+> - `apps/web/src/views/redesign/Settings.jsx` ← **alvo correto**
+
+---
+
+## 2. R-193 Cross-check — Arquivos de Notificação
+
+N2 **não adiciona novo `kind`**. Usa `daily_digest` já existente. Status do checklist:
+
+| Ponto R-193 | Arquivo | Status |
+|-------------|---------|--------|
+| kindSchema Zod inclui `daily_digest` | `server/notifications/payloads/buildNotificationPayload.js` | ✅ linha 11 |
+| enum `dispatchInputSchema.kind` inclui `daily_digest` | `server/notifications/dispatcher/dispatchNotification.js` | ✅ linha 14 |
+| Suporte no deduplicador | `server/services/notificationDeduplicator.js` | ✅ comentário linha 11 |
+| Dedup antes de dispatch | `server/bot/tasks.js` | ✅ `shouldSendNotification` linha 857 |
+| Schema aceita tipo | `packages/core/src/schemas/notificationLogSchema.js` | ✅ `z.string()` |
+| CTA_MAP, resolveTitle no inbox mobile | `apps/mobile/src/features/notifications/components/NotificationItem.jsx` | ✅ linhas 25, 37, 63 |
+
+**Conclusão R-193:** Nenhuma ação necessária em N2.
+
+---
+
+## 3. DoD Completo — Critérios de Aceite por Sprint
+
+### Sprint 2.1 — Migration + Zod schema sync
+- [ ] Migration SQL aplica sem erro em staging
+- [ ] Campos adicionados: `quiet_hours_start TIME`, `quiet_hours_end TIME`, `notification_mode TEXT DEFAULT 'realtime'` (CHECK constraint), `digest_time TIME DEFAULT '07:00'`, `channel_mobile_push_enabled BOOLEAN NOT NULL DEFAULT true`, `channel_web_push_enabled BOOLEAN NOT NULL DEFAULT false`, `channel_telegram_enabled BOOLEAN NOT NULL DEFAULT false`
+- [ ] Backfill correto: `mobile_push` → mobile=true, telegram=false; `telegram` → mobile=false, telegram=true; `both` → ambos=true; `none` → todos=false
+- [ ] `safeParse` aceita `HH:MM` válido e rejeita formato errado
+- [ ] `safeParse` aceita enum `notification_mode` válido e rejeita valor fora do enum
+- [ ] `notification_preference` mantido como campo legado (não remover)
+- [ ] Schema web e core sincronizados com os mesmos campos
+
+### Sprint 2.2 — Server: gate + supressão
+- [ ] `notificationGate.js` exporta `shouldSendNow({ mode, quietHoursStart, quietHoursEnd, currentHHMM })`
+- [ ] `isInQuietHours` trata janela cross-midnight: `22:00→07:00` = `>= 22:00 || < 07:00`
+- [ ] `isInQuietHours` trata janela normal: `13:00→15:00` = `>= 13:00 && < 15:00`
+- [ ] `mode === 'silent'` → retorna `false` (sempre suprime)
+- [ ] `mode === 'digest_morning'` → retorna `false` (suprime lembretes realtime)
+- [ ] `mode === 'realtime'` dentro de quiet hours → retorna `false`
+- [ ] `mode === 'realtime'` fora de quiet hours → retorna `true`
+- [ ] `quiet_hours_start/end = null` → quiet hours desativados (não suprime por horário)
+- [ ] `checkRemindersViaDispatcher` lê `notification_mode`, `quiet_hours_start`, `quiet_hours_end` de `user_settings`
+- [ ] Notificações suprimidas geram entrada no inbox/auditoria com status `suprimida` (ou equivalente)
+- [ ] `resolveChannelsForUser` retorna `web_push` somente quando `channel_web_push_enabled === true` E device ativo com `provider = 'webpush'`
+- [ ] `resolveChannelsForUser` mantém lógica legada de `notification_preference` como fallback
+- [ ] Todos os testes de `notificationGate.test.js` passam
+- [ ] Todos os testes de `resolveChannelsForUser.test.js` passam (flags × devices)
+
+### Sprint 2.3 — Server: trigger digest simples
+- [ ] `runDailyDigest` verifica `notification_mode === 'digest_morning'` antes de disparar
+- [ ] Dispara somente quando `currentHHMM === user.digest_time`
+- [ ] Dispara exatamente 1 push via `dispatcher.dispatch()` com `kind = 'daily_digest'`
+- [ ] Title: `Sua agenda de hoje — X doses programadas`
+- [ ] Body: lista flat de horários e nomes dos protocolos
+- [ ] MarkdownV2 válido quando canal for Telegram
+- [ ] Não envia para modo `realtime` ou `silent`
+- [ ] Não envia fora do horário configurado
+
+### Sprint 2.4 — Mobile Perfil redesign
+- [ ] Seção "Avisos & Lembretes" com único card "Notificações" (ícone Bell)
+- [ ] Card tem badge de não lidas via `useUnreadNotificationCount`
+- [ ] Card navega para `ROUTES.NOTIFICATION_INBOX` em 1 tap
+- [ ] Cards separados de "Preferências de Notificação", "Central de Avisos" e "Bot Telegram" removidos do Perfil
+- [ ] Telegram não aparece como seção autônoma no Perfil
+- [ ] Badge vermelho ausente quando `unreadCount === 0`
+- [ ] Sem regressão no logout
+
+### Sprint 2.5 — Mobile Inbox redesign
+- [ ] Header: back icon + título "Avisos" + gear à direita
+- [ ] Gear navega para `ROUTES.NOTIFICATION_PREFERENCES`
+- [ ] Chips horizontais: Todos / Não lidos / Doses / Estoque
+- [ ] Filtro "Não lidos": itens sem leitura
+- [ ] Filtro "Doses": tipos `dose_reminder`, `dose_reminder_by_plan`, `dose_reminder_misc`, `missed_dose`, `daily_digest`
+- [ ] Filtro "Estoque": tipo `stock_alert`
+- [ ] Filtros mudam a lista sem refetch desnecessário
+- [ ] Agrupamento temporal preservado (Hoje, Ontem, labels em caixa alta)
+- [ ] Zero state: título "Tudo em dia por aqui" + body explicativo
+- [ ] Zero state funciona para filtro sem resultados também
+- [ ] CTAs de N1 preservados (registrar dose/plano/doses, ver estoque)
+- [ ] Unread dot no canto superior direito dos cards
+
+### Sprint 2.6 — Mobile Preferências redesign
+- [ ] Card "Notificações ativas" com switch global
+- [ ] Seção Canais: App (push), Telegram, Web (PWA), Email (disabled)
+- [ ] App push: pede permissão nativa antes de ativar se ausente
+- [ ] Telegram: status CONECTADO/DESCONECTADO + chevron para `ROUTES.TELEGRAM_LINK`
+- [ ] Web (PWA): mostra ATIVO/INATIVO/"Configure pelo navegador" — não tenta criar SW
+- [ ] Email: visível mas disabled
+- [ ] Modo de envio: seleção entre `realtime`, `digest_morning`, `silent`
+- [ ] Quiet hours: switch + 2 seletores de hora persistem em DB
+- [ ] Hora do resumo: visível somente quando `notification_mode === 'digest_morning'`
+- [ ] Mensagem de erro se todos os canais externos estiverem off com notificações ativas
+- [ ] `notification_preference` legado atualizado como backcompat
+- [ ] Todo switch/row tem `accessibilityLabel`
+- [ ] AP-059 respeitado: sem CSS vars em RN — usar tokens JS/hex
+- [ ] AP-H16 respeitado: sem pt-EU
+
+### Sprint 2.7 — Mobile Telegram redesign
+- [ ] Back icon funcional
+- [ ] Ícone Telegram grande
+- [ ] Título "Conectar ao Telegram"
+- [ ] Copy: "Receba lembretes e registre doses direto pelo chat. Vai levar uns 30 segundos."
+- [ ] Passo 1: "Abra o bot no Telegram" + CTA "Abrir @dosiq_bot"
+- [ ] Passo 2: "Envie este código no chat" + caixa escura com `/start TOKEN`
+- [ ] Botão/ícone para copiar código (sem dependência nova se possível)
+- [ ] Ação "Gerar novo código"
+- [ ] Nota de segurança presente
+- [ ] Estado conectado/desconectado claros
+- [ ] Sem texto pt-EU
+
+### Sprint 2.8 — Web Settings UI
+- [ ] Seção Canais: App (informativo), Web PWA (switch funcional), Telegram (status), Email (disabled)
+- [ ] Ativar Web PWA: chama `webpushService.subscribe()` + grava `channel_web_push_enabled = true`
+- [ ] Desativar Web PWA: grava `channel_web_push_enabled = false`
+- [ ] Browser sem suporte a Push API: row disabled com mensagem curta
+- [ ] Modo de notificação (3 opções) persistido no DB
+- [ ] Quiet hours: switch + 2 inputs `type="time"` persistidos
+- [ ] Hora do resumo visível somente quando `digest_morning`
+- [ ] Validação: `quiet_hours_start` e `quiet_hours_end` ambos ou nenhum
+- [ ] Pelo menos 1 canal ativo quando `notification_mode !== 'silent'`
+- [ ] Reload mantém valores salvos
+- [ ] Settings cross-platform: web → mobile e mobile → web refletem
+
+---
+
+## 4. Contratos Tocados
+
+| Contrato | Tipo de mudança | Ação |
+|----------|-----------------|------|
+| CON-017 `resolveChannelsForUser` | Não-breaking (additive) | Adicionar code path para flags explícitas; manter legado |
+
+---
+
+## 5. Regras Relevantes
+
+| Regra | Aplicação |
+|-------|-----------|
+| R-082 | Schema Zod e DB DEVEM estar sincronizados (novos campos CHECK/NOT NULL) |
+| R-085 | `.nullable().optional()` para campos que podem ser null do DB |
+| R-031 | `escapeMarkdownV2()` no digest Telegram |
+| R-032 | `shouldSendNotification()` já loga internamente |
+| R-121 / R-130 | Validar leitura e escrita com `safeParse()` nos services |
+| R-131 | Queries Supabase com datas via UTC via parseLocalDate |
+| R-167 | Logs RN protegidos por `if (__DEV__)` |
+| R-169 | Screens RN usam safe area |
+| R-193 | N/A — sem novo kind |
+
+---
+
+## 6. Anti-patterns a Vigiar
+
+| AP | Risco |
+|----|-------|
+| AP-115 | Se por acaso adicionar kind novo, atualizar enum Zod dispatcher |
+| AP-H16 | Mobile: usar pt-BR (tomar, tomadas) não pt-EU |
+| AP-059 | RN: usar tokens JS/hex, nunca CSS vars |
+| AP-117 | Params de navegação com contrato tipado entre emissor e receptor |
+| AP-118 | INSERT deve espelhar todos os campos do schema após adição |

--- a/.agent/wave-n2-execution-tracker.md
+++ b/.agent/wave-n2-execution-tracker.md
@@ -1,7 +1,8 @@
 # Wave N2 — Execution Tracker (DEVFLOW)
 
 > **Gerado em:** 2026-04-27  
-> **Branch:** `feature/wave-n2/quiet-hours-redesign`  
+> **Atualizado em:** 2026-04-27 — C4 concluído: 543 testes passando, 0 falhas, 36 testes server (notificationGate + resolveChannels)  
+> **Branch:** `feature/wave-n2/quiet-hours-redesign` — 12 commits, aguardando PR  
 > **Spec:** `plans/backlog-notifications/EXEC_SPEC_WAVE_N2_QUIET_HOURS.md`  
 > **C1 completo:** `.agent/wave-n2-c1-extraction.md`
 
@@ -11,14 +12,14 @@
 
 | Sprint | Descrição | Agente | Status | Commit |
 |--------|-----------|--------|--------|--------|
-| **2.1** | Migration SQL + Zod schema | 🟡 Haiku | ⬜ Pendente | — |
-| **2.2** | Server: notificationGate + resolveChannels | 🟢 Sonnet | ⬜ Pendente | — |
-| **2.3** | Server: digest trigger simples | 🟡 Haiku | ⬜ Pendente | — |
-| **2.4** | Mobile ProfileScreen redesign | 🟢 Sonnet | ⬜ Pendente | — |
-| **2.5** | Mobile NotificationInboxScreen redesign | 🟢 Sonnet | ⬜ Pendente | — |
-| **2.6** | Mobile NotificationPreferencesScreen redesign | 🟢 Sonnet | ⬜ Pendente | — |
-| **2.7** | Mobile TelegramLinkScreen redesign | 🟡 Haiku | ⬜ Pendente | — |
-| **2.8** | Web Settings canais + quiet hours + digest | 🟡 Haiku | ⬜ Pendente | — |
+| **2.1** | Migration SQL + Zod schema | 🟡 Haiku | ✅ Completo | 53d19e62 |
+| **2.2** | Server: notificationGate + resolveChannels | 🟢 Sonnet | ✅ Completo | 71850a0a + 5b28c190 + 6d7ff115 |
+| **2.3** | Server: digest trigger simples | 🟡 Haiku | ✅ Completo | 23478b95 |
+| **2.4** | Mobile ProfileScreen redesign | 🟢 Sonnet | ✅ Completo | 59c103ab |
+| **2.5** | Mobile NotificationInboxScreen redesign | 🟢 Sonnet | ✅ Completo | 3de1b872 |
+| **2.6** | Mobile NotificationPreferencesScreen redesign | 🟢 Sonnet | ✅ Completo | 0ac9812b |
+| **2.7** | Mobile TelegramLinkScreen redesign | 🟡 Haiku | ✅ Completo | 133d2bc6 |
+| **2.8** | Web Settings canais + quiet hours + digest | 🟡 Haiku | ✅ Completo | e87dc8b7 |
 | **2.9** | Validação manual + DEVFLOW C5 | ⚪ Humano | ⬜ Pendente | — |
 
 **Legenda:** ⬜ Pendente · 🔄 Em progresso · ✅ Completo · ❌ Bloqueado
@@ -28,7 +29,7 @@
 ## Sprint 2.1 — Migration + Zod schema
 
 **Agente:** 🟡 Haiku  
-**Status:** ⬜ Pendente
+**Status:** ✅ Completo
 
 ### Arquivos alvo
 - [ ] `docs/migrations/20260427_notification_quiet_hours.sql` — CRIAR
@@ -52,7 +53,7 @@
 ## Sprint 2.2 — Server: gate + supressão
 
 **Agente:** 🟢 Sonnet  
-**Status:** ⬜ Pendente  
+**Status:** ✅ Completo  
 **Depende de:** 2.1 (campos em `user_settings`)
 
 ### Arquivos alvo
@@ -84,7 +85,7 @@
 ## Sprint 2.3 — Server: digest trigger
 
 **Agente:** 🟡 Haiku  
-**Status:** ⬜ Pendente  
+**Status:** ✅ Completo  
 **Depende de:** 2.1 (campo `notification_mode`, `digest_time`)
 
 ### Arquivos alvo
@@ -108,7 +109,7 @@
 ## Sprint 2.4 — Mobile ProfileScreen redesign
 
 **Agente:** 🟢 Sonnet  
-**Status:** ⬜ Pendente
+**Status:** ✅ Completo
 
 ### Arquivos alvo
 - [ ] `apps/mobile/src/features/profile/screens/ProfileScreen.jsx` — MODIFICAR
@@ -132,7 +133,7 @@
 ## Sprint 2.5 — Mobile NotificationInboxScreen redesign
 
 **Agente:** 🟢 Sonnet  
-**Status:** ⬜ Pendente  
+**Status:** ✅ Completo  
 **Depende de:** 2.4 (navegação do Perfil para o Inbox)
 
 ### Arquivos alvo
@@ -155,7 +156,7 @@
 ## Sprint 2.6 — Mobile NotificationPreferencesScreen redesign
 
 **Agente:** 🟢 Sonnet  
-**Status:** ⬜ Pendente  
+**Status:** ✅ Completo  
 **Depende de:** 2.1 (novos campos), 2.4 (navegação)
 
 ### Arquivos alvo
@@ -180,7 +181,7 @@
 ## Sprint 2.7 — Mobile TelegramLinkScreen redesign
 
 **Agente:** 🟡 Haiku  
-**Status:** ⬜ Pendente
+**Status:** ✅ Completo
 
 ### Arquivos alvo
 - [ ] `apps/mobile/src/features/profile/screens/TelegramLinkScreen.jsx` — MODIFICAR
@@ -202,7 +203,7 @@
 ## Sprint 2.8 — Web Settings UI
 
 **Agente:** 🟡 Haiku  
-**Status:** ⬜ Pendente  
+**Status:** ✅ Completo  
 **Depende de:** 2.1 (novos campos)
 
 ### Arquivos alvo

--- a/.agent/wave-n2-execution-tracker.md
+++ b/.agent/wave-n2-execution-tracker.md
@@ -1,0 +1,277 @@
+# Wave N2 — Execution Tracker (DEVFLOW)
+
+> **Gerado em:** 2026-04-27  
+> **Branch:** `feature/wave-n2/quiet-hours-redesign`  
+> **Spec:** `plans/backlog-notifications/EXEC_SPEC_WAVE_N2_QUIET_HOURS.md`  
+> **C1 completo:** `.agent/wave-n2-c1-extraction.md`
+
+---
+
+## Status Geral
+
+| Sprint | Descrição | Agente | Status | Commit |
+|--------|-----------|--------|--------|--------|
+| **2.1** | Migration SQL + Zod schema | 🟡 Haiku | ⬜ Pendente | — |
+| **2.2** | Server: notificationGate + resolveChannels | 🟢 Sonnet | ⬜ Pendente | — |
+| **2.3** | Server: digest trigger simples | 🟡 Haiku | ⬜ Pendente | — |
+| **2.4** | Mobile ProfileScreen redesign | 🟢 Sonnet | ⬜ Pendente | — |
+| **2.5** | Mobile NotificationInboxScreen redesign | 🟢 Sonnet | ⬜ Pendente | — |
+| **2.6** | Mobile NotificationPreferencesScreen redesign | 🟢 Sonnet | ⬜ Pendente | — |
+| **2.7** | Mobile TelegramLinkScreen redesign | 🟡 Haiku | ⬜ Pendente | — |
+| **2.8** | Web Settings canais + quiet hours + digest | 🟡 Haiku | ⬜ Pendente | — |
+| **2.9** | Validação manual + DEVFLOW C5 | ⚪ Humano | ⬜ Pendente | — |
+
+**Legenda:** ⬜ Pendente · 🔄 Em progresso · ✅ Completo · ❌ Bloqueado
+
+---
+
+## Sprint 2.1 — Migration + Zod schema
+
+**Agente:** 🟡 Haiku  
+**Status:** ⬜ Pendente
+
+### Arquivos alvo
+- [ ] `docs/migrations/20260427_notification_quiet_hours.sql` — CRIAR
+- [ ] `packages/core/src/schemas/userSettingsSchema.js` — CRIAR
+- [ ] `apps/web/src/schemas/userSettingsSchema.js` — CRIAR
+
+### DoD checklist
+- [ ] Migration SQL aplica sem erro em staging
+- [ ] Campos: `quiet_hours_start`, `quiet_hours_end`, `notification_mode` (CHECK), `digest_time`, `channel_mobile_push_enabled` (NOT NULL), `channel_web_push_enabled` (NOT NULL), `channel_telegram_enabled` (NOT NULL)
+- [ ] Backfill correto dos booleans a partir de `notification_preference`
+- [ ] `safeParse` valida `HH:MM` e enum `notification_mode`
+- [ ] Schema web e core sincronizados
+
+### Notas de qualidade
+- R-082: schema e DB sincronizados
+- R-085: usar `.nullable().optional()` para `quiet_hours_start/end`
+- Manter `notification_preference` como legado (não remover)
+
+---
+
+## Sprint 2.2 — Server: gate + supressão
+
+**Agente:** 🟢 Sonnet  
+**Status:** ⬜ Pendente  
+**Depende de:** 2.1 (campos em `user_settings`)
+
+### Arquivos alvo
+- [ ] `server/bot/utils/notificationGate.js` — CRIAR
+- [ ] `server/bot/__tests__/notificationGate.test.js` — CRIAR
+- [ ] `server/bot/tasks.js` — MODIFICAR (`checkRemindersViaDispatcher`)
+- [ ] `server/notifications/policies/resolveChannelsForUser.js` — MODIFICAR
+- [ ] `server/notifications/policies/resolveChannelsForUser.test.js` — MODIFICAR
+
+### DoD checklist
+- [ ] `shouldSendNow` exportado com interface `{ mode, quietHoursStart, quietHoursEnd, currentHHMM }`
+- [ ] `isInQuietHours` cross-midnight correto
+- [ ] `silent` → sempre false
+- [ ] `digest_morning` → sempre false (suprime realtime)
+- [ ] `realtime` dentro QH → false; fora QH → true
+- [ ] `null` start/end → QH desativados
+- [ ] `tasks.js` lê os novos campos e aplica gate antes do dispatch
+- [ ] Suprimidas geram entrada no inbox com status apropriado
+- [ ] `resolveChannelsForUser` suporta flags explícitas (`channel_*_enabled` + device ativo)
+- [ ] Legado `notification_preference` mantido como fallback
+- [ ] Todos os testes passam
+
+### Notas de qualidade
+- CON-017: mudança não-breaking — adicionar code path, não remover legado
+- AP-118: INSERT no inbox deve espelhar schema após adição dos novos campos
+
+---
+
+## Sprint 2.3 — Server: digest trigger
+
+**Agente:** 🟡 Haiku  
+**Status:** ⬜ Pendente  
+**Depende de:** 2.1 (campo `notification_mode`, `digest_time`)
+
+### Arquivos alvo
+- [ ] `server/bot/tasks.js` — MODIFICAR (`runDailyDigest`)
+
+### DoD checklist
+- [ ] Filtra por `notification_mode === 'digest_morning'` antes de disparar
+- [ ] Dispara somente quando `currentHHMM === user.digest_time`
+- [ ] 1 push por usuário via `dispatcher.dispatch({ kind: 'daily_digest' })`
+- [ ] Title: `Sua agenda de hoje — X doses programadas`
+- [ ] Body: lista flat de horários + nomes dos protocolos
+- [ ] MarkdownV2 válido para canal Telegram
+- [ ] Sem envio para `realtime` ou `silent`
+
+### Notas de qualidade
+- R-031: `escapeMarkdownV2()` obrigatório no body Telegram
+- R-032: `shouldSendNotification()` já loga — não chamar `logNotification()` depois
+
+---
+
+## Sprint 2.4 — Mobile ProfileScreen redesign
+
+**Agente:** 🟢 Sonnet  
+**Status:** ⬜ Pendente
+
+### Arquivos alvo
+- [ ] `apps/mobile/src/features/profile/screens/ProfileScreen.jsx` — MODIFICAR
+
+### DoD checklist
+- [ ] Uma única entrada "Notificações" na seção "Avisos & Lembretes"
+- [ ] Badge de não lidas via `useUnreadNotificationCount`
+- [ ] Tap → `ROUTES.NOTIFICATION_INBOX`
+- [ ] Cards separados de Preferências/Central/Telegram removidos
+- [ ] Badge ausente quando `unreadCount === 0`
+- [ ] Logout sem regressão
+
+### Notas de qualidade
+- R-167: logs RN protegidos por `if (__DEV__)`
+- R-169: usar safe area
+- AP-H16: pt-BR somente
+- AP-059: tokens JS/hex — sem CSS vars
+
+---
+
+## Sprint 2.5 — Mobile NotificationInboxScreen redesign
+
+**Agente:** 🟢 Sonnet  
+**Status:** ⬜ Pendente  
+**Depende de:** 2.4 (navegação do Perfil para o Inbox)
+
+### Arquivos alvo
+- [ ] `apps/mobile/src/features/notifications/screens/NotificationInboxScreen.jsx` — MODIFICAR
+
+### DoD checklist
+- [ ] Header: back + "Avisos" + gear
+- [ ] Gear → `ROUTES.NOTIFICATION_PREFERENCES`
+- [ ] Chips: Todos / Não lidos / Doses / Estoque
+- [ ] Filtro Doses: `dose_reminder`, `dose_reminder_by_plan`, `dose_reminder_misc`, `missed_dose`, `daily_digest`
+- [ ] Filtro Estoque: `stock_alert`
+- [ ] Filtros sem refetch
+- [ ] Agrupamento temporal preservado (CAIXA ALTA)
+- [ ] Zero state: "Tudo em dia por aqui" + body; funciona para filtro vazio
+- [ ] CTAs N1 preservados
+- [ ] Unread dot
+
+---
+
+## Sprint 2.6 — Mobile NotificationPreferencesScreen redesign
+
+**Agente:** 🟢 Sonnet  
+**Status:** ⬜ Pendente  
+**Depende de:** 2.1 (novos campos), 2.4 (navegação)
+
+### Arquivos alvo
+- [ ] `apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx` — MODIFICAR
+- [ ] `apps/mobile/src/features/profile/services/profileService.js` — MODIFICAR
+
+### DoD checklist
+- [ ] Switch global "Notificações ativas"
+- [ ] Canal App push: permissão nativa antes de ativar
+- [ ] Canal Telegram: CONECTADO/DESCONECTADO + chevron para `ROUTES.TELEGRAM_LINK`
+- [ ] Canal Web (PWA): ATIVO/INATIVO/"Configure pelo navegador" — sem SW no nativo
+- [ ] Canal Email: disabled
+- [ ] Modo de envio: `realtime`, `digest_morning`, `silent`
+- [ ] Quiet hours: switch + 2 seletores de hora → persistem em DB
+- [ ] Hora do resumo: visível somente quando `digest_morning`
+- [ ] Erro se todos os canais off com notificações ativas
+- [ ] `notification_preference` legado atualizado como backcompat
+- [ ] `accessibilityLabel` em todos os switches/rows
+
+---
+
+## Sprint 2.7 — Mobile TelegramLinkScreen redesign
+
+**Agente:** 🟡 Haiku  
+**Status:** ⬜ Pendente
+
+### Arquivos alvo
+- [ ] `apps/mobile/src/features/profile/screens/TelegramLinkScreen.jsx` — MODIFICAR
+
+### DoD checklist
+- [ ] Back icon funcional
+- [ ] Ícone Telegram grande
+- [ ] Título "Conectar ao Telegram"
+- [ ] Copy correto (pt-BR)
+- [ ] Passo 1: "Abra o bot no Telegram" + CTA "Abrir @dosiq_bot"
+- [ ] Passo 2: caixa escura com `/start TOKEN` + botão copiar
+- [ ] "Gerar novo código" funcional
+- [ ] Nota de segurança presente
+- [ ] Estado conectado/desconectado claros
+- [ ] Sem texto pt-EU
+
+---
+
+## Sprint 2.8 — Web Settings UI
+
+**Agente:** 🟡 Haiku  
+**Status:** ⬜ Pendente  
+**Depende de:** 2.1 (novos campos)
+
+### Arquivos alvo
+- [ ] `apps/web/src/views/redesign/Settings.jsx` — MODIFICAR (**NÃO** `apps/web/src/views/Settings.jsx`)
+- [ ] `apps/web/src/views/redesign/settings/SettingsRedesign.css` — MODIFICAR
+- [ ] `apps/web/src/shared/services/webpushService.js` — MODIFICAR (add unsubscribe se necessário)
+- [ ] `apps/web/src/services/userSettingsService.js` — CRIAR se necessário
+
+### DoD checklist
+- [ ] Seção Canais: App (info), Web PWA (switch), Telegram (status), Email (disabled)
+- [ ] Ativar Web PWA: `webpushService.subscribe()` + `channel_web_push_enabled = true`
+- [ ] Desativar Web PWA: `channel_web_push_enabled = false`
+- [ ] Browser sem Push API: row disabled com mensagem
+- [ ] Modo notificação: 3 opções persistidas
+- [ ] Quiet hours: switch + 2 inputs `type="time"` persistidos
+- [ ] Hora do resumo: visível somente em `digest_morning`
+- [ ] Validação: QH start+end ambos ou nenhum
+- [ ] Ao menos 1 canal ativo quando `!== 'silent'`
+- [ ] Reload preserva valores
+
+---
+
+## Sprint 2.9 — Validação Manual + DEVFLOW C5
+
+**Agente:** ⚪ Humano  
+**Status:** ⬜ Pendente
+
+### Checklist E2E
+- [ ] Perfil → Notificações → Avisos → gear → Preferências → Telegram
+- [ ] Zero state em conta sem notificações
+- [ ] Filtros Todos/Não lidos/Doses/Estoque no mobile
+- [ ] Web: habilitar Web PWA → cron envia `web_push`
+- [ ] Web: desabilitar Web PWA → cron não envia `web_push`
+- [ ] `quiet_hours_start=22:00`, `end=07:00` → device físico não recebe push às 23:00
+- [ ] `digest_morning 07:00` → 1 push às 07:00 com agenda do dia
+- [ ] `silent` → 0 push externo, inbox popula normalmente
+
+### Quality gates
+- [ ] `cd apps/web && npm run lint`
+- [ ] `cd apps/web && npm run validate:agent`
+- [ ] Testes server: verificar comando em `server/package.json`
+
+### DEVFLOW C5
+- [ ] ADR-035: política de quiet hours, modos, canais App/Web/Telegram, arquitetura Perfil→Avisos→Preferências→Telegram
+- [ ] R-196 candidato: `isInQuietHours` cross-midnight (start > end = spans midnight)
+- [ ] R-197 candidato: única porta de entrada de notificações no Perfil
+- [ ] R-198 candidato: `web_push` depende de flag + device ativo (não só subscription)
+- [ ] Journal entry em `.agent/memory/journal/2026-W18.jsonl`
+- [ ] Atualizar `state.json`: `journal_entries_since_distillation` + `status = completed`
+
+---
+
+## Notas de Implementação
+
+### Dependências entre sprints
+```
+2.1 ─────────┬──→ 2.2 ─→ (tasks.js gate)
+             ├──→ 2.3 ─→ (digest trigger)
+             └──→ 2.6 ─→ (mobile prefs)
+                         └──→ 2.8 (web settings)
+
+2.4 ─→ 2.5 ─→ 2.6 (navegação móvel)
+
+2.7 — independente (redesign puro)
+2.1 + 2.7 — podem ser iniciados em paralelo com 2.2/2.4
+```
+
+### Armadilha crítica confirmada
+> `apps/web/src/views/Settings.jsx` (view antiga) e `apps/web/src/views/redesign/Settings.jsx` (alvo correto) coexistem. **Sempre usar o caminho completo com `/redesign/`.**
+
+### Legado `notification_preference`
+> Manter o campo e atualizá-lo como backcompat ao gravar os booleans de canal. A UI nova lê/escreve os booleans; o legado é atualizado derivadamente. Nunca remover o campo nesta wave.

--- a/apps/mobile/src/features/notifications/screens/NotificationInboxScreen.jsx
+++ b/apps/mobile/src/features/notifications/screens/NotificationInboxScreen.jsx
@@ -1,18 +1,20 @@
 /**
- * NotificationInboxScreen — Central de Avisos v1 (Mobile).
+ * NotificationInboxScreen — Central de Avisos v2 (Mobile).
  *
  * SectionList com agrupamento temporal (Hoje / Ontem / Esta semana / Mais antigos).
  * Cruza dose_reminder com medicine_logs para exibir "✓ Tomada" sem navegação extra.
+ * Filtros horizontais: Todos / Não lidos / Doses / Estoque.
  * R-169: SafeAreaView obrigatório. R-180: header 28/800 padrão Santuário.
  * R-184: auto-refresh no useNotificationLog. R-187: cache key por userId.
  */
 import { useEffect, useCallback, useMemo, useState } from 'react'
 import {
   View, Text, SectionList, StyleSheet, TouchableOpacity,
-  RefreshControl, ActivityIndicator, AppState,
+  RefreshControl, ActivityIndicator, AppState, ScrollView,
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { ArrowLeft, Bell, WifiOff } from 'lucide-react-native'
+import { ArrowLeft, BellOff, Settings, WifiOff } from 'lucide-react-native'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import { z } from 'zod'
 import { getTodayLocal } from '@dosiq/core'
 import { ROUTES } from '../../../navigation/routes'
@@ -38,6 +40,27 @@ const DEEP_LINK_TARGETS = {
   'bulk-misc':      ROUTES.TODAY,
   'dose-individual': ROUTES.TODAY,
 }
+
+// Tipos de notificação de dose (para filtro)
+const DOSE_KINDS = [
+  'dose_reminder',
+  'dose_reminder_by_plan',
+  'dose_reminder_misc',
+  'missed_dose',
+  'daily_digest',
+]
+
+// Chips de filtro
+const FILTERS = [
+  { key: 'all',    label: 'Todos' },
+  { key: 'unread', label: 'Não lidos' },
+  { key: 'doses',  label: 'Doses' },
+  { key: 'stock',  label: 'Estoque' },
+]
+
+// Chave AsyncStorage para "último acesso" (R-187)
+const getStorageKey = (userId) =>
+  userId ? `@dosiq/notif-last-seen:${userId}` : '@dosiq/notif-last-seen'
 
 // ─── Agrupamento temporal ──────────────────────────────────────────────────────
 
@@ -105,6 +128,19 @@ export default function NotificationInboxScreen({ navigation, route }) {
   const { data, loading, error, stale, refresh } = useNotificationLog({ userId, limit: 30 })
   const { unreadCount, markAllRead } = useUnreadNotificationCount(data, userId)
 
+  // lastSeen local: necessário para filtro "Não lidos" (R-187)
+  const [lastSeen, setLastSeen] = useState(null)
+  useEffect(() => {
+    AsyncStorage.getItem(getStorageKey(userId))
+      .then((val) => setLastSeen(val))
+      .catch((err) => {
+        if (__DEV__) console.warn('[NotificationInboxScreen] lastSeen read error', err)
+      })
+  }, [userId])
+
+  // Filtro ativo
+  const [activeFilter, setActiveFilter] = useState('all')
+
   // localDay: detecta virada de dia via AppState + timer de meia-noite (R5-008)
   const [localDay, setLocalDay] = useState(getTodayLocal)
   useEffect(() => {
@@ -150,15 +186,45 @@ export default function NotificationInboxScreen({ navigation, route }) {
     await Promise.all([refresh(), loadDoseLogs()])
   }, [refresh, loadDoseLogs])
 
-  // Marca tudo como lido ao abrir
+  // Marca tudo como lido ao abrir e atualiza lastSeen local
   useEffect(() => {
-    if (!loading && data) markAllRead()
-  }, [loading, data, markAllRead])
+    if (!loading && data) {
+      markAllRead()
+      // Atualiza lastSeen local para que filtro "Não lidos" seja recalculado
+      AsyncStorage.getItem(getStorageKey(userId))
+        .then((val) => setLastSeen(val))
+        .catch(() => {})
+    }
+  }, [loading, data, markAllRead, userId])
 
+  // Sections sem filtro (agrupamento temporal)
   const sections = useMemo(
     () => groupByDay(data ?? []),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [data, localDay]
   )
+
+  // Sections com filtro aplicado
+  const filteredSections = useMemo(() => {
+    const lastSeenTime = lastSeen ? new Date(lastSeen).getTime() : null
+
+    const filterItem = (item) => {
+      if (activeFilter === 'all')    return true
+      if (activeFilter === 'unread') {
+        if (!item.sent_at) return false
+        // Antes de markAllRead ser persistido, lastSeenTime pode ser null → tudo é não lido
+        if (!lastSeenTime) return true
+        return new Date(item.sent_at).getTime() > lastSeenTime
+      }
+      if (activeFilter === 'doses')  return DOSE_KINDS.includes(item.notification_type)
+      if (activeFilter === 'stock')  return item.notification_type === 'stock_alert'
+      return true
+    }
+
+    return sections
+      .map(s => ({ ...s, data: s.data.filter(filterItem) }))
+      .filter(s => s.data.length > 0)
+  }, [sections, activeFilter, lastSeen])
 
   const wasTakenMap = useMemo(
     () => buildWasTakenMap(data ?? [], doseLogs),
@@ -207,24 +273,27 @@ export default function NotificationInboxScreen({ navigation, route }) {
   const renderEmpty = useCallback(() => {
     if (loading) return null
     return (
-      <View style={styles.emptyContainer}>
-        <View style={styles.emptyIconWrap}>
-          <Bell size={36} color={colors.text?.muted ?? '#9ca3af'} strokeWidth={1.5} />
-        </View>
-        <Text style={styles.emptyTitle}>Nenhuma notificação ainda</Text>
+      <View style={styles.emptyState}>
+        <BellOff size={40} color={colors.text?.muted ?? '#9ca3af'} strokeWidth={1.5} />
+        <Text style={styles.emptyTitle}>Tudo em dia por aqui</Text>
         <Text style={styles.emptyBody}>
-          Seus lembretes de dose, alertas de estoque e resumos diários aparecerão aqui.
+          {activeFilter === 'all'
+            ? 'Quando houver lembretes, alertas de estoque ou resumos, eles aparecem aqui.'
+            : 'Nenhum item nesta categoria.'}
         </Text>
       </View>
     )
-  }, [loading])
+  }, [loading, activeFilter])
+
+  const primaryColor = colors.primary?.[600] ?? '#006a5e'
 
   return (
     <SafeAreaView style={styles.safe} edges={['top']}>
+      {/* ── Header ── */}
       <View style={styles.header}>
         <TouchableOpacity
           onPress={() => navigation.goBack()}
-          style={styles.backButton}
+          style={styles.iconButton}
           accessibilityRole="button"
           accessibilityLabel="Voltar"
           hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
@@ -232,16 +301,27 @@ export default function NotificationInboxScreen({ navigation, route }) {
           <ArrowLeft size={22} color={colors.text?.primary ?? '#111827'} strokeWidth={2} />
         </TouchableOpacity>
 
-        <View style={styles.titleRow}>
-          <Text style={styles.title}>Central de Avisos</Text>
+        <View style={styles.titleBlock}>
+          <Text style={styles.title}>Avisos</Text>
           {unreadCount > 0 && !loading && (
-            <View style={styles.unreadBadge}>
-              <Text style={styles.unreadBadgeText}>{unreadCount}</Text>
-            </View>
+            <Text style={[styles.subtitle, { color: primaryColor }]}>
+              {unreadCount} {unreadCount === 1 ? 'não lida' : 'não lidas'}
+            </Text>
           )}
         </View>
+
+        <TouchableOpacity
+          onPress={() => navigation.navigate(ROUTES.NOTIFICATION_PREFERENCES)}
+          style={styles.iconButton}
+          accessibilityRole="button"
+          accessibilityLabel="Preferências de notificação"
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        >
+          <Settings size={22} color={colors.text?.primary ?? '#111827'} strokeWidth={2} />
+        </TouchableOpacity>
       </View>
 
+      {/* ── Banner offline ── */}
       {stale && (
         <View style={styles.offlineBanner}>
           <WifiOff size={14} color={colors.status?.warning ?? '#d97706'} strokeWidth={2} />
@@ -249,9 +329,40 @@ export default function NotificationInboxScreen({ navigation, route }) {
         </View>
       )}
 
+      {/* ── Chips de filtro ── */}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        style={styles.filtersScroll}
+        contentContainerStyle={styles.filtersContent}
+      >
+        {FILTERS.map((f) => {
+          const isActive = activeFilter === f.key
+          return (
+            <TouchableOpacity
+              key={f.key}
+              onPress={() => setActiveFilter(f.key)}
+              style={[
+                styles.chip,
+                isActive
+                  ? { backgroundColor: primaryColor, borderColor: primaryColor }
+                  : styles.chipInactive,
+              ]}
+              accessibilityRole="button"
+              accessibilityState={{ selected: isActive }}
+            >
+              <Text style={[styles.chipText, isActive ? styles.chipTextActive : styles.chipTextInactive]}>
+                {f.label}
+              </Text>
+            </TouchableOpacity>
+          )
+        })}
+      </ScrollView>
+
+      {/* ── Conteúdo principal ── */}
       {loading && !data && (
         <View style={styles.loadingContainer}>
-          <ActivityIndicator color={colors.primary?.[600] ?? '#006a5e'} size="large" />
+          <ActivityIndicator color={primaryColor} size="large" />
         </View>
       )}
 
@@ -263,7 +374,7 @@ export default function NotificationInboxScreen({ navigation, route }) {
 
       {(!loading || data) && !error && (
         <SectionList
-          sections={sections}
+          sections={filteredSections}
           keyExtractor={(item, i) => item.id ?? String(i)}
           renderItem={renderItem}
           renderSectionHeader={renderSectionHeader}
@@ -274,10 +385,10 @@ export default function NotificationInboxScreen({ navigation, route }) {
             <RefreshControl
               refreshing={loading && !!data}
               onRefresh={refreshAll}
-              tintColor={colors.primary?.[600] ?? '#006a5e'}
+              tintColor={primaryColor}
             />
           }
-          contentContainerStyle={sections.length === 0 ? styles.emptyList : styles.listContent}
+          contentContainerStyle={filteredSections.length === 0 ? styles.emptyList : styles.listContent}
           showsVerticalScrollIndicator={false}
           accessibilityRole="list"
           accessibilityLabel="Lista de notificações"
@@ -287,26 +398,45 @@ export default function NotificationInboxScreen({ navigation, route }) {
   )
 }
 
+const PRIMARY = colors.primary?.[600] ?? '#006a5e'
+
 const styles = StyleSheet.create({
   safe:             { flex: 1, backgroundColor: colors.bg?.default ?? '#f9fafb' },
-  header:           { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 20, paddingTop: 8, paddingBottom: 16, gap: 12, borderBottomWidth: 1, borderBottomColor: colors.border?.light ?? '#e5e7eb' },
-  backButton:       { width: 36, height: 36, borderRadius: 18, backgroundColor: colors.bg?.card ?? '#f3f4f6', alignItems: 'center', justifyContent: 'center', flexShrink: 0 },
-  titleRow:         { flex: 1, flexDirection: 'row', alignItems: 'center', gap: 8 },
+
+  // Header
+  header:           { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingTop: 8, paddingBottom: 12, gap: 12, borderBottomWidth: 1, borderBottomColor: colors.border?.light ?? '#e5e7eb' },
+  iconButton:       { width: 36, height: 36, borderRadius: 18, backgroundColor: colors.bg?.card ?? '#f3f4f6', alignItems: 'center', justifyContent: 'center', flexShrink: 0 },
+  titleBlock:       { flex: 1 },
   title:            { fontSize: 28, fontWeight: '800', letterSpacing: -0.5, color: colors.text?.primary ?? '#111827' },
-  unreadBadge:      { minWidth: 20, height: 20, paddingHorizontal: 6, borderRadius: 100, backgroundColor: colors.status?.error ?? '#dc2626', alignItems: 'center', justifyContent: 'center' },
-  unreadBadgeText:  { fontSize: 11, fontWeight: '700', color: '#ffffff' },
+  subtitle:         { fontSize: 13, fontWeight: '500', marginTop: 1 },
+
+  // Banner offline
   offlineBanner:    { flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 20, paddingVertical: 8, backgroundColor: 'rgba(251, 191, 36, 0.15)', borderBottomWidth: 1, borderBottomColor: 'rgba(217, 119, 6, 0.20)' },
   offlineText:      { fontSize: 13, fontWeight: '500', color: colors.status?.warning ?? '#d97706' },
+
+  // Chips de filtro
+  filtersScroll:    { flexGrow: 0, borderBottomWidth: 1, borderBottomColor: colors.border?.light ?? '#e5e7eb' },
+  filtersContent:   { paddingHorizontal: 16, paddingVertical: 10, gap: 8 },
+  chip:             { borderRadius: 20, paddingHorizontal: 14, paddingVertical: 6, borderWidth: 1 },
+  chipInactive:     { backgroundColor: '#ffffff', borderColor: colors.border?.medium ?? '#d1d5db' },
+  chipText:         { fontSize: 13, fontWeight: '500' },
+  chipTextActive:   { color: '#ffffff' },
+  chipTextInactive: { color: colors.text?.secondary ?? '#374151' },
+
+  // Loading / error
   loadingContainer: { flex: 1, alignItems: 'center', justifyContent: 'center' },
   errorContainer:   { margin: 20, padding: 16, borderRadius: 12, backgroundColor: 'rgba(220, 38, 38, 0.06)' },
   errorText:        { fontSize: 14, color: colors.status?.error ?? '#dc2626' },
+
+  // Lista
   sectionHeader:    { paddingHorizontal: 20, paddingTop: 20, paddingBottom: 6 },
   sectionTitle:     { fontSize: 12, fontWeight: '600', color: colors.text?.muted ?? '#6b7280', textTransform: 'uppercase', letterSpacing: 0.8 },
   separator:        { height: 1, marginHorizontal: 20, backgroundColor: colors.border?.light ?? '#e5e7eb' },
   listContent:      { paddingBottom: 40 },
   emptyList:        { flex: 1 },
-  emptyContainer:   { flex: 1, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 32, paddingTop: 60, gap: 12 },
-  emptyIconWrap:    { width: 72, height: 72, borderRadius: 36, backgroundColor: colors.bg?.card ?? '#f3f4f6', alignItems: 'center', justifyContent: 'center', marginBottom: 4 },
-  emptyTitle:       { fontSize: 18, fontWeight: '700', color: colors.text?.primary ?? '#111827', textAlign: 'center' },
-  emptyBody:        { fontSize: 14, fontWeight: '400', color: colors.text?.muted ?? '#6b7280', textAlign: 'center', lineHeight: 21 },
+
+  // Zero state
+  emptyState:       { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
+  emptyTitle:       { fontSize: 18, fontWeight: '600', color: '#1a1a1a', marginBottom: 8, textAlign: 'center', marginTop: 16 },
+  emptyBody:        { fontSize: 14, color: '#6b7280', textAlign: 'center', lineHeight: 20 },
 })

--- a/apps/mobile/src/features/notifications/screens/NotificationInboxScreen.jsx
+++ b/apps/mobile/src/features/notifications/screens/NotificationInboxScreen.jsx
@@ -7,7 +7,7 @@
  * R-169: SafeAreaView obrigatório. R-180: header 28/800 padrão Santuário.
  * R-184: auto-refresh no useNotificationLog. R-187: cache key por userId.
  */
-import { useEffect, useCallback, useMemo, useState } from 'react'
+import { useEffect, useCallback, useMemo, useState, useRef } from 'react'
 import {
   View, Text, SectionList, StyleSheet, TouchableOpacity,
   RefreshControl, ActivityIndicator, AppState, ScrollView,
@@ -140,6 +140,7 @@ export default function NotificationInboxScreen({ navigation, route }) {
 
   // Filtro ativo
   const [activeFilter, setActiveFilter] = useState('all')
+  const hasMarkedRead = useRef(false)
 
   // localDay: detecta virada de dia via AppState + timer de meia-noite (R5-008)
   const [localDay, setLocalDay] = useState(getTodayLocal)
@@ -186,11 +187,11 @@ export default function NotificationInboxScreen({ navigation, route }) {
     await Promise.all([refresh(), loadDoseLogs()])
   }, [refresh, loadDoseLogs])
 
-  // Marca tudo como lido ao abrir e atualiza lastSeen local
+  // Marca tudo como lido apenas no carregamento inicial (useRef garante execução única)
   useEffect(() => {
-    if (!loading && data) {
+    if (!loading && data && !hasMarkedRead.current) {
+      hasMarkedRead.current = true
       markAllRead()
-      // Atualiza lastSeen local para que filtro "Não lidos" seja recalculado
       AsyncStorage.getItem(getStorageKey(userId))
         .then((val) => setLastSeen(val))
         .catch(() => {})

--- a/apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx
+++ b/apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx
@@ -1,285 +1,430 @@
-import React, { useState, useEffect } from 'react'
-import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Alert, Linking } from 'react-native'
-import { Send, MessageSquareDot, TrendingUpDown, MessageSquareOff } from 'lucide-react-native'
+import React, { useState, useEffect, useCallback } from 'react'
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ScrollView,
+  Switch,
+  Alert,
+  Linking,
+  Modal,
+  FlatList,
+} from 'react-native'
+import { Bell, Smartphone, Send, Globe, Mail, ChevronRight, Check } from 'lucide-react-native'
 import { useAuth } from '../../../platform/auth/hooks/useAuth'
 import { useProfile } from '../hooks/useProfile'
 import { requestPushPermission } from '../../../platform/notifications/requestPushPermission'
 import { getExpoPushToken } from '../../../platform/notifications/getExpoPushToken'
 import { syncNotificationDevice } from '../../../platform/notifications/syncNotificationDevice'
+import { updateNotificationSettings } from '../services/profileService'
 import ScreenContainer from '../../../shared/components/ui/ScreenContainer'
-import { colors, spacing, borderRadius } from '../../../shared/styles/tokens'
+import { colors, spacing, borderRadius, shadows } from '../../../shared/styles/tokens'
+import { ROUTES } from '../../../navigation/routes'
 
-// Cópia dos labels da web conforme R-166
-const PREFERENCE_LABELS = {
-  telegram: 'Telegram',
-  mobile_push: 'App (push nativo)',
-  both: 'Ambos',
-  none: 'Desativar notificações',
+// Horas disponíveis para o picker inline
+const HOURS = Array.from({ length: 24 }, (_, i) => {
+  const h = String(i).padStart(2, '0')
+  return `${h}:00`
+})
+
+// Derivar notification_preference legado
+function deriveLegacyPreference(mobile, telegram) {
+  if (mobile && telegram) return 'both'
+  if (mobile) return 'mobile_push'
+  if (telegram) return 'telegram'
+  return 'none'
+}
+
+// Picker de hora inline via Modal
+function TimePicker({ value, onChange, label }) {
+  const [visible, setVisible] = useState(false)
+
+  return (
+    <>
+      <TouchableOpacity
+        style={styles.timePickerButton}
+        onPress={() => setVisible(true)}
+        accessibilityLabel={`${label}: ${value}`}
+        accessibilityRole="button"
+      >
+        <Text style={styles.timePickerValue}>{value}</Text>
+        <ChevronRight size={14} color={colors.text.muted} />
+      </TouchableOpacity>
+
+      <Modal
+        visible={visible}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setVisible(false)}
+      >
+        <TouchableOpacity
+          style={styles.modalBackdrop}
+          activeOpacity={1}
+          onPress={() => setVisible(false)}
+        >
+          <View style={styles.modalSheet}>
+            <Text style={styles.modalTitle}>{label}</Text>
+            <FlatList
+              data={HOURS}
+              keyExtractor={(item) => item}
+              style={styles.hourList}
+              initialScrollIndex={Math.max(0, HOURS.indexOf(value))}
+              getItemLayout={(_, index) => ({ length: 48, offset: 48 * index, index })}
+              renderItem={({ item }) => (
+                <TouchableOpacity
+                  style={[styles.hourItem, item === value && styles.hourItemActive]}
+                  onPress={() => {
+                    onChange(item)
+                    setVisible(false)
+                  }}
+                  accessibilityLabel={item}
+                  accessibilityRole="menuitem"
+                >
+                  <Text style={[styles.hourItemText, item === value && styles.hourItemTextActive]}>
+                    {item}
+                  </Text>
+                  {item === value && <Check size={16} color={colors.primary[600]} />}
+                </TouchableOpacity>
+              )}
+            />
+          </View>
+        </TouchableOpacity>
+      </Modal>
+    </>
+  )
 }
 
 export default function NotificationPreferencesScreen({ navigation }) {
-  const { supabase, user } = useAuth()
+  const { user } = useAuth()
   const { settings, loading: settingsLoading, refresh } = useProfile()
-  const [preference, setPreference] = useState(null)
-  const [hasPermission, setHasPermission] = useState(false)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState(null)
 
-  // Sincronizar preferência com servidor ao carregar
+  const [globalEnabled, setGlobalEnabled] = useState(true)
+  const [mobilePushEnabled, setMobilePushEnabled] = useState(true)
+  const [telegramEnabled, setTelegramEnabled] = useState(false)
+  const [webPushEnabled, setWebPushEnabled] = useState(false)
+  const [notificationMode, setNotificationMode] = useState('realtime')
+  const [quietHoursEnabled, setQuietHoursEnabled] = useState(false)
+  const [quietHoursStart, setQuietHoursStart] = useState('22:00')
+  const [quietHoursEnd, setQuietHoursEnd] = useState('07:00')
+  const [digestTime, setDigestTime] = useState('07:00')
+  const [hasPermission, setHasPermission] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  // Carregar valores do banco ao montar
   useEffect(() => {
-    if (__DEV__) console.log('[NotificationPreferencesScreen] settings atualizado:', settings)
-    if (settings?.notification_preference) {
-      if (__DEV__) console.log('[NotificationPreferencesScreen] Sincronizando preferência do servidor:', settings.notification_preference)
-      setPreference(settings.notification_preference)
-    }
+    if (__DEV__) console.log('[NotificationPreferencesScreen] settings:', settings)
+    if (!settings) return
+
+    const pref = settings.notification_preference
+    setMobilePushEnabled(
+      settings.channel_mobile_push_enabled ??
+      (pref === 'mobile_push' || pref === 'both')
+    )
+    setTelegramEnabled(
+      settings.channel_telegram_enabled ??
+      (pref === 'telegram' || pref === 'both')
+    )
+    setWebPushEnabled(settings.channel_web_push_enabled ?? false)
+    setNotificationMode(settings.notification_mode ?? 'realtime')
+    setQuietHoursEnabled(!!(settings.quiet_hours_start || settings.quiet_hours_end))
+    setQuietHoursStart(settings.quiet_hours_start ?? '22:00')
+    setQuietHoursEnd(settings.quiet_hours_end ?? '07:00')
+    setDigestTime(settings.digest_time ?? '07:00')
+
+    // globalEnabled = desabilitado apenas quando todos canais off e pref='none'
+    const allOff = pref === 'none' &&
+      !settings.channel_mobile_push_enabled &&
+      !settings.channel_telegram_enabled
+    setGlobalEnabled(!allOff)
   }, [settings])
 
   useEffect(() => {
-    checkPermissionStatus()
+    checkPermission()
   }, [])
 
-  async function checkPermissionStatus() {
+  async function checkPermission() {
     try {
       const { granted } = await requestPushPermission()
       setHasPermission(granted)
     } catch (err) {
-      if (__DEV__) console.warn('[NotificationPreferencesScreen] Erro ao verificar permissão:', err)
+      if (__DEV__) console.warn('[NotificationPreferencesScreen] Erro permissão:', err)
     }
   }
 
-  async function handlePreferenceChange(newPreference) {
-    if (newPreference === preference) return
+  const isTelegramConnected = !!settings?.telegram_chat_id
+  const hasAnyChannel = mobilePushEnabled || telegramEnabled || webPushEnabled
+  const showChannelWarning = globalEnabled && !hasAnyChannel
 
-    if (newPreference === 'mobile_push' && !hasPermission) {
-      Alert.alert(
-        'Permissão Necessária',
-        'Para receber notificações do app, é preciso ativar a permissão no sistema.',
-        [
-          { text: 'Cancelar', style: 'cancel' },
-          {
-            text: 'Ativar',
-            onPress: async () => {
-              const { granted } = await requestPushPermission()
-              if (granted) {
-                setHasPermission(true)
-                await savePushPreference(newPreference)
-              } else {
-                Alert.alert(
-                  'Permissão Negada',
-                  'Abrir Configurações para ativar notificações?',
-                  [
-                    { text: 'Cancelar', style: 'cancel' },
-                    {
-                      text: 'Abrir Configurações',
-                      onPress: () => Linking.openSettings(),
-                    },
-                  ]
-                )
-              }
-            },
-          },
-        ]
-      )
-      return
-    }
-
-    if (newPreference === 'both' && !hasPermission) {
-      Alert.alert(
-        'Permissão Necessária',
-        'A opção "Ambos" requer ativar notificações do app.',
-        [
-          { text: 'Cancelar', style: 'cancel' },
-          {
-            text: 'Ativar',
-            onPress: async () => {
-              const { granted } = await requestPushPermission()
-              if (granted) {
-                setHasPermission(true)
-                await savePushPreference(newPreference)
-              }
-            },
-          },
-        ]
-      )
-      return
-    }
-
-    await savePushPreference(newPreference)
-  }
-
-  async function savePushPreference(newPreference) {
-    setLoading(true)
-    setError(null)
+  // Salvar no banco (debounce manual: chama após cada alteração)
+  const persist = useCallback(async (patch) => {
+    if (!user?.id) return
+    setSaving(true)
     try {
-      if (__DEV__) console.log('[NotificationPreferencesScreen] Salvando preferência:', newPreference, 'para user:', user.id)
+      const mobile = patch.mobilePushEnabled ?? mobilePushEnabled
+      const telegram = patch.telegramEnabled ?? telegramEnabled
+      const mode = patch.notificationMode ?? notificationMode
+      const qEnabled = patch.quietHoursEnabled ?? quietHoursEnabled
+      const qStart = patch.quietHoursStart ?? quietHoursStart
+      const qEnd = patch.quietHoursEnd ?? quietHoursEnd
+      const dTime = patch.digestTime ?? digestTime
+      const global = patch.globalEnabled ?? globalEnabled
 
-      const { error: updateError } = await supabase
-        .from('user_settings')
-        .update({ notification_preference: newPreference })
-        .eq('user_id', user.id)
+      await updateNotificationSettings(user.id, {
+        notification_mode: mode,
+        quiet_hours_start: (global && qEnabled) ? qStart : null,
+        quiet_hours_end: (global && qEnabled) ? qEnd : null,
+        digest_time: dTime,
+        channel_mobile_push_enabled: global && mobile,
+        channel_web_push_enabled: global && webPushEnabled,
+        channel_telegram_enabled: global && telegram,
+        notification_preference: deriveLegacyPreference(global && mobile, global && telegram),
+      })
 
-      if (updateError) throw updateError
-
-      if (__DEV__) console.log('[NotificationPreferencesScreen] Preferência salva no banco com sucesso')
-
-      setPreference(newPreference)
-
-      // Se selecionou push (mobile_push ou both), sincronizar device
-      if ((newPreference === 'mobile_push' || newPreference === 'both') && hasPermission) {
-        try {
-          const token = await getExpoPushToken()
-          await syncNotificationDevice({ supabase, userId: user.id, token })
-        } catch (syncErr) {
-          if (__DEV__) console.warn('[NotificationPreferencesScreen] Erro ao sincronizar device:', syncErr)
-          // não falhar se sync falhar — preferência foi salva
-        }
-      }
-
-      Alert.alert('Preferência Atualizada', `Notificações: ${PREFERENCE_LABELS[newPreference]}`)
-
-      // Recarregar dados do servidor para confirmar persistência
-      if (__DEV__) console.log('[NotificationPreferencesScreen] Refetchando dados do servidor...')
+      if (__DEV__) console.log('[NotificationPreferencesScreen] Configurações salvas')
       await refresh()
     } catch (err) {
-      if (__DEV__) console.error('[NotificationPreferencesScreen] Erro ao salvar preferência:', err)
-      setError(err.message)
-      Alert.alert('Erro', 'Não foi possível salvar a preferência: ' + err.message)
+      if (__DEV__) console.error('[NotificationPreferencesScreen] Erro ao salvar:', err)
+      Alert.alert('Erro', 'Não foi possível salvar as preferências: ' + err.message)
     } finally {
-      setLoading(false)
+      setSaving(false)
     }
+  }, [user, mobilePushEnabled, telegramEnabled, webPushEnabled, notificationMode,
+      quietHoursEnabled, quietHoursStart, quietHoursEnd, digestTime, globalEnabled])
+
+  async function handleMobilePushToggle(val) {
+    if (val && !hasPermission) {
+      const { granted } = await requestPushPermission()
+      if (!granted) {
+        Alert.alert(
+          'Permissão necessária',
+          'Abrir Configurações para ativar notificações?',
+          [
+            { text: 'Cancelar', style: 'cancel' },
+            { text: 'Abrir Configurações', onPress: () => Linking.openSettings() },
+          ]
+        )
+        return
+      }
+      setHasPermission(true)
+      try {
+        const token = await getExpoPushToken()
+        await syncNotificationDevice({ supabase: user?.supabase, userId: user.id, token })
+      } catch (syncErr) {
+        if (__DEV__) console.warn('[NotificationPreferencesScreen] Erro sync device:', syncErr)
+      }
+    }
+    setMobilePushEnabled(val)
+    persist({ mobilePushEnabled: val })
   }
 
-  const getIcon = (value, isDangerous) => {
-    const iconProps = { size: 20, strokeWidth: 2, style: { marginRight: spacing[2] } }
-    let iconColor = colors.primary[600]
-
-    if (isDangerous) {
-      iconColor = colors.status.error
-    } else if (preference === value) {
-      iconColor = colors.text.inverse
-    }
-
-    switch (value) {
-      case 'telegram':
-        return <Send {...iconProps} color={iconColor} />
-      case 'mobile_push':
-        return <MessageSquareDot {...iconProps} color={iconColor} />
-      case 'both':
-        return <TrendingUpDown {...iconProps} color={iconColor} />
-      case 'none':
-        return <MessageSquareOff {...iconProps} color={iconColor} />
-      default:
-        return null
-    }
+  function handleGlobalToggle(val) {
+    setGlobalEnabled(val)
+    persist({ globalEnabled: val })
   }
 
-  const PreferenceButton = ({ value, isDangerous }) => {
-    const isActive = preference === value
-    const isDeactivateButton = isDangerous
-
-    return (
-      <TouchableOpacity
-        style={[
-          styles.button,
-          isActive && styles.buttonActive,
-          isDeactivateButton && styles.buttonDeactivate,
-        ]}
-        onPress={() => handlePreferenceChange(value)}
-        disabled={loading}
-        activeOpacity={0.7}
-      >
-        <View style={styles.buttonContent}>
-          {getIcon(value, isDangerous)}
-          <Text style={[
-            styles.buttonText,
-            isActive && !isDeactivateButton && styles.buttonTextActive,
-            isDeactivateButton && styles.buttonDeactivateText,
-          ]}>
-            {PREFERENCE_LABELS[value]}
-          </Text>
-        </View>
-      </TouchableOpacity>
-    )
+  function handleModeSelect(mode) {
+    setNotificationMode(mode)
+    persist({ notificationMode: mode })
   }
+
+  function handleQuietHoursToggle(val) {
+    setQuietHoursEnabled(val)
+    persist({ quietHoursEnabled: val })
+  }
+
+  function handleTelegramPress() {
+    navigation.navigate(ROUTES.TELEGRAM_LINK)
+  }
+
+  // ── Seções de UI ──────────────────────────────────────────────────────────
+
+  const MODES = [
+    { value: 'realtime', label: 'Tempo real' },
+    { value: 'digest_morning', label: 'Resumo matinal' },
+    { value: 'silent', label: 'Silencioso' },
+  ]
 
   return (
     <ScreenContainer>
-      <ScrollView contentContainerStyle={styles.scrollContent}>
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+
+        {/* Header */}
         <View style={styles.header}>
-          <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backButton}>
+          <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backButton} accessibilityLabel="Voltar">
             <Text style={styles.backButtonText}>← Voltar</Text>
           </TouchableOpacity>
-          <Text style={styles.headerTitle}>Preferências de Notificação</Text>
+          <Text style={styles.title}>Preferências</Text>
+          <Text style={styles.subtitle}>Escolha onde e quando ser avisado.</Text>
         </View>
 
-        {/* Pre-prompt */}
-        {!hasPermission && (
-          <View style={styles.section}>
-            <Text style={styles.sectionTitle}>Habilitar Notificações</Text>
-            <View style={styles.card}>
-              <Text style={styles.descriptionText}>
-                Receba lembretes sobre seus medicamentos em tempo real. Você pode escolher receber via Telegram,
-                notificação do app, ou ambas.
+        {/* Global toggle */}
+        <View style={[styles.card, styles.globalRow]}>
+          <View style={styles.rowLeft}>
+            <Bell size={20} color={globalEnabled ? colors.primary[600] : colors.text.muted} strokeWidth={2} />
+            <Text style={styles.rowLabel}>Notificações ativas</Text>
+          </View>
+          <Switch
+            value={globalEnabled}
+            onValueChange={handleGlobalToggle}
+            trackColor={{ false: colors.neutral[200], true: colors.primary[500] }}
+            thumbColor={colors.bg.card}
+            accessibilityLabel="Ativar ou desativar todas as notificações"
+          />
+        </View>
+
+        {/* Canais */}
+        <Text style={styles.sectionLabel}>CANAIS</Text>
+        <View style={styles.card}>
+
+          {/* App push */}
+          <View style={styles.channelRow}>
+            <View style={styles.rowLeft}>
+              <Smartphone size={20} color={colors.primary[600]} strokeWidth={2} />
+              <Text style={styles.rowLabel}>App (push)</Text>
+            </View>
+            <Switch
+              value={mobilePushEnabled && globalEnabled}
+              onValueChange={handleMobilePushToggle}
+              disabled={!globalEnabled}
+              trackColor={{ false: colors.neutral[200], true: colors.primary[500] }}
+              thumbColor={colors.bg.card}
+              accessibilityLabel="Ativar notificações push do aplicativo"
+            />
+          </View>
+
+          <View style={styles.divider} />
+
+          {/* Telegram */}
+          <TouchableOpacity style={styles.channelRow} onPress={handleTelegramPress} activeOpacity={0.7} accessibilityLabel="Configurar Telegram">
+            <View style={styles.rowLeft}>
+              <Send size={20} color={colors.primary[600]} strokeWidth={2} />
+              <Text style={styles.rowLabel}>Telegram</Text>
+            </View>
+            <View style={styles.rowRight}>
+              <View style={[styles.badge, isTelegramConnected ? styles.badgeConnected : styles.badgeDisconnected]}>
+                <Text style={[styles.badgeText, isTelegramConnected ? styles.badgeTextConnected : styles.badgeTextDisconnected]}>
+                  {isTelegramConnected ? 'CONECTADO' : 'DESCONECTADO'}
+                </Text>
+              </View>
+              <ChevronRight size={16} color={colors.text.muted} />
+            </View>
+          </TouchableOpacity>
+
+          <View style={styles.divider} />
+
+          {/* Web PWA — informativo */}
+          <View style={[styles.channelRow, styles.rowDisabled]} pointerEvents="none">
+            <View style={styles.rowLeft}>
+              <Globe size={20} color={colors.text.muted} strokeWidth={2} />
+              <View>
+                <Text style={[styles.rowLabel, { color: colors.text.secondary }]}>Web (PWA)</Text>
+                <Text style={styles.rowHint}>Configure pelo navegador</Text>
+              </View>
+            </View>
+            <View style={[styles.badge, styles.badgeDisconnected]}>
+              <Text style={[styles.badgeText, styles.badgeTextDisconnected]}>
+                {webPushEnabled ? 'ATIVO' : 'INATIVO'}
               </Text>
             </View>
           </View>
-        )}
 
-        {/* Status atual da preferência — 3 estados com cores diferentes */}
-        {preference === 'none' && (
-          <View style={[styles.statusBadge, styles.statusBadgeDisabled]}>
-            <Text style={[styles.statusText, styles.statusTextDisabled]}>✓ Notificações desativadas</Text>
-          </View>
-        )}
+          <View style={styles.divider} />
 
-        {hasPermission && preference && preference !== 'none' && (
-          <View style={[styles.statusBadge, styles.statusBadgeEnabled]}>
-            <Text style={[styles.statusText, styles.statusTextEnabled]}>✓ Notificações habilitadas</Text>
-          </View>
-        )}
-
-        {!hasPermission && preference !== 'none' && (
-          <View style={[styles.statusBadge, styles.statusBadgeUnauthorized]}>
-            <Text style={[styles.statusText, styles.statusTextUnauthorized]}>⚠ Permissão não concedida</Text>
-          </View>
-        )}
-
-        {/* Seletor de preferência */}
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Escolha como receber notificações</Text>
-          <View style={styles.buttonsContainer}>
-            <PreferenceButton value="telegram" />
-            <PreferenceButton value="mobile_push" />
-            <PreferenceButton value="both" />
+          {/* Email — em breve */}
+          <View style={[styles.channelRow, { opacity: 0.4 }]} pointerEvents="none">
+            <View style={styles.rowLeft}>
+              <Mail size={20} color={colors.text.muted} strokeWidth={2} />
+              <Text style={styles.rowLabel}>Email</Text>
+            </View>
+            <View style={[styles.badge, styles.badgeDisconnected]}>
+              <Text style={[styles.badgeText, styles.badgeTextDisconnected]}>EM BREVE</Text>
+            </View>
           </View>
         </View>
 
-        {/* Botão desativar separado */}
-        <View style={styles.section}>
-          <PreferenceButton value="none" isDangerous />
+        {/* Aviso canal mínimo */}
+        {showChannelWarning && (
+          <Text style={styles.channelWarning}>
+            Ative ao menos um canal para receber lembretes de dose.
+          </Text>
+        )}
+
+        {/* Modo de envio */}
+        <Text style={styles.sectionLabel}>MODO DE ENVIO</Text>
+        <View style={styles.card}>
+          {MODES.map((m, idx) => (
+            <React.Fragment key={m.value}>
+              <TouchableOpacity
+                style={styles.modeRow}
+                onPress={() => handleModeSelect(m.value)}
+                disabled={!globalEnabled}
+                activeOpacity={0.7}
+                accessibilityLabel={`Modo: ${m.label}`}
+                accessibilityRole="radio"
+                accessibilityState={{ checked: notificationMode === m.value }}
+              >
+                <View style={[styles.radio, notificationMode === m.value && styles.radioActive]}>
+                  {notificationMode === m.value && <View style={styles.radioDot} />}
+                </View>
+                <Text style={[styles.rowLabel, !globalEnabled && { color: colors.text.muted }]}>
+                  {m.label}
+                </Text>
+              </TouchableOpacity>
+              {idx < MODES.length - 1 && <View style={styles.divider} />}
+            </React.Fragment>
+          ))}
         </View>
 
-        {/* Botão para abrir Configurações (se permissão negada) */}
-        {!hasPermission && (
-          <View style={styles.section}>
-            <TouchableOpacity
-              style={styles.settingsButton}
-              onPress={() => Linking.openSettings()}
-              activeOpacity={0.7}
-            >
-              <Text style={styles.settingsButtonText}>Abrir Configurações do Dispositivo</Text>
-            </TouchableOpacity>
-            <Text style={styles.settingsHint}>
-              Navegue para Aplicativos › Dosiq › Notificações e ative as notificações.
-            </Text>
+        {/* Hora do resumo — só quando digest_morning */}
+        {notificationMode === 'digest_morning' && globalEnabled && (
+          <>
+            <Text style={styles.sectionLabel}>HORA DO RESUMO</Text>
+            <View style={[styles.card, styles.timeRow]}>
+              <Text style={styles.rowLabel}>Enviar resumo às</Text>
+              <TimePicker
+                value={digestTime}
+                label="Hora do resumo"
+                onChange={(v) => { setDigestTime(v); persist({ digestTime: v }) }}
+              />
+            </View>
+          </>
+        )}
+
+        {/* Não me incomode */}
+        <Text style={styles.sectionLabel}>NÃO ME INCOMODE</Text>
+        <View style={[styles.card, styles.globalRow]}>
+          <Text style={[styles.rowLabel, !globalEnabled && { color: colors.text.muted }]}>
+            Silenciar por período
+          </Text>
+          <Switch
+            value={quietHoursEnabled && globalEnabled}
+            onValueChange={handleQuietHoursToggle}
+            disabled={!globalEnabled}
+            trackColor={{ false: colors.neutral[200], true: colors.primary[500] }}
+            thumbColor={colors.bg.card}
+            accessibilityLabel="Ativar horas de silêncio"
+          />
+        </View>
+
+        {quietHoursEnabled && globalEnabled && (
+          <View style={[styles.card, styles.timeRow]}>
+            <Text style={styles.rowLabel}>Das</Text>
+            <TimePicker
+              value={quietHoursStart}
+              label="Início do silêncio"
+              onChange={(v) => { setQuietHoursStart(v); persist({ quietHoursStart: v }) }}
+            />
+            <Text style={styles.rowLabel}>às</Text>
+            <TimePicker
+              value={quietHoursEnd}
+              label="Fim do silêncio"
+              onChange={(v) => { setQuietHoursEnd(v); persist({ quietHoursEnd: v }) }}
+            />
           </View>
         )}
 
-        {error && (
-          <View style={styles.errorContainer}>
-            <Text style={styles.errorText}>Erro: {error}</Text>
-          </View>
-        )}
+        <View style={{ height: spacing[8] }} />
       </ScrollView>
     </ScreenContainer>
   )
@@ -287,13 +432,10 @@ export default function NotificationPreferencesScreen({ navigation }) {
 
 const styles = StyleSheet.create({
   scrollContent: {
-    paddingVertical: spacing[6],
     paddingHorizontal: spacing[4],
+    paddingVertical: spacing[6],
   },
   header: {
-    padding: spacing[4],
-    borderBottomWidth: 1,
-    borderBottomColor: colors.border.light,
     marginBottom: spacing[6],
   },
   backButton: {
@@ -304,128 +446,209 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
   },
-  headerTitle: {
-    fontSize: 24,
+  title: {
+    fontSize: 26,
     fontWeight: '700',
     color: colors.text.primary,
+    marginBottom: spacing[1],
   },
-  section: {
-    marginBottom: spacing[6],
+  subtitle: {
+    fontSize: 14,
+    color: colors.text.muted,
+    lineHeight: 20,
   },
-  sectionTitle: {
-    fontSize: 16,
+
+  // Section label
+  sectionLabel: {
+    fontSize: 11,
     fontWeight: '600',
-    color: colors.text.secondary,
+    color: colors.text.muted,
+    letterSpacing: 0.8,
     marginBottom: spacing[2],
+    marginTop: spacing[5],
     marginLeft: spacing[1],
   },
+
+  // Card container
   card: {
     backgroundColor: colors.bg.card,
     borderRadius: borderRadius.md,
+    ...shadows.sm,
+    overflow: 'hidden',
+  },
+
+  divider: {
+    height: 1,
+    backgroundColor: colors.border.light,
+    marginHorizontal: spacing[4],
+  },
+
+  // Rows
+  globalRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
     padding: spacing[4],
   },
-  descriptionText: {
-    fontSize: 14,
-    lineHeight: 20,
-    color: colors.text.secondary,
+  channelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[4],
+    minHeight: 56,
   },
-  statusBadge: {
-    borderRadius: borderRadius.md,
-    padding: spacing[4],
-    marginBottom: spacing[6],
-    borderLeftWidth: 4,
+  rowDisabled: {
+    opacity: 0.6,
   },
-  statusBadgeEnabled: {
-    backgroundColor: colors.status.success + '20',
-    borderLeftColor: colors.status.success,
+  rowLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    flex: 1,
   },
-  statusBadgeDisabled: {
-    backgroundColor: colors.text.secondary + '15',
-    borderLeftColor: colors.text.secondary,
+  rowRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
   },
-  statusBadgeUnauthorized: {
-    backgroundColor: colors.status.error + '20',
-    borderLeftColor: colors.status.error,
-  },
-  statusText: {
-    fontSize: 12,
+  rowLabel: {
+    fontSize: 15,
     fontWeight: '500',
+    color: colors.text.primary,
   },
-  statusTextEnabled: {
+  rowHint: {
+    fontSize: 12,
+    color: colors.text.muted,
+    marginTop: 2,
+  },
+
+  // Badges
+  badge: {
+    borderRadius: borderRadius.full,
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+  },
+  badgeConnected: {
+    backgroundColor: colors.status.success + '22',
+  },
+  badgeDisconnected: {
+    backgroundColor: colors.neutral[200],
+  },
+  badgeText: {
+    fontSize: 10,
+    fontWeight: '700',
+    letterSpacing: 0.4,
+  },
+  badgeTextConnected: {
     color: colors.status.success,
   },
-  statusTextDisabled: {
-    color: colors.text.secondary,
+  badgeTextDisconnected: {
+    color: colors.text.muted,
   },
-  statusTextUnauthorized: {
+
+  // Aviso canal mínimo
+  channelWarning: {
+    fontSize: 12,
     color: colors.status.error,
+    marginTop: spacing[2],
+    marginLeft: spacing[1],
   },
-  buttonsContainer: {
-    gap: spacing[3],
-  },
-  button: {
-    paddingVertical: spacing[4],
-    paddingHorizontal: spacing[6],
-    borderRadius: borderRadius.md,
-    borderWidth: 2,
-    borderColor: colors.border.default,
-    backgroundColor: colors.bg.screen,
-    alignItems: 'center',
-  },
-  buttonActive: {
-    backgroundColor: colors.primary[600],
-    borderColor: colors.primary[600],
-  },
-  buttonDeactivate: {
-    backgroundColor: colors.bg.card,
-    borderColor: colors.status.error + '50',
-  },
-  buttonContent: {
+
+  // Modo radio
+  modeRow: {
     flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[4],
+    minHeight: 52,
+  },
+  radio: {
+    width: 20,
+    height: 20,
+    borderRadius: borderRadius.full,
+    borderWidth: 2,
+    borderColor: colors.neutral[300],
     alignItems: 'center',
     justifyContent: 'center',
   },
-  buttonText: {
+  radioActive: {
+    borderColor: colors.primary[600],
+  },
+  radioDot: {
+    width: 10,
+    height: 10,
+    borderRadius: borderRadius.full,
+    backgroundColor: colors.primary[600],
+  },
+
+  // Time picker row
+  timeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    gap: spacing[3],
+    flexWrap: 'wrap',
+  },
+  timePickerButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+    backgroundColor: colors.neutral[100],
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    borderRadius: borderRadius.sm,
+  },
+  timePickerValue: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.primary[600],
+  },
+
+  // Modal
+  modalBackdrop: {
+    flex: 1,
+    backgroundColor: colors.bg.overlay,
+    justifyContent: 'flex-end',
+  },
+  modalSheet: {
+    backgroundColor: colors.bg.card,
+    borderTopLeftRadius: borderRadius.xl,
+    borderTopRightRadius: borderRadius.xl,
+    paddingTop: spacing[4],
+    maxHeight: 360,
+  },
+  modalTitle: {
     fontSize: 14,
     fontWeight: '600',
+    color: colors.text.secondary,
+    textAlign: 'center',
+    marginBottom: spacing[2],
+    paddingHorizontal: spacing[4],
+  },
+  hourList: {
+    maxHeight: 300,
+  },
+  hourItem: {
+    height: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing[6],
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border.light,
+  },
+  hourItemActive: {
+    backgroundColor: colors.primary[50],
+  },
+  hourItemText: {
+    fontSize: 16,
     color: colors.text.primary,
   },
-  buttonTextActive: {
-    color: colors.text.inverse,
-  },
-  buttonDeactivateText: {
-    color: colors.status.error,
+  hourItemTextActive: {
     fontWeight: '700',
-    fontSize: 16,
-  },
-  settingsButton: {
-    paddingVertical: spacing[4],
-    paddingHorizontal: spacing[6],
-    borderRadius: borderRadius.md,
-    backgroundColor: colors.primary[500],
-    alignItems: 'center',
-    marginBottom: spacing[3],
-  },
-  settingsButtonText: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: colors.text.inverse,
-  },
-  settingsHint: {
-    fontSize: 12,
-    color: colors.text.secondary,
-    lineHeight: 18,
-  },
-  errorContainer: {
-    backgroundColor: colors.status.error + '20',
-    borderRadius: borderRadius.md,
-    padding: spacing[4],
-    marginTop: spacing[6],
-    borderLeftWidth: 4,
-    borderLeftColor: colors.status.error,
-  },
-  errorText: {
-    fontSize: 12,
-    color: colors.status.error,
+    color: colors.primary[600],
   },
 })

--- a/apps/mobile/src/features/profile/screens/ProfileScreen.jsx
+++ b/apps/mobile/src/features/profile/screens/ProfileScreen.jsx
@@ -1,11 +1,10 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView, RefreshControl, Alert } from 'react-native'
 import { useNavigation } from '@react-navigation/native'
-import { Bell } from 'lucide-react-native'
+import { Bell, ChevronRight } from 'lucide-react-native'
 import Constants from 'expo-constants'
 import { useProfile } from '../hooks/useProfile'
 import { logoutUser } from '../services/profileService'
-import TelegramLinkCard from '../components/TelegramLinkCard'
 import ScreenContainer from '../../../shared/components/ui/ScreenContainer'
 import LoadingState from '../../../shared/components/states/LoadingState'
 import { colors, spacing, borderRadius, shadows, typography } from '../../../shared/styles/tokens'
@@ -19,8 +18,7 @@ import { useUnreadNotificationCount } from '../../../shared/hooks/useUnreadNotif
  */
 export default function ProfileScreen() {
   const navigation = useNavigation()
-  const { user, settings, loading, error, refresh, generateToken } = useProfile()
-  const [isGenerating, setIsGenerating] = useState(false)
+  const { user, loading, error, refresh } = useProfile()
 
   const { data: notifData } = useNotificationLog({ userId: user?.id, limit: 30, enabled: !!user?.id })
   const { unreadCount } = useUnreadNotificationCount(notifData, user?.id)
@@ -31,8 +29,8 @@ export default function ProfileScreen() {
       'Tem certeza que deseja sair?',
       [
         { text: 'Cancelar', style: 'cancel' },
-        { 
-          text: 'Sair', 
+        {
+          text: 'Sair',
           style: 'destructive',
           onPress: async () => {
             const { success, error: logoutErr } = await logoutUser()
@@ -43,18 +41,6 @@ export default function ProfileScreen() {
         }
       ]
     )
-  }
-
-  const handleGenerateToken = async () => {
-    setIsGenerating(true)
-    try {
-      await generateToken()
-    } catch (err) {
-      if (__DEV__) console.error('Erro ao gerar token:', err)
-      Alert.alert('Erro', 'Não foi possível gerar o código: ' + err.message)
-    } finally {
-      setIsGenerating(false)
-    }
   }
 
   if (loading) {
@@ -83,7 +69,7 @@ export default function ProfileScreen() {
         </View>
 
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Minha Conta</Text>
+          <Text style={styles.sectionTitle}>MINHA CONTA</Text>
           <View style={styles.card}>
             <View style={styles.infoRow}>
               <Text style={styles.label}>Email</Text>
@@ -99,47 +85,54 @@ export default function ProfileScreen() {
         </View>
 
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Notificações</Text>
+          <Text style={styles.sectionTitle}>AVISOS & LEMBRETES</Text>
           <TouchableOpacity
             style={styles.card}
-            onPress={() => navigation.navigate(ROUTES.NOTIFICATION_PREFERENCES)}
-            activeOpacity={0.7}
-          >
-            <View style={styles.notificationRow}>
-              <Bell size={20} color={colors.primary[600]} strokeWidth={1.5} />
-              <Text style={styles.notificationLabel}>Preferências de Notificação</Text>
-              <Text style={styles.arrow}>›</Text>
-            </View>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            style={[styles.card, { marginTop: spacing[2] }]}
             onPress={() => navigation.navigate(ROUTES.NOTIFICATION_INBOX, { userId: user?.id })}
             activeOpacity={0.7}
           >
             <View style={styles.notificationRow}>
               <Bell size={20} color={colors.primary[600]} strokeWidth={1.5} />
-              <Text style={styles.notificationLabel}>Central de Avisos</Text>
+              <View style={styles.notificationTextGroup}>
+                <Text style={styles.notificationLabel}>Notificações</Text>
+                <Text style={styles.notificationSubtitle}>Avisos, preferências e canais</Text>
+              </View>
               {unreadCount > 0 && (
                 <View style={styles.inboxBadge}>
                   <Text style={styles.inboxBadgeText}>{unreadCount > 9 ? '9+' : unreadCount}</Text>
                 </View>
               )}
-              <Text style={styles.arrow}>›</Text>
+              <ChevronRight size={18} color={colors.text.secondary} strokeWidth={1.5} />
             </View>
           </TouchableOpacity>
         </View>
 
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Bot Telegram</Text>
-          <TelegramLinkCard
-            settings={settings}
-          />
+          <Text style={styles.sectionTitle}>OUTROS</Text>
+          <View style={styles.card}>
+            <TouchableOpacity
+              style={styles.otherRow}
+              onPress={() => {}}
+              activeOpacity={0.7}
+            >
+              <Text style={styles.otherLabel}>Privacidade & dados</Text>
+              <ChevronRight size={18} color={colors.text.secondary} strokeWidth={1.5} />
+            </TouchableOpacity>
+            <View style={styles.otherDivider} />
+            <TouchableOpacity
+              style={styles.otherRow}
+              onPress={() => {}}
+              activeOpacity={0.7}
+            >
+              <Text style={styles.otherLabel}>Sobre o Dosiq</Text>
+              <ChevronRight size={18} color={colors.text.secondary} strokeWidth={1.5} />
+            </TouchableOpacity>
+          </View>
         </View>
 
         <View style={styles.logoutSection}>
-          <TouchableOpacity 
-            style={styles.logoutButton} 
+          <TouchableOpacity
+            style={styles.logoutButton}
             onPress={handleLogout}
             activeOpacity={0.7}
           >
@@ -183,11 +176,12 @@ const styles = StyleSheet.create({
     marginBottom: spacing[6],
   },
   sectionTitle: {
-    fontSize: 16,
-    fontWeight: '600',
+    fontSize: 12,
+    fontWeight: '700',
     color: colors.text.secondary,
     marginBottom: spacing[2],
     paddingHorizontal: 20,
+    letterSpacing: 0.8,
   },
   card: {
     backgroundColor: colors.bg.card,
@@ -248,15 +242,33 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: spacing[3],
   },
-  notificationLabel: {
+  notificationTextGroup: {
     flex: 1,
+    gap: 2,
+  },
+  notificationLabel: {
     fontSize: 16,
     color: colors.text.primary,
     fontWeight: '500',
   },
-  arrow: {
-    fontSize: 20,
+  notificationSubtitle: {
+    fontSize: 12,
     color: colors.text.secondary,
+  },
+  otherRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing[3],
+  },
+  otherLabel: {
+    fontSize: 16,
+    color: colors.text.primary,
+    fontWeight: '500',
+  },
+  otherDivider: {
+    height: 1,
+    backgroundColor: colors.border.light,
   },
   inboxBadge: {
     minWidth: 20,

--- a/apps/mobile/src/features/profile/screens/TelegramLinkScreen.jsx
+++ b/apps/mobile/src/features/profile/screens/TelegramLinkScreen.jsx
@@ -5,14 +5,15 @@ import ScreenContainer from '../../../shared/components/ui/ScreenContainer'
 import { colors, spacing, borderRadius, shadows } from '../../../shared/styles/tokens'
 
 /**
- * Tela de vinculação do Telegram (H5.7)
- * Exibe as instruções de vinculação e gera o token de verificação.
+ * Tela de vinculação do Telegram — Sprint 2.7 Wave N2 Redesign
+ * Fluxo visual: Passo 1 (Abrir bot) → Passo 2 (Enviar código) → Status conectado
  */
 export default function TelegramLinkScreen({ navigation }) {
   const { settings, generateToken } = useProfile()
   const [isGenerating, setIsGenerating] = useState(false)
   const isConnected = !!settings?.telegram_chat_id
   const token = settings?.verification_token
+  const chatIdMasked = isConnected ? String(settings.telegram_chat_id).slice(-4).padStart(7, '*') : null
 
   const handleGenerateToken = async () => {
     setIsGenerating(true)
@@ -36,81 +37,110 @@ export default function TelegramLinkScreen({ navigation }) {
     }
   }
 
+  const handleCopyToken = () => {
+    if (token) {
+      const fullCommand = `/start ${token}`
+      Alert.alert('Código copiado!', fullCommand, [{ text: 'OK' }])
+    }
+  }
+
   return (
     <ScreenContainer>
       <View style={styles.header}>
         <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backButton}>
           <Text style={styles.backButtonText}>← Voltar</Text>
         </TouchableOpacity>
-        <Text style={styles.title}>Integração Telegram</Text>
       </View>
 
       <View style={styles.content}>
         {isConnected ? (
+          // Estado conectado
           <View style={styles.successContainer}>
             <Text style={styles.successIcon}>✅</Text>
-            <Text style={styles.successTitle}>Bot Vinculado!</Text>
+            <Text style={styles.successTitle}>Conectado</Text>
             <Text style={styles.successMessage}>
-              Sua conta já está conectada ao Telegram. Você receberá notificações de medicamentos lá.
+              Sua conta está vinculada ao Telegram. Você receberá lembretes e poderá registrar doses pelo chat.
             </Text>
+            {chatIdMasked && (
+              <View style={styles.chatIdContainer}>
+                <Text style={styles.chatIdLabel}>Chat ID</Text>
+                <Text style={styles.chatIdValue}>{chatIdMasked}</Text>
+              </View>
+            )}
           </View>
         ) : (
+          // Estado não conectado
           <>
-            <Text style={styles.introText}>
-              Vincule sua conta para receber avisos de doses e gerenciar seu estoque diretamente pelo Telegram.
+            {/* Ícone Telegram grande */}
+            <View style={styles.iconContainer}>
+              <Text style={styles.telegramIcon}>📱</Text>
+            </View>
+
+            {/* Título e descrição */}
+            <Text style={styles.mainTitle}>Conectar ao Telegram</Text>
+            <Text style={styles.mainDescription}>
+              Receba lembretes e registre doses direto pelo chat. Vai levar uns 30 segundos.
             </Text>
 
-            {!token ? (
-              <View style={styles.setupContainer}>
-                <Text style={styles.stepTitle}>Para começar:</Text>
-                <Text style={styles.stepDescription}>
-                  Gere um código de vínculo único para autenticar o bot na sua conta com segurança.
-                </Text>
-                <TouchableOpacity 
-                  style={styles.primaryButton} 
+            {/* Passo 1: Abrir bot */}
+            <View style={styles.stepCard}>
+              <View style={styles.stepHeader}>
+                <Text style={styles.stepNumber}>Passo 1</Text>
+              </View>
+              <Text style={styles.stepTitle}>Abra o bot no Telegram</Text>
+              <TouchableOpacity
+                style={styles.telegramButton}
+                onPress={handleOpenBot}
+              >
+                <Text style={styles.telegramButtonText}>Abrir @dosiq_bot</Text>
+              </TouchableOpacity>
+            </View>
+
+            {/* Passo 2: Enviar código */}
+            <View style={styles.stepCard}>
+              <View style={styles.stepHeader}>
+                <Text style={styles.stepNumber}>Passo 2</Text>
+              </View>
+              <Text style={styles.stepTitle}>Envie este código no chat</Text>
+
+              {!token ? (
+                <TouchableOpacity
+                  style={styles.generateButton}
                   onPress={handleGenerateToken}
                   disabled={isGenerating}
                 >
                   {isGenerating ? (
-                    <ActivityIndicator color={colors.text.inverse} />
+                    <ActivityIndicator color={colors.primary[600]} size="small" />
                   ) : (
-                    <Text style={styles.primaryButtonText}>Gerar Código de Vínculo</Text>
+                    <Text style={styles.generateButtonText}>Gerar código</Text>
                   )}
                 </TouchableOpacity>
-              </View>
-            ) : (
-              <View style={styles.tokenContainer}>
-                <Text style={styles.stepTitle}>Próximo Passo:</Text>
-                <Text style={styles.stepDescription}>
-                  Abra o nosso bot no Telegram e envie o comando abaixo:
-                </Text>
-                
-                <View style={styles.codeBox}>
-                  <Text style={styles.codeLabel}>COMANDO:</Text>
-                  <Text style={styles.codeText}>/start {token}</Text>
-                </View>
+              ) : (
+                <>
+                  <View style={styles.codeBox}>
+                    <Text style={styles.codeText}>/start {token}</Text>
+                    <TouchableOpacity style={styles.copyButton} onPress={handleCopyToken}>
+                      <Text style={styles.copyButtonText}>copiar</Text>
+                    </TouchableOpacity>
+                  </View>
+                  <TouchableOpacity
+                    style={styles.regenerateButton}
+                    onPress={handleGenerateToken}
+                    disabled={isGenerating}
+                  >
+                    <Text style={styles.regenerateButtonText}>
+                      {isGenerating ? '...' : 'Gerar novo código'}
+                    </Text>
+                  </TouchableOpacity>
+                </>
+              )}
+            </View>
 
-                <TouchableOpacity 
-                  style={[styles.primaryButton, { backgroundColor: colors.primary[600] }]} 
-                  onPress={handleOpenBot}
-                >
-                  <Text style={styles.primaryButtonText}>Abrir Bot no Telegram</Text>
-                </TouchableOpacity>
-
-                <TouchableOpacity 
-                  style={styles.ghostButton} 
-                  onPress={handleGenerateToken}
-                  disabled={isGenerating}
-                >
-                  <Text style={styles.ghostButtonText}>Gerar novo código</Text>
-                </TouchableOpacity>
-              </View>
-            )}
-            
-            <View style={styles.noteBox}>
-              <Text style={styles.noteTitle}>Nota de privacidade:</Text>
-              <Text style={styles.noteText}>
-                O bot nunca pedirá sua senha. O vínculo é feito através de um token temporário.
+            {/* Nota de segurança */}
+            <View style={styles.securityNote}>
+              <Text style={styles.securityIcon}>🔒</Text>
+              <Text style={styles.securityText}>
+                O bot nunca pede sua senha. O código é temporário e só serve para vincular sua conta.
               </Text>
             </View>
           </>
@@ -122,109 +152,165 @@ export default function TelegramLinkScreen({ navigation }) {
 
 const styles = StyleSheet.create({
   header: {
-    padding: spacing[4],
-    borderBottomWidth: 1,
-    borderBottomColor: colors.border.light,
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
   },
   backButton: {
-    marginBottom: spacing[4],
+    paddingVertical: spacing[2],
   },
   backButtonText: {
     color: colors.primary[600],
     fontSize: 16,
     fontWeight: '600',
   },
-  title: {
-    fontSize: 24,
-    fontWeight: '700',
-    color: colors.text.primary,
-  },
   content: {
-    padding: spacing[6],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[6],
     flex: 1,
   },
-  introText: {
+  // Ícone Telegram grande
+  iconContainer: {
+    alignItems: 'center',
+    marginBottom: spacing[6],
+  },
+  telegramIcon: {
+    fontSize: 64,
+  },
+  // Título e descrição principais
+  mainTitle: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: colors.text.primary,
+    textAlign: 'center',
+    marginBottom: spacing[2],
+  },
+  mainDescription: {
     fontSize: 16,
     color: colors.text.secondary,
+    textAlign: 'center',
     lineHeight: 22,
     marginBottom: spacing[8],
   },
-  setupContainer: {
+  // Cards de passo
+  stepCard: {
     backgroundColor: colors.bg.card,
     borderRadius: borderRadius.lg,
-    padding: spacing[6],
+    padding: spacing[4],
+    marginBottom: spacing[4],
     ...shadows.md,
   },
-  tokenContainer: {
-    backgroundColor: colors.bg.card,
-    borderRadius: borderRadius.lg,
-    padding: spacing[6],
-    ...shadows.md,
+  stepHeader: {
+    marginBottom: spacing[3],
+  },
+  stepNumber: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: colors.text.muted,
+    letterSpacing: 0.5,
   },
   stepTitle: {
-    fontSize: 18,
-    fontWeight: '700',
+    fontSize: 16,
+    fontWeight: '600',
     color: colors.text.primary,
-    marginBottom: spacing[2],
+    marginBottom: spacing[4],
   },
-  stepDescription: {
-    fontSize: 14,
-    color: colors.text.secondary,
-    marginBottom: spacing[6],
-    lineHeight: 20,
-  },
-  primaryButton: {
-    backgroundColor: colors.primary[500],
-    height: 52,
+  // Botão "Abrir bot"
+  telegramButton: {
+    backgroundColor: colors.primary[600],
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[4],
     borderRadius: borderRadius.md,
     alignItems: 'center',
-    justifyContent: 'center',
   },
-  primaryButtonText: {
+  telegramButtonText: {
     color: colors.text.inverse,
-    fontSize: 16,
+    fontSize: 15,
     fontWeight: '700',
   },
+  // Botão "Gerar código"
+  generateButton: {
+    backgroundColor: colors.bg.screen,
+    borderWidth: 2,
+    borderColor: colors.border.default,
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[4],
+    borderRadius: borderRadius.md,
+    alignItems: 'center',
+  },
+  generateButtonText: {
+    color: colors.primary[600],
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  // Code box com copiar
   codeBox: {
     backgroundColor: colors.neutral[900],
-    padding: spacing[4],
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[4],
     borderRadius: borderRadius.md,
-    marginBottom: spacing[6],
+    flexDirection: 'row',
     alignItems: 'center',
-  },
-  codeLabel: {
-    color: colors.text.muted,
-    fontSize: 11,
-    fontWeight: '700',
-    letterSpacing: 1,
-    marginBottom: spacing[1],
+    justifyContent: 'space-between',
+    marginBottom: spacing[3],
   },
   codeText: {
     color: colors.text.inverse,
-    fontSize: 18,
-    fontWeight: '700',
-    letterSpacing: 1,
+    fontSize: 15,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+    flex: 1,
   },
-  ghostButton: {
-    marginTop: spacing[4],
+  copyButton: {
+    paddingVertical: spacing[2],
+    paddingHorizontal: spacing[3],
+    backgroundColor: colors.primary[600],
+    borderRadius: borderRadius.sm,
+  },
+  copyButtonText: {
+    color: colors.text.inverse,
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  // Botão "Gerar novo código"
+  regenerateButton: {
+    paddingVertical: spacing[2],
     alignItems: 'center',
-    padding: spacing[2],
   },
-  ghostButtonText: {
+  regenerateButtonText: {
     color: colors.text.secondary,
     fontSize: 14,
     fontWeight: '600',
+    textDecorationLine: 'underline',
   },
+  // Nota de segurança
+  securityNote: {
+    flexDirection: 'row',
+    backgroundColor: colors.neutral[100],
+    borderRadius: borderRadius.md,
+    padding: spacing[4],
+    marginTop: spacing[2],
+  },
+  securityIcon: {
+    fontSize: 18,
+    marginRight: spacing[3],
+  },
+  securityText: {
+    fontSize: 13,
+    color: colors.text.secondary,
+    lineHeight: 18,
+    flex: 1,
+  },
+  // Estado conectado
   successContainer: {
     alignItems: 'center',
-    paddingTop: spacing[10],
+    paddingVertical: spacing[8],
   },
   successIcon: {
     fontSize: 64,
     marginBottom: spacing[4],
   },
   successTitle: {
-    fontSize: 22,
+    fontSize: 24,
     fontWeight: '700',
     color: colors.status.success,
     marginBottom: spacing[4],
@@ -234,22 +320,28 @@ const styles = StyleSheet.create({
     color: colors.text.secondary,
     textAlign: 'center',
     lineHeight: 22,
+    marginBottom: spacing[6],
   },
-  noteBox: {
-    marginTop: 'auto',
-    backgroundColor: colors.neutral[100],
-    padding: spacing[4],
+  chatIdContainer: {
+    backgroundColor: colors.bg.card,
     borderRadius: borderRadius.md,
+    paddingVertical: spacing[4],
+    paddingHorizontal: spacing[5],
+    marginTop: spacing[6],
+    alignItems: 'center',
+    ...shadows.sm,
   },
-  noteTitle: {
+  chatIdLabel: {
     fontSize: 12,
     fontWeight: '700',
-    color: colors.text.secondary,
-    marginBottom: spacing[1],
-  },
-  noteText: {
-    fontSize: 12,
     color: colors.text.muted,
-    lineHeight: 18,
-  }
+    marginBottom: spacing[1],
+    letterSpacing: 0.5,
+  },
+  chatIdValue: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.text.primary,
+    letterSpacing: 1,
+  },
 })

--- a/apps/mobile/src/features/profile/services/profileService.js
+++ b/apps/mobile/src/features/profile/services/profileService.js
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { userSettingsNotificationSchema } from '@dosiq/core'
 import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
 
 /**
@@ -105,6 +106,11 @@ export async function getUserSettings() {
 export async function updateNotificationSettings(userId, settings) {
   try {
     z.string().uuid().parse(userId)
+
+    const parsed = userSettingsNotificationSchema.partial().safeParse(settings)
+    if (!parsed.success) {
+      throw new Error(parsed.error.errors.map(e => e.message).join(', '))
+    }
 
     const { error } = await supabase
       .from('user_settings')

--- a/apps/mobile/src/features/profile/services/profileService.js
+++ b/apps/mobile/src/features/profile/services/profileService.js
@@ -97,6 +97,38 @@ export async function getUserSettings() {
 }
 
 /**
+ * Atualizar configurações de notificação do utilizador (Sprint N2.6)
+ * @param {string} userId
+ * @param {Object} settings
+ * @returns {Promise<{success: boolean, error: string|null}>}
+ */
+export async function updateNotificationSettings(userId, settings) {
+  try {
+    z.string().uuid().parse(userId)
+
+    const { error } = await supabase
+      .from('user_settings')
+      .upsert({
+        user_id: userId,
+        notification_mode: settings.notification_mode,
+        quiet_hours_start: settings.quiet_hours_start ?? null,
+        quiet_hours_end:   settings.quiet_hours_end   ?? null,
+        digest_time:       settings.digest_time,
+        channel_mobile_push_enabled: settings.channel_mobile_push_enabled,
+        channel_web_push_enabled:    settings.channel_web_push_enabled,
+        channel_telegram_enabled:    settings.channel_telegram_enabled,
+        notification_preference:     settings.notification_preference,
+      }, { onConflict: 'user_id' })
+
+    if (error) throw error
+    return { success: true, error: null }
+  } catch (err) {
+    if (__DEV__) console.error('[profileService] erro ao salvar notificações:', err)
+    return { success: false, error: mapErrorToMessage(err) }
+  }
+}
+
+/**
  * Gerar token de verificação via Supabase RPC (Opção A)
  * @returns {Promise<{token: string|null, error: string|null}>}
  */

--- a/apps/web/src/schemas/userSettingsSchema.js
+++ b/apps/web/src/schemas/userSettingsSchema.js
@@ -1,0 +1,45 @@
+// Schema Zod para user_settings — campos de notificação (Wave N2)
+import { z } from 'zod'
+
+const HH_MM = /^([01]\d|2[0-3]):[0-5]\d$/
+
+export const NOTIFICATION_MODES = ['realtime', 'digest_morning', 'silent']
+
+export const userSettingsNotificationSchema = z.object({
+  notification_preference: z
+    .enum(['telegram', 'mobile_push', 'both', 'none'])
+    .optional(),
+
+  notification_mode: z
+    .enum(['realtime', 'digest_morning', 'silent'])
+    .default('realtime'),
+
+  quiet_hours_start: z
+    .string()
+    .regex(HH_MM, 'Formato HH:MM inválido')
+    .nullable()
+    .optional(),
+
+  quiet_hours_end: z
+    .string()
+    .regex(HH_MM, 'Formato HH:MM inválido')
+    .nullable()
+    .optional(),
+
+  digest_time: z
+    .string()
+    .regex(HH_MM, 'Formato HH:MM inválido')
+    .default('07:00'),
+
+  channel_mobile_push_enabled: z.boolean().default(true),
+  channel_web_push_enabled:    z.boolean().default(false),
+  channel_telegram_enabled:    z.boolean().default(false),
+})
+
+// Derivar notification_preference legado a partir dos booleans de canal
+export function deriveLegacyPreference({ channel_mobile_push_enabled, channel_telegram_enabled }) {
+  if (channel_mobile_push_enabled && channel_telegram_enabled) return 'both'
+  if (channel_mobile_push_enabled) return 'mobile_push'
+  if (channel_telegram_enabled) return 'telegram'
+  return 'none'
+}

--- a/apps/web/src/views/redesign/Settings.jsx
+++ b/apps/web/src/views/redesign/Settings.jsx
@@ -8,10 +8,12 @@ import {
   Wand2,
   Grid3x2,
   LogOut,
+  Bell,
 } from 'lucide-react'
 import { supabase, getUserId } from '@shared/utils/supabase'
 import { useComplexityMode } from '@dashboard/hooks/useComplexityMode'
 import { validatePasswordChange } from '@schemas/authSchema'
+import { webpushService } from '@shared/services/webpushService'
 import Button from '@shared/components/ui/Button'
 import './settings/SettingsRedesign.css'
 
@@ -35,8 +37,19 @@ export default function Settings({ onNavigate }) {
   const [message, setMessage] = useState(null)
   const [error, setError] = useState(null)
 
+  // ═══ Notification States (Wave N2) ═══
+  const [channelWebPushEnabled, setChannelWebPushEnabled] = useState(false)
+  const [notificationMode, setNotificationMode] = useState('realtime')
+  const [quietHoursEnabled, setQuietHoursEnabled] = useState(false)
+  const [quietHoursStart, setQuietHoursStart] = useState('22:00')
+  const [quietHoursEnd, setQuietHoursEnd] = useState('07:00')
+  const [digestTime, setDigestTime] = useState('07:00')
+  const [savingChannel, setSavingChannel] = useState(false)
+  const [savingNotification, setSavingNotification] = useState(false)
+
   // ═══ Hooks ═══
   const { mode: complexityMode, medicineCount, overrideMode, setOverride } = useComplexityMode()
+  const webPushSupported = typeof window !== 'undefined' && 'PushManager' in window
 
   // ═══ Helper Functions ═══
   const showFeedback = useCallback((msg) => {
@@ -64,6 +77,21 @@ export default function Settings({ onNavigate }) {
         setSettings(settingsData ?? {})
         if (settingsData?.telegram_token) {
           setTelegramToken(settingsData.telegram_token)
+        }
+        // Load notification settings
+        if (settingsData?.notification_mode) {
+          setNotificationMode(settingsData.notification_mode)
+        }
+        if (settingsData?.channel_web_push_enabled) {
+          setChannelWebPushEnabled(settingsData.channel_web_push_enabled)
+        }
+        if (settingsData?.quiet_hours_start && settingsData?.quiet_hours_end) {
+          setQuietHoursEnabled(true)
+          setQuietHoursStart(settingsData.quiet_hours_start)
+          setQuietHoursEnd(settingsData.quiet_hours_end)
+        }
+        if (settingsData?.digest_time) {
+          setDigestTime(settingsData.digest_time)
         }
       }
     } catch (err) {
@@ -147,6 +175,113 @@ export default function Settings({ onNavigate }) {
       setError('Erro ao sair: ' + err.message)
     }
   }, [onNavigate])
+
+  const handleToggleWebPush = useCallback(async (e) => {
+    const enabled = e.target.checked
+    setSavingChannel(true)
+    try {
+      const userId = await getUserId()
+      if (enabled) {
+        await webpushService.subscribe()
+      }
+      const { error } = await supabase
+        .from('user_settings')
+        .upsert(
+          {
+            user_id: userId,
+            channel_web_push_enabled: enabled,
+          },
+          { onConflict: 'user_id' }
+        )
+      if (error) throw error
+      setChannelWebPushEnabled(enabled)
+      showFeedback(enabled ? 'Push web ativado' : 'Push web desativado')
+    } catch (err) {
+      console.error('[Settings] webpush toggle error', err)
+      setError('Erro ao configurar push web: ' + err.message)
+    } finally {
+      setSavingChannel(false)
+    }
+  }, [showFeedback])
+
+  const handleModeChange = useCallback(
+    async (mode) => {
+      setSavingNotification(true)
+      try {
+        const userId = await getUserId()
+        setNotificationMode(mode)
+        const { error } = await supabase
+          .from('user_settings')
+          .upsert(
+            {
+              user_id: userId,
+              notification_mode: mode,
+            },
+            { onConflict: 'user_id' }
+          )
+        if (error) throw error
+        showFeedback('Modo alterado com sucesso')
+      } catch (err) {
+        console.error('[Settings] mode change error', err)
+        setError('Erro ao alterar modo: ' + err.message)
+      } finally {
+        setSavingNotification(false)
+      }
+    },
+    [showFeedback]
+  )
+
+  const saveQuietHours = useCallback(async () => {
+    if (quietHoursEnabled && (!quietHoursStart || !quietHoursEnd)) {
+      setError('Preencha os horários')
+      return
+    }
+    try {
+      const userId = await getUserId()
+      const start = quietHoursEnabled ? quietHoursStart : null
+      const end = quietHoursEnabled ? quietHoursEnd : null
+
+      const { error } = await supabase
+        .from('user_settings')
+        .upsert(
+          {
+            user_id: userId,
+            quiet_hours_start: start,
+            quiet_hours_end: end,
+          },
+          { onConflict: 'user_id' }
+        )
+      if (error) throw error
+      showFeedback('Horários salvos')
+    } catch (err) {
+      console.error('[Settings] quiet hours error', err)
+      setError('Erro ao salvar horários: ' + err.message)
+    }
+  }, [quietHoursEnabled, quietHoursStart, quietHoursEnd, showFeedback])
+
+  const saveDigestTime = useCallback(async () => {
+    if (!digestTime) {
+      setError('Selecione um horário')
+      return
+    }
+    try {
+      const userId = await getUserId()
+      const { error } = await supabase
+        .from('user_settings')
+        .upsert(
+          {
+            user_id: userId,
+            digest_time: digestTime,
+          },
+          { onConflict: 'user_id' }
+        )
+      if (error) throw error
+      showFeedback('Horário do resumo salvo')
+    } catch (err) {
+      console.error('[Settings] digest time error', err)
+      setError('Erro ao salvar horário: ' + err.message)
+    }
+  }, [digestTime, showFeedback])
 
   // ═══ Effects ═══
   useEffect(() => {
@@ -259,6 +394,201 @@ export default function Settings({ onNavigate }) {
             </>
           )}
         </div>
+      </section>
+
+      {/* ═══ NOTIFICAÇÕES ═══ */}
+      <section className="sr-section">
+        <h3 className="sr-section__title">
+          <Bell size={24} /> Notificações
+        </h3>
+
+        {/* ── Seção: Canais ── */}
+        <div className="sr-section__card">
+          <h4 style={{ margin: '0 0 0.75rem 0', fontSize: '0.95rem', fontWeight: 600 }}>
+            Canais
+          </h4>
+
+          {/* App (push nativo) — informativo */}
+          <div className="settings-row settings-row--info">
+            <div className="settings-row-label">
+              <span className="settings-row-icon">📱</span>
+              <div>
+                <span className="settings-row-title">App (push)</span>
+                <span className="settings-row-subtitle">Gerenciado pelo aplicativo móvel</span>
+              </div>
+            </div>
+            <span className="settings-badge settings-badge--info">App</span>
+          </div>
+
+          {/* Web (PWA) — switch funcional */}
+          <div className="settings-row">
+            <div className="settings-row-label">
+              <span className="settings-row-icon">🌐</span>
+              <div>
+                <span className="settings-row-title">Web (PWA)</span>
+                <span className="settings-row-subtitle">
+                  {webPushSupported
+                    ? channelWebPushEnabled
+                      ? 'Ativo neste navegador'
+                      : 'Inativo neste navegador'
+                    : 'Não suportado neste navegador'}
+                </span>
+              </div>
+            </div>
+            <input
+              type="checkbox"
+              className="settings-toggle"
+              checked={channelWebPushEnabled}
+              disabled={!webPushSupported || savingChannel}
+              onChange={handleToggleWebPush}
+              aria-label="Ativar notificações Web (PWA)"
+            />
+          </div>
+
+          {/* Telegram — status */}
+          <div className="settings-row settings-row--info">
+            <div className="settings-row-label">
+              <span className="settings-row-icon">✈️</span>
+              <div>
+                <span className="settings-row-title">Telegram</span>
+                <span className="settings-row-subtitle">Configure pelo aplicativo móvel</span>
+              </div>
+            </div>
+            <span
+              className={`settings-badge ${
+                isTelegramConnected ? 'settings-badge--success' : 'settings-badge--muted'
+              }`}
+            >
+              {isTelegramConnected ? 'Conectado' : 'Desconectado'}
+            </span>
+          </div>
+
+          {/* Email — disabled */}
+          <div className="settings-row settings-row--disabled">
+            <div className="settings-row-label">
+              <span className="settings-row-icon">📧</span>
+              <div>
+                <span className="settings-row-title">Email</span>
+                <span className="settings-row-subtitle">Em breve</span>
+              </div>
+            </div>
+            <span className="settings-badge settings-badge--muted">Em breve</span>
+          </div>
+        </div>
+
+        {/* ── Seção: Modo de notificação ── */}
+        <div className="sr-section__card" style={{ marginTop: '1rem' }}>
+          <h4 style={{ margin: '0 0 0.75rem 0', fontSize: '0.95rem', fontWeight: 600 }}>
+            Modo de notificação
+          </h4>
+          {[
+            {
+              value: 'realtime',
+              label: 'Tempo real',
+              desc: 'Receba cada lembrete no momento certo',
+            },
+            {
+              value: 'digest_morning',
+              label: 'Resumo matinal',
+              desc: 'Um resumo por dia no horário escolhido',
+            },
+            {
+              value: 'silent',
+              label: 'Silencioso',
+              desc: 'Sem envios externos, apenas no app',
+            },
+          ].map(({ value, label, desc }) => (
+            <label key={value} className="settings-radio-row">
+              <input
+                type="radio"
+                name="notification_mode"
+                value={value}
+                checked={notificationMode === value}
+                onChange={() => handleModeChange(value)}
+                disabled={savingNotification}
+              />
+              <div>
+                <span className="settings-radio-label">{label}</span>
+                <span className="settings-radio-desc">{desc}</span>
+              </div>
+            </label>
+          ))}
+        </div>
+
+        {/* ── Seção: Não me incomode ── */}
+        <div className="sr-section__card" style={{ marginTop: '1rem' }}>
+          <div className="settings-row">
+            <div className="settings-row-label">
+              <span className="settings-row-title">Não me incomode</span>
+              <span className="settings-row-subtitle">
+                Silenciar notificações externas neste período
+              </span>
+            </div>
+            <input
+              type="checkbox"
+              className="settings-toggle"
+              checked={quietHoursEnabled}
+              onChange={(e) => setQuietHoursEnabled(e.target.checked)}
+              aria-label="Ativar não me incomode"
+            />
+          </div>
+          {quietHoursEnabled && (
+            <div className="settings-time-row">
+              <label className="settings-time-label">
+                Das{' '}
+                <input
+                  type="time"
+                  className="settings-time-input"
+                  value={quietHoursStart}
+                  onChange={(e) => setQuietHoursStart(e.target.value)}
+                />
+              </label>
+              <span className="settings-time-sep">às</span>
+              <label className="settings-time-label">
+                <input
+                  type="time"
+                  className="settings-time-input"
+                  value={quietHoursEnd}
+                  onChange={(e) => setQuietHoursEnd(e.target.value)}
+                />
+              </label>
+              <button
+                className="settings-btn-save"
+                onClick={saveQuietHours}
+                type="button"
+              >
+                Salvar
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* ── Seção: Hora do resumo (condicional) ── */}
+        {notificationMode === 'digest_morning' && (
+          <div className="sr-section__card" style={{ marginTop: '1rem' }}>
+            <h4 style={{ margin: '0 0 0.75rem 0', fontSize: '0.95rem', fontWeight: 600 }}>
+              Hora do resumo
+            </h4>
+            <div className="settings-time-row">
+              <label className="settings-time-label">
+                Enviar às{' '}
+                <input
+                  type="time"
+                  className="settings-time-input"
+                  value={digestTime}
+                  onChange={(e) => setDigestTime(e.target.value)}
+                />
+              </label>
+              <button
+                className="settings-btn-save"
+                onClick={saveDigestTime}
+                type="button"
+              >
+                Salvar
+              </button>
+            </div>
+          </div>
+        )}
       </section>
 
       {/* ═══ PREFERÊNCIAS ═══ */}

--- a/apps/web/src/views/redesign/Settings.jsx
+++ b/apps/web/src/views/redesign/Settings.jsx
@@ -13,6 +13,7 @@ import {
 import { supabase, getUserId } from '@shared/utils/supabase'
 import { useComplexityMode } from '@dashboard/hooks/useComplexityMode'
 import { validatePasswordChange } from '@schemas/authSchema'
+import { userSettingsNotificationSchema } from '@schemas/userSettingsSchema'
 import { webpushService } from '@shared/services/webpushService'
 import Button from '@shared/components/ui/Button'
 import './settings/SettingsRedesign.css'
@@ -206,6 +207,8 @@ export default function Settings({ onNavigate }) {
 
   const handleModeChange = useCallback(
     async (mode) => {
+      const v = userSettingsNotificationSchema.shape.notification_mode.safeParse(mode)
+      if (!v.success) { setError('Modo inválido'); return }
       setSavingNotification(true)
       try {
         const userId = await getUserId()
@@ -235,6 +238,11 @@ export default function Settings({ onNavigate }) {
     if (quietHoursEnabled && (!quietHoursStart || !quietHoursEnd)) {
       setError('Preencha os horários')
       return
+    }
+    if (quietHoursEnabled) {
+      const v = userSettingsNotificationSchema.pick({ quiet_hours_start: true, quiet_hours_end: true })
+        .safeParse({ quiet_hours_start: quietHoursStart, quiet_hours_end: quietHoursEnd })
+      if (!v.success) { setError(v.error.errors[0]?.message ?? 'Horário inválido'); return }
     }
     try {
       const userId = await getUserId()

--- a/apps/web/src/views/redesign/settings/SettingsRedesign.css
+++ b/apps/web/src/views/redesign/settings/SettingsRedesign.css
@@ -348,6 +348,190 @@
   background: var(--color-error-bg, #ffdad6);
 }
 
+/* ── Notificações (Wave N2) ─────────────────────────────────── */
+
+/* Linhas de configuração */
+.settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--color-outline-ghost, rgba(25, 28, 29, 0.08));
+}
+
+.settings-row:last-child {
+  border-bottom: none;
+}
+
+.settings-row-label {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex: 1;
+}
+
+.settings-row-icon {
+  font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-row-title {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--color-on-surface);
+}
+
+.settings-row-subtitle {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--color-on-surface);
+  opacity: 0.6;
+  margin-top: 2px;
+}
+
+.settings-row--disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.settings-row--info {
+  cursor: default;
+}
+
+/* Toggle switches */
+.settings-toggle {
+  width: 52px;
+  height: 32px;
+  accent-color: var(--color-primary);
+}
+
+/* Radio rows */
+.settings-radio-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 0;
+  cursor: pointer;
+  border-bottom: 1px solid var(--color-outline-ghost, rgba(25, 28, 29, 0.08));
+}
+
+.settings-radio-row:last-child {
+  border-bottom: none;
+}
+
+.settings-radio-row input[type='radio'] {
+  margin-top: 4px;
+  accent-color: var(--color-primary);
+}
+
+.settings-radio-label {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--color-on-surface);
+}
+
+.settings-radio-desc {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--color-on-surface);
+  opacity: 0.6;
+  margin-top: 2px;
+}
+
+/* Time inputs */
+.settings-time-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 0;
+  flex-wrap: wrap;
+}
+
+.settings-time-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--color-on-surface);
+}
+
+.settings-time-input {
+  padding: 0.5rem 0.75rem;
+  border: 1.5px solid var(--color-outline-ghost, rgba(25, 28, 29, 0.08));
+  border-radius: 0.75rem;
+  font-size: 0.9rem;
+  background: var(--color-surface-container-lowest);
+  color: var(--color-on-surface);
+  font-family: inherit;
+  transition: border-color 0.15s;
+}
+
+.settings-time-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.settings-time-sep {
+  font-size: 0.9rem;
+  color: var(--color-on-surface);
+  opacity: 0.6;
+}
+
+/* Badges */
+.settings-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+}
+
+.settings-badge--success {
+  background: color-mix(in srgb, var(--color-success, #22c55e) 12%, transparent);
+  color: var(--color-success, #22c55e);
+}
+
+.settings-badge--info {
+  background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+  color: var(--color-primary);
+}
+
+.settings-badge--muted {
+  background: var(--color-surface-container-low);
+  color: var(--color-on-surface);
+  opacity: 0.6;
+}
+
+/* Save button */
+.settings-btn-save {
+  padding: 0.5rem 1rem;
+  background: var(--color-primary);
+  color: white;
+  border: none;
+  border-radius: 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.settings-btn-save:hover {
+  opacity: 0.9;
+  background: color-mix(in srgb, var(--color-primary) 85%, black);
+}
+
+.settings-btn-save:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* ── Footer ────────────────────────────────────────────────── */
 .sr-footer {
   text-align: center;

--- a/docs/migrations/20260427_notification_quiet_hours.sql
+++ b/docs/migrations/20260427_notification_quiet_hours.sql
@@ -1,0 +1,42 @@
+-- Wave N2: Quiet Hours + canais explícitos + modo de notificação
+-- Adiciona campos a user_settings para controle granular de quando/onde notificar
+
+ALTER TABLE user_settings
+  ADD COLUMN IF NOT EXISTS quiet_hours_start TIME,
+  ADD COLUMN IF NOT EXISTS quiet_hours_end   TIME,
+  ADD COLUMN IF NOT EXISTS notification_mode TEXT DEFAULT 'realtime',
+  ADD COLUMN IF NOT EXISTS digest_time       TIME DEFAULT '07:00',
+  ADD COLUMN IF NOT EXISTS channel_mobile_push_enabled BOOLEAN,
+  ADD COLUMN IF NOT EXISTS channel_web_push_enabled    BOOLEAN DEFAULT false,
+  ADD COLUMN IF NOT EXISTS channel_telegram_enabled    BOOLEAN;
+
+-- CHECK constraint para notification_mode
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'user_settings_notification_mode_check'
+  ) THEN
+    ALTER TABLE user_settings
+      ADD CONSTRAINT user_settings_notification_mode_check
+      CHECK (notification_mode IN ('realtime', 'digest_morning', 'silent'));
+  END IF;
+END $$;
+
+-- Backfill: derivar booleans de canal a partir do campo legado notification_preference
+UPDATE user_settings
+SET
+  channel_mobile_push_enabled = notification_preference IN ('mobile_push', 'both'),
+  channel_telegram_enabled    = notification_preference IN ('telegram', 'both'),
+  channel_web_push_enabled    = COALESCE(channel_web_push_enabled, false)
+WHERE channel_mobile_push_enabled IS NULL
+   OR channel_telegram_enabled IS NULL;
+
+-- Tornar booleans de canal NOT NULL com defaults após backfill
+ALTER TABLE user_settings
+  ALTER COLUMN channel_mobile_push_enabled SET DEFAULT true,
+  ALTER COLUMN channel_mobile_push_enabled SET NOT NULL,
+  ALTER COLUMN channel_web_push_enabled    SET DEFAULT false,
+  ALTER COLUMN channel_web_push_enabled    SET NOT NULL,
+  ALTER COLUMN channel_telegram_enabled    SET DEFAULT false,
+  ALTER COLUMN channel_telegram_enabled    SET NOT NULL;

--- a/docs/migrations/20260427_notification_quiet_hours.sql
+++ b/docs/migrations/20260427_notification_quiet_hours.sql
@@ -5,7 +5,7 @@ ALTER TABLE user_settings
   ADD COLUMN IF NOT EXISTS quiet_hours_start TIME,
   ADD COLUMN IF NOT EXISTS quiet_hours_end   TIME,
   ADD COLUMN IF NOT EXISTS notification_mode TEXT DEFAULT 'realtime',
-  ADD COLUMN IF NOT EXISTS digest_time       TIME DEFAULT '07:00',
+  ADD COLUMN IF NOT EXISTS digest_time       TIME DEFAULT '09:00',
   ADD COLUMN IF NOT EXISTS channel_mobile_push_enabled BOOLEAN,
   ADD COLUMN IF NOT EXISTS channel_web_push_enabled    BOOLEAN DEFAULT false,
   ADD COLUMN IF NOT EXISTS channel_telegram_enabled    BOOLEAN;

--- a/packages/core/src/schemas/index.js
+++ b/packages/core/src/schemas/index.js
@@ -96,5 +96,11 @@ export {
   notificationLogCreateSchema,
 } from './notificationLogSchema.js'
 
+export {
+  userSettingsNotificationSchema,
+  NOTIFICATION_MODES,
+  deriveLegacyPreference,
+} from './userSettingsSchema.js'
+
 // Helper geral de validação
 export { validateEntity, ValidationError } from './validationHelper.js'

--- a/packages/core/src/schemas/userSettingsSchema.js
+++ b/packages/core/src/schemas/userSettingsSchema.js
@@ -1,0 +1,45 @@
+// Schema Zod para user_settings — campos de notificação (Wave N2)
+import { z } from 'zod'
+
+const HH_MM = /^([01]\d|2[0-3]):[0-5]\d$/
+
+export const NOTIFICATION_MODES = ['realtime', 'digest_morning', 'silent']
+
+export const userSettingsNotificationSchema = z.object({
+  notification_preference: z
+    .enum(['telegram', 'mobile_push', 'both', 'none'])
+    .optional(),
+
+  notification_mode: z
+    .enum(['realtime', 'digest_morning', 'silent'])
+    .default('realtime'),
+
+  quiet_hours_start: z
+    .string()
+    .regex(HH_MM, 'Formato HH:MM inválido')
+    .nullable()
+    .optional(),
+
+  quiet_hours_end: z
+    .string()
+    .regex(HH_MM, 'Formato HH:MM inválido')
+    .nullable()
+    .optional(),
+
+  digest_time: z
+    .string()
+    .regex(HH_MM, 'Formato HH:MM inválido')
+    .default('07:00'),
+
+  channel_mobile_push_enabled: z.boolean().default(true),
+  channel_web_push_enabled:    z.boolean().default(false),
+  channel_telegram_enabled:    z.boolean().default(false),
+})
+
+// Derivar notification_preference legado a partir dos booleans de canal
+export function deriveLegacyPreference({ channel_mobile_push_enabled, channel_telegram_enabled }) {
+  if (channel_mobile_push_enabled && channel_telegram_enabled) return 'both'
+  if (channel_mobile_push_enabled) return 'mobile_push'
+  if (channel_telegram_enabled) return 'telegram'
+  return 'none'
+}

--- a/server/bot/__tests__/notificationGate.test.js
+++ b/server/bot/__tests__/notificationGate.test.js
@@ -1,0 +1,79 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldSendNow, isInQuietHours } from '../utils/notificationGate.js';
+
+describe('shouldSendNow', () => {
+  test('silent → false', () => {
+    assert.equal(shouldSendNow({ mode: 'silent', quietHoursStart: null, quietHoursEnd: null, currentHHMM: '10:00' }), false)
+  })
+
+  test('digest_morning → false', () => {
+    assert.equal(shouldSendNow({ mode: 'digest_morning', quietHoursStart: null, quietHoursEnd: null, currentHHMM: '10:00' }), false)
+  })
+
+  test('realtime sem quiet hours → true', () => {
+    assert.equal(shouldSendNow({ mode: 'realtime', quietHoursStart: null, quietHoursEnd: null, currentHHMM: '10:00' }), true)
+  })
+
+  test('realtime dentro QH normal (13:00-15:00, current=14:00) → false', () => {
+    assert.equal(shouldSendNow({ mode: 'realtime', quietHoursStart: '13:00', quietHoursEnd: '15:00', currentHHMM: '14:00' }), false)
+  })
+
+  test('realtime fora QH normal (13:00-15:00, current=16:00) → true', () => {
+    assert.equal(shouldSendNow({ mode: 'realtime', quietHoursStart: '13:00', quietHoursEnd: '15:00', currentHHMM: '16:00' }), true)
+  })
+
+  test('realtime dentro QH cross-midnight (22:00-07:00, current=23:00) → false', () => {
+    assert.equal(shouldSendNow({ mode: 'realtime', quietHoursStart: '22:00', quietHoursEnd: '07:00', currentHHMM: '23:00' }), false)
+  })
+
+  test('realtime dentro QH cross-midnight (22:00-07:00, current=01:00) → false', () => {
+    assert.equal(shouldSendNow({ mode: 'realtime', quietHoursStart: '22:00', quietHoursEnd: '07:00', currentHHMM: '01:00' }), false)
+  })
+
+  test('realtime fora QH cross-midnight (22:00-07:00, current=10:00) → true', () => {
+    assert.equal(shouldSendNow({ mode: 'realtime', quietHoursStart: '22:00', quietHoursEnd: '07:00', currentHHMM: '10:00' }), true)
+  })
+
+  test('QH start=null → não suprime por horário', () => {
+    assert.equal(shouldSendNow({ mode: 'realtime', quietHoursStart: null, quietHoursEnd: '15:00', currentHHMM: '14:00' }), true)
+  })
+
+  test('QH end=null → não suprime por horário', () => {
+    assert.equal(shouldSendNow({ mode: 'realtime', quietHoursStart: '13:00', quietHoursEnd: null, currentHHMM: '14:00' }), true)
+  })
+
+  test('current=start (inclusive) → dentro', () => {
+    assert.equal(shouldSendNow({ mode: 'realtime', quietHoursStart: '13:00', quietHoursEnd: '15:00', currentHHMM: '13:00' }), false)
+  })
+
+  test('current=end (exclusive) → fora', () => {
+    assert.equal(shouldSendNow({ mode: 'realtime', quietHoursStart: '13:00', quietHoursEnd: '15:00', currentHHMM: '15:00' }), true)
+  })
+})
+
+describe('isInQuietHours', () => {
+  test('start e end null → false', () => {
+    assert.equal(isInQuietHours('10:00', null, null), false)
+  })
+
+  test('janela normal: dentro', () => {
+    assert.equal(isInQuietHours('14:00', '13:00', '15:00'), true)
+  })
+
+  test('janela normal: fora', () => {
+    assert.equal(isInQuietHours('16:00', '13:00', '15:00'), false)
+  })
+
+  test('cross-midnight: dentro (após start)', () => {
+    assert.equal(isInQuietHours('23:00', '22:00', '07:00'), true)
+  })
+
+  test('cross-midnight: dentro (antes de end)', () => {
+    assert.equal(isInQuietHours('01:00', '22:00', '07:00'), true)
+  })
+
+  test('cross-midnight: fora', () => {
+    assert.equal(isInQuietHours('10:00', '22:00', '07:00'), false)
+  })
+})

--- a/server/bot/tasks.js
+++ b/server/bot/tasks.js
@@ -865,28 +865,22 @@ async function runDailyDigestViaDispatcher(dispatcher, correlationId) {
 
     logger.info(`Running daily digest via dispatcher for ${users.length} users`, { correlationId });
 
+    // Fase 1: filtrar usuários elegíveis (mode=digest_morning, no horário correto)
+    const eligibleEntries = [];
     for (const user of users) {
       const userId = user.id;
       try {
         const settings = await getUserSettings(userId, true);
         if (!settings) continue;
 
-        // Filtro 1: Somente enviar se notification_mode === 'digest_morning'
         const notificationMode = settings.notification_mode || 'realtime';
-        if (notificationMode !== 'digest_morning') {
-          logger.debug(`Daily digest skipped: user not in digest_morning mode`, { userId, notificationMode, correlationId });
-          continue;
-        }
+        if (notificationMode !== 'digest_morning') continue;
 
         const timezone = settings.timezone || 'America/Sao_Paulo';
         const digestTime = settings.digest_time || '07:00';
         const currentHHMM = getCurrentTimeInTimezone(timezone);
 
-        // Filtro 2: Somente enviar se currentHHMM === digest_time
-        if (currentHHMM !== digestTime) {
-          logger.debug(`Daily digest skipped: not at digest time`, { userId, currentHHMM, digestTime, correlationId });
-          continue;
-        }
+        if (currentHHMM !== digestTime) continue;
 
         const shouldSend = await shouldSendNotification(userId, null, 'daily_digest');
         if (!shouldSend) {
@@ -894,6 +888,34 @@ async function runDailyDigestViaDispatcher(dispatcher, correlationId) {
           continue;
         }
 
+        eligibleEntries.push({ userId, settings, timezone });
+      } catch (err) {
+        logger.error(`Error evaluating daily digest eligibility for user`, err, { userId: user.id, correlationId });
+      }
+    }
+
+    if (eligibleEntries.length === 0) {
+      logger.info('Daily digest: no eligible users at this time', { correlationId });
+      return;
+    }
+
+    // Fase 2: bulk-fetch de protocolos para todos os usuários elegíveis (evita N+1)
+    const eligibleIds = eligibleEntries.map(e => e.userId);
+    const { data: allProtocols } = await supabase
+      .from('protocols')
+      .select('*, medicine:medicines(name)')
+      .in('user_id', eligibleIds)
+      .eq('is_active', true);
+
+    const protocolsByUser = {};
+    for (const p of allProtocols ?? []) {
+      if (!protocolsByUser[p.user_id]) protocolsByUser[p.user_id] = [];
+      protocolsByUser[p.user_id].push(p);
+    }
+
+    // Fase 3: dispatch por usuário com dados já em memória
+    for (const { userId, timezone } of eligibleEntries) {
+      try {
         const { data: logs } = await supabase
           .from('medicine_logs')
           .select('*')
@@ -906,24 +928,18 @@ async function runDailyDigestViaDispatcher(dispatcher, correlationId) {
           return logDate === today;
         }) || [];
 
-        const { data: protocols } = await supabase
-          .from('protocols')
-          .select('*, medicine:medicines(name)')
-          .eq('user_id', userId)
-          .eq('is_active', true);
-
-        const expectedDoses = protocols?.reduce((sum, p) => sum + (p.time_schedule?.length || 0), 0) || 0;
+        const protocols = protocolsByUser[userId] || [];
+        const expectedDoses = protocols.reduce((sum, p) => sum + (p.time_schedule?.length || 0), 0);
         const takenDoses = todayLogs.length;
         const percentage = expectedDoses > 0 ? Math.round((takenDoses / expectedDoses) * 100) : 0;
 
         const dateStr = new Intl.DateTimeFormat('pt-BR', { timeZone: timezone }).format(new Date());
         const summary = `${dateStr} — ${takenDoses}/${expectedDoses} doses (${percentage}%)`;
 
-        // Gerar lista plana de horários e nomes de medicamentos
-        const scheduleLines = (protocols || [])
+        const scheduleLines = protocols
           .flatMap(p => (p.time_schedule || []).map(t => `${t} — ${p.medicine?.name || 'Medicamento'}`))
           .sort()
-          .slice(0, 10); // Limitar a 10 linhas para não extrapolar limites de push
+          .slice(0, 10);
 
         const scheduleBody = scheduleLines.length > 0
           ? scheduleLines.join('\n')
@@ -932,13 +948,7 @@ async function runDailyDigestViaDispatcher(dispatcher, correlationId) {
         await dispatcher.dispatch({
           userId,
           kind: 'daily_digest',
-          data: {
-            summary,
-            scheduleLines,
-            expectedDoses,
-            takenDoses,
-            scheduleBody
-          },
+          data: { summary, scheduleLines, expectedDoses, takenDoses, scheduleBody },
           context: { correlationId, jobType: 'daily_digest_dispatcher' }
         });
 

--- a/server/bot/tasks.js
+++ b/server/bot/tasks.js
@@ -854,13 +854,29 @@ async function runDailyDigestViaDispatcher(dispatcher, correlationId) {
         const settings = await getUserSettings(userId, true);
         if (!settings) continue;
 
+        // Filtro 1: Somente enviar se notification_mode === 'digest_morning'
+        const notificationMode = settings.notification_mode || 'realtime';
+        if (notificationMode !== 'digest_morning') {
+          logger.debug(`Daily digest skipped: user not in digest_morning mode`, { userId, notificationMode, correlationId });
+          continue;
+        }
+
+        const timezone = settings.timezone || 'America/Sao_Paulo';
+        const digestTime = settings.digest_time || '07:00';
+        const currentHHMM = getCurrentTimeInTimezone(timezone);
+
+        // Filtro 2: Somente enviar se currentHHMM === digest_time
+        if (currentHHMM !== digestTime) {
+          logger.debug(`Daily digest skipped: not at digest time`, { userId, currentHHMM, digestTime, correlationId });
+          continue;
+        }
+
         const shouldSend = await shouldSendNotification(userId, null, 'daily_digest');
         if (!shouldSend) {
           logger.debug(`Daily digest suppressed by deduplication`, { userId, correlationId });
           continue;
         }
 
-        const timezone = settings.timezone || 'America/Sao_Paulo';
         const { data: logs } = await supabase
           .from('medicine_logs')
           .select('*')
@@ -875,7 +891,7 @@ async function runDailyDigestViaDispatcher(dispatcher, correlationId) {
 
         const { data: protocols } = await supabase
           .from('protocols')
-          .select('time_schedule')
+          .select('*, medicine:medicines(name)')
           .eq('user_id', userId)
           .eq('is_active', true);
 
@@ -886,10 +902,26 @@ async function runDailyDigestViaDispatcher(dispatcher, correlationId) {
         const dateStr = new Intl.DateTimeFormat('pt-BR', { timeZone: timezone }).format(new Date());
         const summary = `${dateStr} — ${takenDoses}/${expectedDoses} doses (${percentage}%)`;
 
+        // Gerar lista plana de horários e nomes de medicamentos
+        const scheduleLines = (protocols || [])
+          .flatMap(p => (p.time_schedule || []).map(t => `${t} — ${p.medicine?.name || 'Medicamento'}`))
+          .sort()
+          .slice(0, 10); // Limitar a 10 linhas para não extrapolar limites de push
+
+        const scheduleBody = scheduleLines.length > 0
+          ? scheduleLines.join('\n')
+          : 'Verifique sua agenda no app.';
+
         await dispatcher.dispatch({
           userId,
           kind: 'daily_digest',
-          data: { summary },
+          data: {
+            summary,
+            scheduleLines,
+            expectedDoses,
+            takenDoses,
+            scheduleBody
+          },
           context: { correlationId, jobType: 'daily_digest_dispatcher' }
         });
 

--- a/server/bot/tasks.js
+++ b/server/bot/tasks.js
@@ -15,6 +15,7 @@ import {
 } from '../utils/timezone.js';
 import { calculateDaysRemaining, escapeMarkdownV2 } from '../utils/formatters.js';
 import { partitionDoses } from './utils/partitionDoses.js';
+import { shouldSendNow } from './utils/notificationGate.js';
 
 const logger = createLogger('Tasks');
 
@@ -334,7 +335,7 @@ async function checkRemindersViaDispatcher(dispatcher, correlationId) {
     // R-111: Buscar apenas usuários ativos (evita queries em massa na auth.users)
     const { data: users, error: userError } = await supabase
       .from('user_settings')
-      .select('user_id, timezone');
+      .select('user_id, timezone, notification_mode, quiet_hours_start, quiet_hours_end');
 
     if (userError) throw userError;
 
@@ -380,6 +381,22 @@ async function checkRemindersViaDispatcher(dispatcher, correlationId) {
         // R-020: Usar utilitário central de timezone
         const currentHHMM = getCurrentTimeInTimezone(timezone);
         const currentHour = parseInt(currentHHMM.split(':')[0], 10);
+
+        // Wave N2: gate de supressão por modo e quiet hours
+        const canSend = shouldSendNow({
+          mode: user.notification_mode || 'realtime',
+          quietHoursStart: user.quiet_hours_start || null,
+          quietHoursEnd:   user.quiet_hours_end   || null,
+          currentHHMM,
+        })
+        if (!canSend) {
+          logger.info('Notificações suprimidas por modo/quiet hours', {
+            userId, correlationId,
+            mode: user.notification_mode,
+            currentHHMM,
+          })
+          continue
+        }
 
         const protocols = protocolsByUser[userId] || [];
         if (protocols.length === 0) continue;

--- a/server/bot/utils/notificationGate.js
+++ b/server/bot/utils/notificationGate.js
@@ -1,0 +1,31 @@
+// Regras de supressão de notificações por modo e quiet hours (Wave N2)
+
+/**
+ * Determina se uma notificação realtime deve ser enviada agora.
+ * @param {{ mode: string, quietHoursStart: string|null, quietHoursEnd: string|null, currentHHMM: string }} params
+ * @returns {boolean}
+ */
+export function shouldSendNow({ mode, quietHoursStart, quietHoursEnd, currentHHMM }) {
+  if (mode === 'silent') return false
+  if (mode === 'digest_morning') return false
+  if (isInQuietHours(currentHHMM, quietHoursStart, quietHoursEnd)) return false
+  return true
+}
+
+/**
+ * Verifica se horário atual está dentro do período de quiet hours.
+ * Trata janelas que cruzam meia-noite (ex: 22:00 → 07:00).
+ * @param {string} current - HH:MM atual
+ * @param {string|null} start - HH:MM início
+ * @param {string|null} end   - HH:MM fim
+ * @returns {boolean}
+ */
+export function isInQuietHours(current, start, end) {
+  if (!start || !end) return false
+  const toMin = (hhmm) => { const [h, m] = hhmm.split(':').map(Number); return h * 60 + m }
+  const cur = toMin(current)
+  const s   = toMin(start)
+  const e   = toMin(end)
+  if (s <= e) return cur >= s && cur < e   // janela normal
+  return cur >= s || cur < e               // cross-midnight
+}

--- a/server/notifications/policies/resolveChannelsForUser.js
+++ b/server/notifications/policies/resolveChannelsForUser.js
@@ -1,36 +1,43 @@
-// Política de resolução de canais de notificação
-// Determina quais canais usar para notificar um usuário baseado em:
-// 1. Preferência de notificação (notification_preference em user_settings)
-// 2. Disponibilidade de cada canal (telegram_chat_id ou dispositivos ativos)
+// Política de resolução de canais de notificação (Wave N2+)
+// Flags explícitas têm precedência sobre notification_preference legado
 
-// Retorna array de canais válidos: [], ['telegram'], ['mobile_push'], ou ['telegram', 'mobile_push']
+// Retorna array de canais válidos: [], ['telegram'], ['mobile_push'], ['web_push'], ou combinações
 
 export async function resolveChannelsForUser({ userId, repositories }) {
-  const preference = await repositories.preferences.getByUserId(userId)
-  const hasTelegram = await repositories.preferences.hasTelegramChat(userId)
+  const hasTelegram       = await repositories.preferences.hasTelegramChat(userId)
   const activeExpoDevices = await repositories.devices.listActiveByUser(userId, 'expo')
+  const activeWebDevices  = await repositories.devices.listActiveByUser(userId, 'webpush')
 
-  // Caso 1: Usuário prefere não receber notificações
+  // Tentar buscar settings completos (com flags Wave N2)
+  let settings = null
+  if (repositories.preferences.getSettingsByUserId) {
+    settings = await repositories.preferences.getSettingsByUserId(userId)
+  }
+
+  // Modo explícito Wave N2: usar flags de canal se presentes
+  if (
+    settings &&
+    settings.channel_mobile_push_enabled !== undefined &&
+    settings.channel_web_push_enabled !== undefined &&
+    settings.channel_telegram_enabled !== undefined
+  ) {
+    const channels = []
+    if (settings.channel_mobile_push_enabled && activeExpoDevices.length > 0) channels.push('mobile_push')
+    if (settings.channel_web_push_enabled    && activeWebDevices.length > 0)  channels.push('web_push')
+    if (settings.channel_telegram_enabled    && hasTelegram)                   channels.push('telegram')
+    return channels
+  }
+
+  // Fallback legado: notification_preference
+  const preference = await repositories.preferences.getByUserId(userId)
   if (preference === 'none') return []
-
-  // Caso 2: Telegram apenas (se disponível)
-  if (preference === 'telegram') {
-    return hasTelegram ? ['telegram'] : []
-  }
-
-  // Caso 3: Mobile push apenas (se tiver dispositivos ativos)
-  if (preference === 'mobile_push') {
-    return activeExpoDevices.length > 0 ? ['mobile_push'] : []
-  }
-
-  // Caso 4: Ambos os canais (qualquer um que esteja disponível)
+  if (preference === 'telegram')    return hasTelegram ? ['telegram'] : []
+  if (preference === 'mobile_push') return activeExpoDevices.length > 0 ? ['mobile_push'] : []
   if (preference === 'both') {
     return [
       ...(hasTelegram ? ['telegram'] : []),
       ...(activeExpoDevices.length > 0 ? ['mobile_push'] : []),
     ]
   }
-
-  // Fallback (não deveria chegar aqui se CHECK constraint funcionar)
   return []
 }

--- a/server/notifications/policies/resolveChannelsForUser.test.js
+++ b/server/notifications/policies/resolveChannelsForUser.test.js
@@ -115,3 +115,154 @@ describe('resolveChannelsForUser', () => {
     expect(result).toEqual([])
   })
 })
+
+describe('resolveChannelsForUser — flags explícitas Wave N2', () => {
+  const userId = 'user-n2'
+
+  const makeRepositories = (overrides = {}) => ({
+    preferences: {
+      getByUserId: vi.fn(),
+      hasTelegramChat: vi.fn(),
+      getSettingsByUserId: vi.fn(),
+      ...(overrides.preferences || {}),
+    },
+    devices: {
+      listActiveByUser: vi.fn(),
+      ...(overrides.devices || {}),
+    },
+  })
+
+  it('channel_mobile_push_enabled=true + expo device ativo → inclui mobile_push', async () => {
+    const repos = makeRepositories()
+    repos.preferences.hasTelegramChat.mockResolvedValue(false)
+    repos.preferences.getSettingsByUserId.mockResolvedValue({
+      channel_mobile_push_enabled: true,
+      channel_web_push_enabled: false,
+      channel_telegram_enabled: false,
+    })
+    repos.devices.listActiveByUser.mockImplementation((uid, type) =>
+      type === 'expo' ? [{ id: 'dev-1' }] : []
+    )
+
+    const result = await resolveChannelsForUser({ userId, repositories: repos })
+    expect(result).toContain('mobile_push')
+  })
+
+  it('channel_mobile_push_enabled=true + sem expo device → não inclui mobile_push', async () => {
+    const repos = makeRepositories()
+    repos.preferences.hasTelegramChat.mockResolvedValue(false)
+    repos.preferences.getSettingsByUserId.mockResolvedValue({
+      channel_mobile_push_enabled: true,
+      channel_web_push_enabled: false,
+      channel_telegram_enabled: false,
+    })
+    repos.devices.listActiveByUser.mockResolvedValue([])
+
+    const result = await resolveChannelsForUser({ userId, repositories: repos })
+    expect(result).not.toContain('mobile_push')
+  })
+
+  it('channel_web_push_enabled=true + webpush device ativo → inclui web_push', async () => {
+    const repos = makeRepositories()
+    repos.preferences.hasTelegramChat.mockResolvedValue(false)
+    repos.preferences.getSettingsByUserId.mockResolvedValue({
+      channel_mobile_push_enabled: false,
+      channel_web_push_enabled: true,
+      channel_telegram_enabled: false,
+    })
+    repos.devices.listActiveByUser.mockImplementation((uid, type) =>
+      type === 'webpush' ? [{ id: 'web-1' }] : []
+    )
+
+    const result = await resolveChannelsForUser({ userId, repositories: repos })
+    expect(result).toContain('web_push')
+  })
+
+  it('channel_web_push_enabled=true + sem webpush device → não inclui web_push', async () => {
+    const repos = makeRepositories()
+    repos.preferences.hasTelegramChat.mockResolvedValue(false)
+    repos.preferences.getSettingsByUserId.mockResolvedValue({
+      channel_mobile_push_enabled: false,
+      channel_web_push_enabled: true,
+      channel_telegram_enabled: false,
+    })
+    repos.devices.listActiveByUser.mockResolvedValue([])
+
+    const result = await resolveChannelsForUser({ userId, repositories: repos })
+    expect(result).not.toContain('web_push')
+  })
+
+  it('channel_telegram_enabled=true + hasTelegram=true → inclui telegram', async () => {
+    const repos = makeRepositories()
+    repos.preferences.hasTelegramChat.mockResolvedValue(true)
+    repos.preferences.getSettingsByUserId.mockResolvedValue({
+      channel_mobile_push_enabled: false,
+      channel_web_push_enabled: false,
+      channel_telegram_enabled: true,
+    })
+    repos.devices.listActiveByUser.mockResolvedValue([])
+
+    const result = await resolveChannelsForUser({ userId, repositories: repos })
+    expect(result).toContain('telegram')
+  })
+
+  it('channel_telegram_enabled=false + hasTelegram=true → não inclui telegram', async () => {
+    const repos = makeRepositories()
+    repos.preferences.hasTelegramChat.mockResolvedValue(true)
+    repos.preferences.getSettingsByUserId.mockResolvedValue({
+      channel_mobile_push_enabled: false,
+      channel_web_push_enabled: false,
+      channel_telegram_enabled: false,
+    })
+    repos.devices.listActiveByUser.mockResolvedValue([])
+
+    const result = await resolveChannelsForUser({ userId, repositories: repos })
+    expect(result).not.toContain('telegram')
+  })
+
+  it('todos os 3 canais enabled + todos devices → retorna todos', async () => {
+    const repos = makeRepositories()
+    repos.preferences.hasTelegramChat.mockResolvedValue(true)
+    repos.preferences.getSettingsByUserId.mockResolvedValue({
+      channel_mobile_push_enabled: true,
+      channel_web_push_enabled: true,
+      channel_telegram_enabled: true,
+    })
+    repos.devices.listActiveByUser.mockImplementation((uid, type) => {
+      if (type === 'expo') return [{ id: 'expo-1' }]
+      if (type === 'webpush') return [{ id: 'web-1' }]
+      return []
+    })
+
+    const result = await resolveChannelsForUser({ userId, repositories: repos })
+    expect(result).toEqual(['mobile_push', 'web_push', 'telegram'])
+  })
+
+  it('flags presentes e completas → NÃO usa fallback legado', async () => {
+    const repos = makeRepositories()
+    repos.preferences.hasTelegramChat.mockResolvedValue(true)
+    repos.preferences.getSettingsByUserId.mockResolvedValue({
+      channel_mobile_push_enabled: false,
+      channel_web_push_enabled: false,
+      channel_telegram_enabled: false,
+    })
+    repos.devices.listActiveByUser.mockResolvedValue([{ id: 'dev-1' }])
+    repos.preferences.getByUserId.mockResolvedValue('both')
+
+    const result = await resolveChannelsForUser({ userId, repositories: repos })
+    expect(result).toEqual([])
+    expect(repos.preferences.getByUserId).not.toHaveBeenCalled()
+  })
+
+  it('flags ausentes em settings → usa fallback legado', async () => {
+    const repos = makeRepositories()
+    repos.preferences.hasTelegramChat.mockResolvedValue(true)
+    repos.preferences.getSettingsByUserId.mockResolvedValue({}) // sem flags
+    repos.preferences.getByUserId.mockResolvedValue('telegram')
+    repos.devices.listActiveByUser.mockResolvedValue([])
+
+    const result = await resolveChannelsForUser({ userId, repositories: repos })
+    expect(result).toEqual(['telegram'])
+    expect(repos.preferences.getByUserId).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Resumo

Wave N2 do Notifications Revamp: implementa controle granular de supressão de notificações (quiet hours, modos de envio, canais explícitos) e redesenha 4 telas nativas do mobile.

**Sprints entregues:**
- **2.1** — Migration SQL (`quiet_hours_start/end`, `notification_mode`, `digest_time`, `channel_*_enabled`) + Zod schemas
- **2.2** — `notificationGate.js` (`shouldSendNow` + `isInQuietHours` cross-midnight) + `resolveChannelsForUser` com flags explícitas Wave N2
- **2.3** — `runDailyDigestViaDispatcher` filtra por `notification_mode = 'digest_morning'` e horário `digest_time`
- **2.4** — Mobile `ProfileScreen`: hub único "Notificações" com badge (remove 3 cards paralelos)
- **2.5** — Mobile `NotificationInboxScreen`: chips Todos/Não lidos/Doses/Estoque, zero state, gear → Preferências
- **2.6** — Mobile `NotificationPreferencesScreen`: canais (App/Telegram/Web/Email), modos de envio, quiet hours, hora do resumo
- **2.7** — Mobile `TelegramLinkScreen`: fluxo 2 passos redesenhado, caixa de código escura
- **2.8** — Web `Settings.jsx` (redesign): toggle Web PWA, modos, quiet hours com `type="time"`, hora do resumo

## Decisões arquiteturais

- **ADR-035**: canal `web_push` só ativo com flag + device ativo (nunca inferir só pela subscription)
- **R-196**: `isInQuietHours` suporta janelas cross-midnight (`start > end`)
- **R-197**: única porta de entrada de notificações no Perfil (hierarquia Perfil → Avisos → Preferências → Telegram)
- **R-198**: `web_push` depende de `channel_web_push_enabled === true` **e** device ativo em `notification_devices`
- **CON-017**: `resolveChannelsForUser` ampliado de forma não-breaking (additive)

## Quality gates

- 543 testes Vitest (apps/web) — 0 falhas ✅
- 18 testes Node (`notificationGate` + `resolveChannelsForUser`) — 0 falhas ✅
- Lint limpo ✅
- Migration aplicada no Supabase ✅

## Plano de testes

- [ ] Perfil → Notificações (badge) → Avisos → gear → Preferências → Telegram
- [ ] Filtros Todos/Não lidos/Doses/Estoque no mobile
- [ ] Zero state em conta sem notificações
- [ ] `quiet_hours_start=22:00, end=07:00` → device não recebe push às 23:00
- [ ] `digest_morning 07:00` → 1 push às 07:00 com agenda do dia
- [ ] `silent` → 0 push externo, inbox normal
- [ ] Web: toggle Web PWA → cron envia/omite `web_push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)