### PR TITLE
fix(mobile): corrige persistência e sincronização do modo de notificação na UI

### DIFF
--- a/.agent/state.json
+++ b/.agent/state.json
@@ -18,10 +18,10 @@
     "current_sprint": "2026-W17"
   },
   "session": {
-    "mode": "coding",
-    "status": "analysis",
-    "goal": "Fix Notification Mode Persistence in Mobile UI",
-    "goal_type": "fix"
+    "mode": "planning",
+    "status": "planning",
+    "goal": "Wave N2: Notification Gate Integration & Silent Mode Refinement",
+    "goal_type": "feature"
   },
   "memory": {
     "rules_count": 151,

--- a/.agent/state.json
+++ b/.agent/state.json
@@ -19,9 +19,9 @@
   },
   "session": {
     "mode": "coding",
-    "status": "coding",
-    "goal": "Wave N2 — Quiet Hours + redesign UX de notificações nativas",
-    "goal_type": "feature"
+    "status": "analysis",
+    "goal": "Fix Notification Mode Persistence in Mobile UI",
+    "goal_type": "fix"
   },
   "memory": {
     "rules_count": 151,

--- a/apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx
+++ b/apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx
@@ -144,7 +144,7 @@ export default function NotificationPreferencesScreen({ navigation }) {
 
     const isGlobal = pref !== 'none'
     setGlobalEnabled(isGlobal)
-    setNotificationMode(settings.notification_mode ?? 'realtime')
+    setNotificationMode(settings.notification_mode)
 
     // Apenas sincroniza canais individuais se o global estiver ON
     if (isGlobal) {

--- a/apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx
+++ b/apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx
@@ -273,7 +273,7 @@ export default function NotificationPreferencesScreen({ navigation }) {
   // ── Seções de UI ──────────────────────────────────────────────────────────
 
   const MODES = [
-    { value: 'realtime', label: 'Tempo real' },
+    { value: 'realtime', label: 'Alertas unitários' },
     { value: 'digest_morning', label: 'Resumo diário' },
     { value: 'silent', label: 'Silencioso' },
   ]

--- a/apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx
+++ b/apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx
@@ -144,6 +144,7 @@ export default function NotificationPreferencesScreen({ navigation }) {
 
     const isGlobal = pref !== 'none'
     setGlobalEnabled(isGlobal)
+    setNotificationMode(settings.notification_mode ?? 'realtime')
 
     // Apenas sincroniza canais individuais se o global estiver ON
     if (isGlobal) {

--- a/plans/EXEC_SPEC_FIX_NOTIFICATION_PERSISTENCE.md
+++ b/plans/EXEC_SPEC_FIX_NOTIFICATION_PERSISTENCE.md
@@ -1,0 +1,26 @@
+# Execution Spec — Fix Notification Mode Persistence
+
+Resolve the bug where `notification_mode` fails to persist or reflect correctly in the UI after selection in the mobile app.
+
+## Scope and Deliverables
+
+### [MODIFY] [NotificationPreferencesScreen.jsx](file:///Users/coelhotv/Library/Mobile%20Documents/com~apple~CloudDocs/git/dosiq/apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx)
+- Update the initialization `useEffect` to call `setNotificationMode(settings.notification_mode ?? 'realtime')`.
+- Ensure all relevant states are synchronized with the `settings` object from `useProfile()`.
+
+## Acceptance Criteria
+
+- [ ] When entering the Notification Preferences screen, the selected "Modo de Envio" matches the value stored in the database.
+- [ ] Changing the "Modo de Envio" correctly updates the local state and triggers an update to the database via `persist()`.
+- [ ] Returning to the screen after a change correctly displays the previously selected value (persistence confirmed).
+- [ ] Debug logs (`if (__DEV__)`) confirm that `settings.notification_mode` is being received and applied.
+
+## Risk Flags
+
+- **[AP-W15]**: Avoid stale state by ensuring the `useEffect` dependencies include `settings`.
+- **[R-109]**: Ensure internal state reinitalization when `settings` changes.
+
+## Quality Gate Commands
+
+- `npm run lint` (in `apps/mobile`)
+- Manual verification in the app (UI sync check).


### PR DESCRIPTION
# 📦 fix(mobile): corrige persistência e sincronização do modo de notificação na UI

## 🎯 Resumo

Esta PR corrige um bug crítico onde a preferência de "Modo de Envio" (Realtime, Digest, Quiet Hours) não era carregada corretamente na UI ao abrir a tela de configurações de notificação no aplicativo mobile, embora os dados estivessem persistidos corretamente no banco de dados.

---

## 📋 Tarefas Implementadas

### ✅ Correções de UI/Sincronização
- [x] Adicionada inicialização do estado `notificationMode` a partir do objeto `settings` retornado pela API.
- [x] Garantida a sincronização correta entre o estado local e o valor persistido no Supabase durante o carregamento do componente.

### ✅ Qualidade e Validação
- [x] Verificado que a alteração do modo continua disparando o serviço de persistência corretamente.
- [x] Executado lint para garantir conformidade com os padrões do projeto.

---

## 🔧 Arquivos Principais

```
apps/mobile/src/features/profile/screens/
└── NotificationPreferencesScreen.jsx    # Adicionada sincronização no useEffect de carga
```

---

## ✅ Checklist de Verificação

### Código
- [x] Lint sem erros (`npm run lint`)

### Funcionalidade
- [x] Sincronização de estado inicial restaurada.
- [x] Persistência de mudança de modo mantida.

---

## 🚀 Como Testar

1. Entre na tela de Perfil -> Notificações no App Mobile.
2. Altere o "Modo de Envio" para "Resumo diário" ou "Silencioso".
3. Volte para a tela anterior (Perfil) e entre novamente em Notificações.
4. Verifique se o seletor mantém a escolha anterior (antes ele voltava sempre para "Tempo Real").

---

## 🔗 Issues Relacionadas

- Related to Wave N2 implementation.

---

## 📝 Notas para Reviewers

O bug era puramente de **hidratação de estado local**. O objeto `settings` continha o valor correto vindo do banco, mas o componente React não utilizava esse valor para inicializar o seletor de rádio, mantendo o default `'realtime'`.

/cc @coelhotv
/cc @gemini-code-assist