### PR TITLE
feat(notifications): overhaul delivery gates and morning planner strategy

### DIFF
--- a/.agent/state.json
+++ b/.agent/state.json
@@ -18,9 +18,9 @@
     "current_sprint": "2026-W18"
   },
   "session": {
-    "mode": "planning",
-    "status": "planning",
-    "goal": "Implement Daily Adherence Reporting with Storytelling and Nudges",
+    "mode": "coding",
+    "status": "analysis",
+    "goal": "Refine Notification Experience: Morning Planner, Stock Alerts, and Nightly Storytelling",
     "goal_type": "feature"
   },
   "memory": {

--- a/server/bot/__tests__/tasks.test.js
+++ b/server/bot/__tests__/tasks.test.js
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { 
+  runDailyDigest, 
+  runDailyAdherenceReport, 
+  checkStockAlerts 
+} from '../tasks.js';
+// import { supabase } from '../../services/supabase.js';
+
+const mockDataQueue = [];
+
+const { mockSupabase } = vi.hoisted(() => {
+  const m = {
+    from: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    neq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    lt: vi.fn().mockReturnThis(),
+    single: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    contains: vi.fn().mockReturnThis(),
+    // Supabase queries are thenables
+    then: vi.fn((onFulfilled) => {
+      const result = mockDataQueue.shift() || { data: [], error: null };
+      return Promise.resolve(result).then(onFulfilled);
+    }),
+  };
+  return { mockSupabase: m };
+});
+
+vi.mock('../../services/supabase.js', () => ({
+  supabase: mockSupabase
+}));
+
+// Helper to set mock results in order
+const setMockData = (data, error = null) => {
+  mockDataQueue.push({ data, error });
+};
+
+
+
+vi.mock('../../bot/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('../../services/notificationDeduplicator.js', () => ({
+  shouldSendNotification: vi.fn(() => Promise.resolve(true)),
+  shouldSendGroupedNotification: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock('../../utils/timezone.js', () => ({
+  getCurrentTimeInTimezone: vi.fn(() => '08:00'),
+  getCurrentDateInTimezone: vi.fn(() => '2026-04-29'),
+}));
+
+describe('Tasks Service - Wave 11 Refactor', () => {
+  let mockDispatcher;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDataQueue.length = 0;
+    mockDispatcher = {
+      dispatch: vi.fn(() => Promise.resolve({ success: true })),
+    };
+  });
+
+
+  describe('runDailyDigest', () => {
+    it('should correctly build the Morning Planner message', async () => {
+      // Mock user settings
+      setMockData([{ user_id: 'user1', display_name: 'Test User', digest_time: '08:00', timezone: 'America/Sao_Paulo' }]);
+
+      // Mock protocols
+      setMockData([
+        { 
+          user_id: 'user1', 
+          name: 'Med 1', 
+          time_schedule: ['08:00', '20:00'], 
+          medicine: { name: 'Aspirina', dosage_unit: 'pill' },
+          dosage_per_intake: 1
+        }
+      ]);
+
+      // Mock logs (yesterday)
+      setMockData([{ id: 'log1' }]); // 1 dose taken yesterday
+
+      await runDailyDigest({}, { correlationId: 'test-corr', notificationDispatcher: mockDispatcher });
+
+      expect(mockDispatcher.dispatch).toHaveBeenCalledWith(expect.objectContaining({
+        kind: 'daily_digest',
+        payload: expect.objectContaining({
+          metadata: expect.objectContaining({
+            greeting: 'Bom dia',
+            yesterdayPercentage: 50, // 1 taken / 2 scheduled
+            scheduleCount: 2,
+          }),
+        }),
+      }));
+    });
+  });
+
+  describe('runDailyAdherenceReport', () => {
+    it('should generate storytelling based on performance improvement', async () => {
+      // Mock user settings (23:00)
+      setMockData([{ user_id: 'user1', display_name: 'Test User', digest_time: '23:00', timezone: 'America/Sao_Paulo' }]);
+
+      // Mock current time
+      const { getCurrentTimeInTimezone } = await import('../../utils/timezone.js');
+      getCurrentTimeInTimezone.mockReturnValue('23:00');
+
+      // Mock protocols
+      setMockData([
+        { 
+          user_id: 'user1', 
+          name: 'Med 1', 
+          time_schedule: ['08:00', '20:00'], 
+          medicine: { name: 'Aspirina' }
+        }
+      ]);
+
+      // Mock logs (today and yesterday)
+      setMockData([
+        { taken_at: '2026-04-29T08:05:00Z', protocol_id: 'p1' }, // today
+        { taken_at: '2026-04-29T20:10:00Z', protocol_id: 'p1' }, // today (100%)
+        { taken_at: '2026-04-28T08:10:00Z', protocol_id: 'p1' }, // yesterday (50%)
+      ]);
+
+      await runDailyAdherenceReport({}, { correlationId: 'test-corr', notificationDispatcher: mockDispatcher });
+
+      expect(mockDispatcher.dispatch).toHaveBeenCalledWith(expect.objectContaining({
+        kind: 'adherence_report',
+        payload: expect.objectContaining({
+          metadata: expect.objectContaining({
+            percentage: 100,
+            storytelling: expect.stringContaining('📈 Melhora'),
+          }),
+        }),
+      }));
+    });
+  });
+
+  describe('checkStockAlerts', () => {
+    it('should provide predictive stock alerts (days remaining)', async () => {
+      // Mock users
+      setMockData([{ user_id: 'user1', timezone: 'America/Sao_Paulo' }]);
+
+      // Mock protocols (consumption calculation)
+      setMockData([
+        { user_id: 'user1', medicine_id: 'med1', time_schedule: ['08:00', '20:00'], dosage_per_intake: 1 }
+      ]);
+
+      // Mock stock
+      setMockData([
+        { user_id: 'user1', medicine_id: 'med1', quantity: 10, medicine: { name: 'Aspirina' } }
+      ]);
+
+      await checkStockAlerts({}, { correlationId: 'test-corr', notificationDispatcher: mockDispatcher });
+
+      // Daily consumption = 2. Stock = 10. Days remaining = 5.
+      expect(mockDispatcher.dispatch).toHaveBeenCalledWith(expect.objectContaining({
+        kind: 'stock_alert',
+        payload: expect.objectContaining({
+          metadata: expect.objectContaining({
+            daysRemaining: 5,
+            stockQuantity: 10,
+          }),
+        }),
+      }));
+    });
+  });
+
+});

--- a/server/bot/tasks.js
+++ b/server/bot/tasks.js
@@ -14,9 +14,19 @@ import { escapeMarkdownV2 } from '../utils/formatters.js';
 import { partitionDoses } from './utils/partitionDoses.js';
 import { parseLocalDate, formatLocalDate } from '../utils/dateUtils.js';
 
+
 const logger = createLogger('Tasks');
 
-
+/**
+ * Retorna uma saudação baseada na hora do dia
+ * @param {number} hour - Hora local (0-23)
+ * @returns {string}
+ */
+function getGreeting(hour) {
+  if (hour >= 5 && hour < 12) return 'Bom dia';
+  if (hour >= 12 && hour < 18) return 'Boa tarde';
+  return 'Boa noite';
+}
 
 /**
  * Função genérica para enviar alertas de estoque
@@ -31,18 +41,6 @@ const logger = createLogger('Tasks');
  * @param {object} params.dlqPayload - Dados para enfileiramento em DLQ em caso de erro
  * @param {object} params.logContext - Contexto adicional para logging
  */
-
-
-
-
-
-
-
-
-
-
-
-
 
 /**
  * Format titration alert message
@@ -96,19 +94,25 @@ async function checkRemindersViaDispatcher(dispatcher, correlationId) {
 
     if (userError) throw userError;
 
-    if (!users || users.length === 0) {
-      logger.info('Nenhum usuário encontrado em user_settings para dispatch', { correlationId });
+    // WAVE 11: Filtrar usuários que não estão no modo realtime
+    // Silent: sem notificações
+    // Digest: notificações individuais suprimidas (recebe apenas o resumo matinal)
+    const realtimeUsers = (users || []).filter(u => u.notification_mode === 'realtime');
+
+    if (realtimeUsers.length === 0) {
+      logger.info('Nenhum usuário em modo realtime encontrado para dispatch de lembretes unitários', { correlationId });
       return;
     }
 
-    logger.info(`Iniciando verificação de lembretes para ${users.length} usuários (Dispatcher)`, { correlationId });
+    logger.info(`Iniciando verificação de lembretes para ${realtimeUsers.length} usuários em modo realtime`, { correlationId });
 
     // Otimização Wave 12: Agrupar usuários por HHMM local para busca otimizada via JSONB (@>)
     // R-020: Usamos Map para garantir consistência de tempo por usuário (evita minute-flip race)
     const userTimes = new Map();
     const userIdsByHHMM = {};
     
-    for (const user of users) {
+    for (const user of realtimeUsers) {
+
       const timezone = user.timezone || 'America/Sao_Paulo';
       // Sanitização: remove caracteres de controle do Intl (ex: \u202f no Node 18+) que quebram JSONB
       const currentHHMM = getCurrentTimeInTimezone(timezone).replace(/[^\d:]/g, ''); 
@@ -156,7 +160,7 @@ async function checkRemindersViaDispatcher(dispatcher, correlationId) {
       protocolsByUser[p.user_id].push(p);
     }
 
-    for (const user of users) {
+    for (const user of realtimeUsers) {
       const userId = user.user_id;
 
       try {
@@ -334,7 +338,12 @@ async function runDailyDigestViaDispatcher(dispatcher, correlationId) {
           continue;
         }
 
-        eligibleEntries.push({ userId, timezone, displayName: user.display_name });
+        eligibleEntries.push({ 
+          userId, 
+          timezone, 
+          displayName: user.display_name,
+          digestTime 
+        });
       } catch (err) {
         logger.error(`Error evaluating daily digest eligibility for user`, err, { userId, correlationId });
       }
@@ -349,7 +358,7 @@ async function runDailyDigestViaDispatcher(dispatcher, correlationId) {
     const eligibleIds = eligibleEntries.map(e => e.userId);
     const { data: allProtocols } = await supabase
       .from('protocols')
-      .select('*, medicine:medicines(name)')
+      .select('*, medicine:medicines(name, dosage_unit)')
       .in('user_id', eligibleIds)
       .eq('active', true);
 
@@ -360,86 +369,89 @@ async function runDailyDigestViaDispatcher(dispatcher, correlationId) {
     }
 
     // Fase 3: dispatch por usuário com dados já em memória
-    for (const { userId, timezone, displayName } of eligibleEntries) {
+    for (const { userId, timezone, displayName, digestTime } of eligibleEntries) {
       try {
-        // Buscar logs de hoje E de ontem para Storytelling (Wave 12)
         const dateToday = getCurrentDateInTimezone(timezone);
-        const dateYesterdayDate = parseLocalDate(dateToday);
+        const dateTodayStart = parseLocalDate(dateToday);
+        const dateYesterdayDate = new Date(dateTodayStart);
         dateYesterdayDate.setDate(dateYesterdayDate.getDate() - 1);
         const dateYesterday = formatLocalDate(dateYesterdayDate);
 
+        // Buscar logs de ontem para o nudge motivacional (Wave 12)
         const { data: logs } = await supabase
           .from('medicine_logs')
           .select('*')
           .eq('user_id', userId)
-          .gte('taken_at', dateYesterdayDate.toISOString());
+          .gte('taken_at', dateYesterdayDate.toISOString())
+          .lt('taken_at', dateTodayStart.toISOString());
 
-        const todayLogs = logs?.filter(l => new Intl.DateTimeFormat('en-CA', { timeZone: timezone }).format(new Date(l.taken_at)) === dateToday) || [];
-        const yesterdayLogs = logs?.filter(l => new Intl.DateTimeFormat('en-CA', { timeZone: timezone }).format(new Date(l.taken_at)) === dateYesterday) || [];
-
+        const yesterdayLogs = logs || [];
         const protocols = protocolsByUser[userId] || [];
-        const expectedDoses = protocols.reduce((sum, p) => sum + (p.time_schedule?.length || 0), 0);
-        const takenDosesToday = todayLogs.length;
-        const takenDosesYesterday = yesterdayLogs.length;
         
-        const percentageToday = expectedDoses > 0 ? Math.round((takenDosesToday / expectedDoses) * 100) : 0;
-        const percentageYesterday = expectedDoses > 0 ? Math.round((takenDosesYesterday / expectedDoses) * 100) : 0;
+        // Cálculo de Score de Ontem
+        const expectedDosesYesterday = protocols.reduce((sum, p) => {
+          // Filtrar protocolos que já estavam ativos ontem
+          if (p.start_date && p.start_date > dateYesterday) return sum;
+          return sum + (p.time_schedule?.length || 0);
+        }, 0);
+        const takenDosesYesterday = yesterdayLogs.length;
+        const percentageYesterday = expectedDosesYesterday > 0 ? Math.min(100, Math.round((takenDosesYesterday / expectedDosesYesterday) * 100)) : 0;
 
-        // Construir Storytelling
-        let storytelling = '';
-        if (percentageToday > percentageYesterday) {
-          storytelling = `📈 Melhora de ${percentageToday - percentageYesterday}% em relação a ontem! Continue assim.`;
-        } else if (percentageToday < percentageYesterday && percentageToday > 0) {
-          storytelling = `📉 Hoje você tomou um pouco menos que ontem (${percentageToday}% vs ${percentageYesterday}%). Vamos recuperar amanhã?`;
-        } else if (percentageToday === 100) {
-          storytelling = `🌟 Dia perfeito! Você manteve os 100% de ontem.`;
-        } else {
-          storytelling = `⚖️ Mantendo a constância! ${percentageToday}% hoje.`;
+        // Agenda de Hoje
+        const todaySchedule = [];
+        protocols.forEach(p => {
+          (p.time_schedule || []).forEach(time => {
+            todaySchedule.push({
+              time,
+              medicineName: p.medicine?.name || p.name,
+              dosage: p.dosage_per_intake || 1,
+              unit: p.medicine?.dosage_unit || 'dose'
+            });
+          });
+        });
+        todaySchedule.sort((a, b) => a.time.localeCompare(b.time));
+
+        const currentHour = parseInt(digestTime.split(':')[0], 10);
+        const greeting = getGreeting(currentHour);
+        const dateStr = dateTodayStart.toLocaleDateString('pt-BR');
+        
+        // Template Rico (Telegram / Inbox) - Planejador Matinal
+        const richTitle = `📅 Seu Planejador — ${dateStr}`;
+        let richBody = `${greeting}, ${displayName || 'Paciente'}! 👋\n\n`;
+        
+        if (expectedDosesYesterday > 0) {
+          richBody += `📊 **Ontem:** você completou ${percentageYesterday}% das doses\\. `;
+          richBody += percentageYesterday === 100 ? 'Excelente\\! 🌟' : 'Vamos manter o foco hoje? 💪';
+          richBody += `\n\n`;
         }
 
-        const dateStr = parseLocalDate(dateToday).toLocaleDateString('pt-BR');
-        const nudge = getMotivationalNudge(percentageToday);
-        
-        // Template Rico (Telegram / Inbox)
-        const richTitle = `📋 Resumo do Dia — ${dateStr}`;
-        let richBody = `Olá, ${displayName || 'Paciente'}! 👋\n\n`;
-        richBody += `${nudge}\n\n`;
-        richBody += `📊 **Sua Adesão Hoje:** ${takenDosesToday}/${expectedDoses} doses (${percentageToday}%)\n`;
-        richBody += `${storytelling}\n\n`;
-        
-        if (protocols.length > 0) {
-          richBody += `📝 **Detalhamento por Protocolo:**\n`;
-          protocols.forEach(p => {
-            const pLogs = todayLogs.filter(l => l.protocol_id === p.id).length;
-            const pExpected = p.time_schedule?.length || 0;
-            const statusEmoji = pLogs >= pExpected ? '✅' : pLogs > 0 ? '⚠️' : '❌';
-            richBody += `${statusEmoji} ${escapeMarkdownV2(p.name)}: ${pLogs}/${pExpected}\n`;
+        if (todaySchedule.length > 0) {
+          richBody += `🕒 **Sua Agenda de Hoje:**\n`;
+          todaySchedule.forEach(s => {
+            richBody += `• ${s.time} — ${escapeMarkdownV2(s.medicineName)} (${s.dosage} ${escapeMarkdownV2(s.unit)})\n`;
           });
+        } else {
+          richBody += `✨ Você não tem doses agendadas para hoje\\. Aproveite o descanso\\!`;
         }
 
         // Template Compacto (Push)
-        const pushBody = `${nudge} Hoje: ${percentageToday}%.` + (storytelling ? ` ${storytelling.split('!')[0]}!` : '');
+        const pushBody = `${greeting}\\! Ontem: ${percentageYesterday}%\\. Hoje você tem ${todaySchedule.length} doses agendadas\\. Vamos nessa?`;
 
         await dispatcher.dispatch({
           userId,
           kind: 'daily_digest',
-          data: {
+          payload: {
             title: richTitle,
             body: richBody,
             pushBody,
-            summary: `${dateStr} — ${percentageToday}%`,
-            percentage: percentageToday,
-            taken_doses: takenDosesToday,
-            expected_doses: expectedDoses,
-            nudge,
-            storytelling,
-            details: protocols.map(p => ({
-              name: p.name,
-              protocol_id: p.id,
-              taken: todayLogs.filter(l => l.protocol_id === p.id).length,
-              expected: p.time_schedule?.length || 0
-            }))
-          }
+            metadata: {
+              summary: `${dateStr} — ${todaySchedule.length} doses`,
+              yesterdayPercentage: percentageYesterday,
+              scheduleCount: todaySchedule.length,
+              greeting
+            }
+          },
+          context: { correlationId, jobType: 'daily_digest' }
         });
 
       } catch (err) {
@@ -461,7 +473,8 @@ async function runDailyAdherenceReportViaDispatcher(dispatcher, correlationId) {
     const { data: users } = await supabase
       .from('user_settings')
       .select('user_id, timezone, display_name, digest_time, notification_mode')
-      .neq('notification_mode', 'digest_morning');
+      .neq('notification_mode', 'silent');
+
 
     if (!users || users.length === 0) return;
 
@@ -506,54 +519,87 @@ async function runDailyAdherenceReportViaDispatcher(dispatcher, correlationId) {
       try {
         const dateToday = getCurrentDateInTimezone(timezone || 'America/Sao_Paulo');
         const startOfDay = parseLocalDate(dateToday);
+        const dateYesterdayDate = new Date(startOfDay);
+        dateYesterdayDate.setDate(dateYesterdayDate.getDate() - 1);
+        const startOfYesterday = formatLocalDate(dateYesterdayDate);
         
         const { data: logs } = await supabase
           .from('medicine_logs')
           .select('*')
           .eq('user_id', userId)
-          .gte('taken_at', startOfDay.toISOString());
+          .gte('taken_at', dateYesterdayDate.toISOString());
+
+        const todayLogs = logs?.filter(l => l.taken_at >= startOfDay.toISOString()) || [];
+        const yesterdayLogs = logs?.filter(l => l.taken_at < startOfDay.toISOString() && l.taken_at >= dateYesterdayDate.toISOString()) || [];
 
         const protocols = protocolsByUser[userId] || [];
         if (protocols.length === 0) continue;
 
         const expectedDoses = protocols.reduce((sum, p) => sum + (p.time_schedule?.length || 0), 0);
-        const takenDoses = logs?.length || 0;
-        const percentage = expectedDoses > 0 ? Math.round((takenDoses / expectedDoses) * 100) : 0;
+        const takenDoses = todayLogs.length;
+        const percentage = expectedDoses > 0 ? Math.min(100, Math.round((takenDoses / expectedDoses) * 100)) : 0;
+        
+        const expectedYesterday = protocols.reduce((sum, p) => {
+          if (p.start_date && p.start_date > startOfYesterday) return sum;
+          return sum + (p.time_schedule?.length || 0);
+        }, 0);
+        const percentageYesterday = expectedYesterday > 0 ? Math.min(100, Math.round((yesterdayLogs.length / expectedYesterday) * 100)) : 0;
+
+        // Storytelling logic
+        let storytelling = '';
+        if (percentage > percentageYesterday) {
+          storytelling = `📈 Melhora de ${percentage - percentageYesterday}% em relação a ontem\\!`;
+        } else if (percentage < percentageYesterday && percentage > 0) {
+          storytelling = `📉 Hoje foi um pouco mais difícil que ontem (${percentage}% vs ${percentageYesterday}%)\\.`;
+        } else if (percentage === 100 && percentageYesterday === 100) {
+          storytelling = `🌟 Segundo dia seguido com 100%\\!`;
+        } else if (percentage === 0 && expectedDoses > 0) {
+          storytelling = `🧘 Amanhã é uma nova oportunidade para cuidar de você\\.`;
+        } else {
+          storytelling = `⚖️ Mantendo a constância de ontem\\.`;
+        }
 
         const nudge = getMotivationalNudge(percentage);
-        const dateStr = new Intl.DateTimeFormat('pt-BR', { timeZone: timezone }).format(new Date());
+        const dateStr = startOfDay.toLocaleDateString('pt-BR');
 
-        const title = `📊 Relatório de Adesão — ${dateStr}`;
-        let body = `Olá, ${displayName || 'Paciente'}! Aqui está seu desempenho de hoje:\n\n`;
-        body += `${nudge}\n\n`;
-        body += `✅ **Doses Tomadas:** ${takenDoses}\n`;
-        body += `📅 **Doses Previstas:** ${expectedDoses}\n`;
-        body += `📈 **Score do Dia:** ${percentage}%\n\n`;
+        const title = `🌙 Resumo do seu Dia — ${dateStr}`;
+        let body = `Olá, ${displayName || 'Paciente'}! 👋\n\n`;
+        body += `📊 **Hoje:** ${percentage}% das doses concluídas (${takenDoses}/${expectedDoses})\\.\n`;
+        body += `📈 **Comparação:** ${storytelling}\n\n`;
+        body += `${escapeMarkdownV2(nudge)}\n\n`;
 
-        if (percentage < 100 && expectedDoses > takenDoses) {
-          body += `💡 *Dica:* Que tal ajustar os horários das próximas doses para facilitar seu dia?`;
-        } else if (percentage === 100) {
-          body += `🏆 **Excelência!** Você completou 100% do seu tratamento hoje.`;
+        if (percentage === 100) {
+          body += `🏆 **Excelência\\!** Amanhã seguimos firmes\\.`;
+        } else {
+          body += `💡 Amanhã é uma nova chance de brilhar\\!`;
         }
+
+        // Template Compacto (Push)
+        const pushBody = `🌙 Resumo: ${percentage}% concluído hoje\\. ${storytelling.split('\\!')[0]}\\! Prepare-se para amanhã\\!`;
 
         await dispatcher.dispatch({
           userId,
-          kind: 'daily_adherence_report',
-          data: {
+          kind: 'adherence_report',
+          payload: {
             title,
             body,
-            summary: `${dateStr} — ${percentage}%`,
-            percentage,
-            taken_doses: takenDoses,
-            expected_doses: expectedDoses,
-            nudge,
-            details: protocols.map(p => ({
-              name: p.medicine?.name || 'Medicamento',
-              protocol_id: p.id,
-              taken: logs?.filter(l => l.protocol_id === p.id).length || 0,
-              expected: p.time_schedule?.length || 1
-            }))
-          }
+            pushBody,
+            metadata: {
+              summary: `${dateStr} — ${percentage}%`,
+              percentage,
+              taken_doses: takenDoses,
+              expected_doses: expectedDoses,
+              nudge,
+              storytelling,
+              details: protocols.map(p => ({
+                name: p.medicine?.name || 'Medicamento',
+                protocol_id: p.id,
+                taken: todayLogs.filter(l => l.protocol_id === p.id).length || 0,
+                expected: p.time_schedule?.length || 1
+              }))
+            }
+          },
+          context: { correlationId, jobType: 'adherence_report' }
         });
 
       } catch (err) {
@@ -609,15 +655,19 @@ export async function checkStockAlertsViaDispatcher(dispatcher, correlationId) {
     // 1. Buscar todos os usuários ativos com configurações (evita auth.users por causa do RLS)
     const { data: users, error: usersErr } = await supabase
       .from('user_settings')
-      .select('user_id, timezone');
+      .select('user_id, timezone, notification_mode');
 
     if (usersErr || !users || users.length === 0) {
       logger.info('Nenhum usuário encontrado em user_settings para alertas de estoque', { correlationId });
       return;
     }
 
-    const userIds = users.map(u => u.user_id);
-    logger.info(`Verificando alertas de estoque para ${userIds.length} usuários`, { correlationId });
+    // WAVE 11: Respeitar o modo de notificação (Silent = nada)
+    const eligibleUsers = users.filter(u => u.notification_mode !== 'silent');
+    if (eligibleUsers.length === 0) return;
+
+    const userIds = eligibleUsers.map(u => u.user_id);
+    logger.info(`Verificando alertas de estoque para ${userIds.length} usuários elegíveis`, { correlationId });
 
     // 2. Buscar protocolos ativos para calcular consumo diário (ADR-022)
     const { data: allProtocols } = await supabase
@@ -670,16 +720,23 @@ export async function checkStockAlertsViaDispatcher(dispatcher, correlationId) {
           userId, medicineId, correlationId
         });
 
+        const richTitle = `📦 Alerta de Estoque: ${escapeMarkdownV2(stock.name)}`;
+        const richBody = `📉 **Restam:** ${stock.qty} doses\\.\n⏳ **Previsão:** Acaba em aproximadamente **${daysRemaining} dias**\\.\n\nRecomendamos a reposição em breve\\.`;
+        const pushBody = `📦 ${stock.name} acabando: restam ${stock.qty} doses (~${daysRemaining} dias)\\. Garanta sua reposição\\!`;
+
         await dispatcher.dispatch({
           userId,
           kind: 'stock_alert',
-          data: {
-            title: '📦 Estoque Baixo',
-            body: `Seu estoque de ${stock.name} está acabando (restam aprox. ${daysRemaining} dias).`,
-            medicineId,
-            medicineName: stock.name,
-            daysRemaining,
-            stockQuantity: stock.qty
+          payload: {
+            title: richTitle,
+            body: richBody,
+            pushBody,
+            metadata: {
+              medicineId,
+              medicineName: stock.name,
+              daysRemaining,
+              stockQuantity: stock.qty
+            }
           },
           context: { correlationId, jobType: 'stock_alert_dispatcher' }
         });
@@ -699,14 +756,18 @@ export async function checkAdherenceReportsViaDispatcher(dispatcher, correlation
   try {
     const { data: users, error: userError } = await supabase
       .from('user_settings')
-      .select('user_id, timezone');
+      .select('user_id, timezone, notification_mode');
 
     if (userError) throw userError;
     if (!users || users.length === 0) return;
 
-    logger.info(`Iniciando relatórios semanais via Dispatcher para ${users.length} usuários`, { correlationId });
+    // WAVE 11: Respeitar o modo de notificação (Silent = nada)
+    const eligibleUsers = users.filter(u => u.notification_mode !== 'silent');
+    if (eligibleUsers.length === 0) return;
 
-    for (const user of users) {
+    logger.info(`Iniciando relatórios semanais via Dispatcher para ${eligibleUsers.length} usuários elegíveis`, { correlationId });
+
+    for (const user of eligibleUsers) {
       const userId = user.user_id;
       
       // Cálculo de adesão (últimos 7 dias)

--- a/server/bot/tasks.js
+++ b/server/bot/tasks.js
@@ -417,7 +417,7 @@ async function runDailyDigestViaDispatcher(dispatcher, correlationId) {
         
         // Template Rico (Telegram / Inbox) - Planejador Matinal
         const richTitle = `📅 Seu Planejador — ${dateStr}`;
-        let richBody = `${greeting}, ${displayName || 'Paciente'}! 👋\n\n`;
+        let richBody = `${escapeMarkdownV2(greeting)}, ${escapeMarkdownV2(displayName || 'Paciente')}\\! 👋\n\n`;
         
         if (expectedDosesYesterday > 0) {
           richBody += `📊 **Ontem:** você completou ${percentageYesterday}% das doses\\. `;
@@ -428,14 +428,14 @@ async function runDailyDigestViaDispatcher(dispatcher, correlationId) {
         if (todaySchedule.length > 0) {
           richBody += `🕒 **Sua Agenda de Hoje:**\n`;
           todaySchedule.forEach(s => {
-            richBody += `• ${s.time} — ${escapeMarkdownV2(s.medicineName)} (${s.dosage} ${escapeMarkdownV2(s.unit)})\n`;
+            richBody += `• ${s.time} — ${escapeMarkdownV2(s.medicineName)} \\(${s.dosage} ${escapeMarkdownV2(s.unit)}\\)\n`;
           });
         } else {
           richBody += `✨ Você não tem doses agendadas para hoje\\. Aproveite o descanso\\!`;
         }
 
-        // Template Compacto (Push)
-        const pushBody = `${greeting}\\! Ontem: ${percentageYesterday}%\\. Hoje você tem ${todaySchedule.length} doses agendadas\\. Vamos nessa?`;
+        // Template Compacto (Push) - Sem escapes Markdown
+        const pushBody = `${greeting}! Ontem: ${percentageYesterday}%. Hoje você tem ${todaySchedule.length} doses agendadas. Vamos nessa?`;
 
         await dispatcher.dispatch({
           userId,
@@ -563,8 +563,8 @@ async function runDailyAdherenceReportViaDispatcher(dispatcher, correlationId) {
         const dateStr = startOfDay.toLocaleDateString('pt-BR');
 
         const title = `🌙 Resumo do seu Dia — ${dateStr}`;
-        let body = `Olá, ${displayName || 'Paciente'}! 👋\n\n`;
-        body += `📊 **Hoje:** ${percentage}% das doses concluídas (${takenDoses}/${expectedDoses})\\.\n`;
+        let body = `Olá, ${escapeMarkdownV2(displayName || 'Paciente')}\\! 👋\n\n`;
+        body += `📊 **Hoje:** ${percentage}% das doses concluídas \\(${takenDoses}/${expectedDoses}\\)\\.\n`;
         body += `📈 **Comparação:** ${storytelling}\n\n`;
         body += `${escapeMarkdownV2(nudge)}\n\n`;
 
@@ -574,8 +574,8 @@ async function runDailyAdherenceReportViaDispatcher(dispatcher, correlationId) {
           body += `💡 Amanhã é uma nova chance de brilhar\\!`;
         }
 
-        // Template Compacto (Push)
-        const pushBody = `🌙 Resumo: ${percentage}% concluído hoje\\. ${storytelling.split('\\!')[0]}\\! Prepare-se para amanhã\\!`;
+        // Template Compacto (Push) - Sem escapes Markdown
+        const pushBody = `🌙 Resumo: ${percentage}% concluído hoje. ${storytelling.replace(/\\/g, '')} Prepare-se para amanhã!`;
 
         await dispatcher.dispatch({
           userId,

--- a/server/notifications/channels/expoPushChannel.js
+++ b/server/notifications/channels/expoPushChannel.js
@@ -27,7 +27,7 @@ export async function sendExpoPushNotification({ userId, payload, context, repos
     to: device.push_token,
     sound: 'default',
     title: payload.title,
-    body: payload.body,
+    body: payload.pushBody || payload.body,
     data: {
       ...(payload.metadata ?? {}),
       notificationLogId: payload.metadata?.notificationLogId ?? null,

--- a/server/notifications/dispatcher/dispatchNotification.js
+++ b/server/notifications/dispatcher/dispatchNotification.js
@@ -4,7 +4,7 @@
 // correlationId é obrigatório em todos os logs (R-087)
 
 import { z } from 'zod'
-import { buildNotificationPayload } from '../payloads/buildNotificationPayload.js'
+import { buildNotificationPayload, kindSchema } from '../payloads/buildNotificationPayload.js'
 import { sendTelegramNotification } from '../channels/telegramChannel.js'
 import { sendExpoPushNotification } from '../channels/expoPushChannel.js'
 import { shouldSendNow } from '../utils/notificationGate.js'
@@ -16,7 +16,7 @@ const logger = createLogger('Dispatcher')
 
 const dispatchInputSchema = z.object({
   userId: z.string().min(1),
-  kind: z.string().min(1), // Relaxed for flexibility, buildNotificationPayload will validate
+  kind: kindSchema,
   channels: z.array(z.string()).default([]),
 })
 

--- a/server/notifications/dispatcher/dispatchNotification.js
+++ b/server/notifications/dispatcher/dispatchNotification.js
@@ -4,26 +4,19 @@
 // correlationId é obrigatório em todos os logs (R-087)
 
 import { z } from 'zod'
+import { buildNotificationPayload } from '../payloads/buildNotificationPayload.js'
 import { sendTelegramNotification } from '../channels/telegramChannel.js'
 import { sendExpoPushNotification } from '../channels/expoPushChannel.js'
+import { shouldSendNow } from '../utils/notificationGate.js'
 import { normalizeChannelResults } from '../utils/normalizeChannelResults.js'
 import { notificationLogRepository } from '../repositories/notificationLogRepository.js'
-import { shouldSendNow } from '../utils/notificationGate.js'
+import { createLogger } from '../../bot/logger.js'
+
+const logger = createLogger('Dispatcher')
 
 const dispatchInputSchema = z.object({
   userId: z.string().min(1),
-  kind: z.enum([
-    'dose_reminder', 
-    'dose_reminder_by_plan', 
-    'dose_reminder_misc', 
-    'stock_alert', 
-    'daily_digest',
-    'weekly_adherence',
-    'monthly_report',
-    'titration_alert',
-    'prescription_alert',
-    'adherence_report'
-  ]),
+  kind: z.string().min(1), // Relaxed for flexibility, buildNotificationPayload will validate
   channels: z.array(z.string()).default([]),
 })
 
@@ -35,11 +28,11 @@ async function dispatchChannel({ channel, userId, payload, context, repositories
     } else if (channel === 'mobile_push') {
       return await sendExpoPushNotification({ userId, payload, context, repositories, expoClient })
     } else {
-      console.warn('[dispatchNotification] canal desconhecido ignorado', { correlationId, channel })
+      logger.warn('canal desconhecido ignorado', { correlationId, channel })
       return null
     }
   } catch (error) {
-    console.error('[dispatchNotification] canal falhou', { correlationId, userId, channel, error: error.message })
+    logger.error('canal falhou', error, { correlationId, userId, channel })
     return {
       channel,
       success: false,
@@ -52,7 +45,7 @@ async function dispatchChannel({ channel, userId, payload, context, repositories
   }
 }
 
-export async function dispatchNotification({ userId, kind, payload, channels, context, repositories, bot, expoClient }) {
+export async function dispatchNotification({ userId, kind, payload, data, channels, context, repositories, bot, expoClient }) {
   const parsed = dispatchInputSchema.safeParse({ userId, kind, channels })
   if (!parsed.success) {
     throw new Error(`[dispatchNotification] Entrada inválida: ${parsed.error.message}`)
@@ -62,15 +55,18 @@ export async function dispatchNotification({ userId, kind, payload, channels, co
   const ctx = { ...context, correlationId }
   const validChannels = parsed.data.channels
 
+  // Se payload não veio, tentamos construir a partir de data usando o builder canônico
+  // Isso unifica as chamadas vindas de tasks legadas que ainda usam "data"
+  const finalPayload = payload || (typeof buildNotificationPayload === 'function' ? buildNotificationPayload({ kind, data }) : (data || {}))
+
   // --- Wave N2: Centralized Gate Policy ---
   let isSuppressed = false
-  const isAlert = !['daily_digest', 'weekly_adherence', 'monthly_report'].includes(kind)
+  // Relatórios e digests não são "alertas" e ignoram quiet_hours e modo digest (só param no silent)
+  const isAlert = !['daily_digest', 'weekly_adherence', 'monthly_report', 'adherence_report'].includes(kind)
 
   if (isAlert) {
     const settings = await repositories.preferences.getSettingsByUserId(userId)
     const now = new Date()
-    // TODO: Usar luxon ou date-fns para timezone correto se necessário, 
-    // mas shouldSendNow usa HH:MM string que simplifica
     const currentHHMM = now.toLocaleTimeString('pt-BR', { 
       hour: '2-digit', 
       minute: '2-digit', 
@@ -80,23 +76,30 @@ export async function dispatchNotification({ userId, kind, payload, channels, co
 
     const isQuietEnabled = settings.quiet_hours_enabled ?? false
     
-    if (isQuietEnabled && !shouldSendNow({
-      mode: settings.notification_mode,
-      quietHoursStart: settings.quiet_hours_start,
-      quietHoursEnd: settings.quiet_hours_end,
+    const shouldSend = shouldSendNow({
+      mode: settings.notification_mode || 'realtime',
+      quietHoursStart: isQuietEnabled ? settings.quiet_hours_start : null,
+      quietHoursEnd: isQuietEnabled ? settings.quiet_hours_end : null,
       currentHHMM
-    })) {
+    })
+
+    if (!shouldSend) {
       isSuppressed = true
-      console.info('[dispatchNotification] suprimida pelo gate', { correlationId, userId, kind, mode: settings.notification_mode })
+      console.info('[dispatchNotification] suprimida pelo gate', { 
+        correlationId, 
+        userId, 
+        kind, 
+        mode: settings.notification_mode,
+        quietHours: isQuietEnabled ? `${settings.quiet_hours_start}-${settings.quiet_hours_end}` : 'disabled'
+      })
     }
   }
 
   if (validChannels.length === 0 && !isSuppressed) {
     console.info('[dispatchNotification] nenhum canal físico ativo — prosseguindo apenas com log (Inbox-First)', { correlationId, userId, kind })
-    // Não retornamos mais; deixamos seguir para a rotina de log
   }
 
-  console.info('[dispatchNotification] iniciando', { 
+  logger.info('Iniciando dispatch de notificação', { 
     correlationId, 
     userId, 
     kind, 
@@ -107,7 +110,7 @@ export async function dispatchNotification({ userId, kind, payload, channels, co
   let results = []
   if (!isSuppressed && validChannels.length > 0) {
     const settledResults = await Promise.allSettled(
-      validChannels.map((channel) => dispatchChannel({ channel, userId, payload, context: ctx, repositories, bot, expoClient }))
+      validChannels.map((channel) => dispatchChannel({ channel, userId, payload: finalPayload, context: ctx, repositories, bot, expoClient }))
     )
 
     results = settledResults
@@ -124,19 +127,16 @@ export async function dispatchNotification({ userId, kind, payload, channels, co
   const normalized = normalizeChannelResults(results);
 
   // Sprint 8.4: Um único log por evento (não por canal) — evita duplicatas na inbox
-  // Fire-and-forget: não trava o retorno para o cron/request original
   ;(async () => {
     try {
       // Wave 12: Sempre logar se houver payload, mesmo sem canais físicos, para alimentar a Inbox
-      if (!payload) return;
+      if (!finalPayload) return;
 
       const isGroupedKind = kind === 'dose_reminder_by_plan' || kind === 'dose_reminder_misc'
-      const protocolId = isGroupedKind ? null : (payload?.metadata?.protocolId ?? null)
+      const protocolId = isGroupedKind ? null : (finalPayload?.metadata?.protocolId ?? null)
       
-      // Filtra canais sem tentativa e sem erro (ex: nenhum device registrado)
       const activeResults = results.filter(r => r.attempted > 0 || r.errors.length > 0)
 
-      // Consolida canais num único array para o log
       const logChannels = activeResults.map((res) => ({
         channel:    res.channel,
         status:     res.success ? 'enviada' : 'falhou',
@@ -144,8 +144,6 @@ export async function dispatchNotification({ userId, kind, payload, channels, co
         tickets:    res.channel === 'mobile_push' ? (res.tickets ?? null) : null,
       }))
 
-      // Status geral: enviada se ao menos um canal teve sucesso, falhou se todos falharam, silenciada,
-      // ou enviada se for apenas Inbox (sem canais físicos mas não suprimida)
       let overallStatus = 'falhou'
       if (isSuppressed) {
         overallStatus = 'silenciada'
@@ -160,26 +158,25 @@ export async function dispatchNotification({ userId, kind, payload, channels, co
           user_id:              userId,
           protocol_id:          protocolId,
           notification_type:    kind,
-          title:                payload.title ?? null,
-          body:                 payload.body ?? null,
-          medicine_name:        payload.metadata?.medicineName ?? null,
-          protocol_name:        payload.metadata?.protocolName ?? null,
-          treatment_plan_id:    payload.metadata?.planId ?? null,
-          treatment_plan_name:  payload.metadata?.planName ?? null,
+          title:                finalPayload.title ?? null,
+          body:                 finalPayload.body ?? null,
+          medicine_name:        finalPayload.metadata?.medicineName ?? null,
+          protocol_name:        finalPayload.metadata?.protocolName ?? null,
+          treatment_plan_id:    finalPayload.metadata?.planId ?? null,
+          treatment_plan_name:  finalPayload.metadata?.planName ?? null,
           status:               overallStatus,
           channels:             logChannels,
           telegram_message_id:  logChannels.find(c => c.channel === 'telegram')?.message_id ?? null,
           mensagem_erro:        firstError,
           provider_metadata: {
-            ...(payload.metadata?.protocolIds ? { protocol_ids: payload.metadata.protocolIds } : {}),
-            ...(payload.metadata?.planId ? { treatment_plan_id: payload.metadata.planId } : {}),
-            // M2.5: Metadados de adesão para Inbox
-            ...(payload.metadata?.percentage !== undefined ? { percentage: payload.metadata.percentage } : {}),
-            ...(payload.metadata?.expected_doses !== undefined ? { expected_doses: payload.metadata.expected_doses } : {}),
-            ...(payload.metadata?.taken_doses !== undefined ? { taken_doses: payload.metadata.taken_doses } : {}),
-            ...(payload.metadata?.nudge ? { nudge: payload.metadata.nudge } : {}),
-            ...(payload.metadata?.storytelling ? { storytelling: payload.metadata.storytelling } : {}),
-            ...(payload.metadata?.details ? { details: payload.metadata.details } : {}),
+            ...(finalPayload.metadata?.protocolIds ? { protocol_ids: finalPayload.metadata.protocolIds } : {}),
+            ...(finalPayload.metadata?.planId ? { treatment_plan_id: finalPayload.metadata.planId } : {}),
+            ...(finalPayload.metadata?.percentage !== undefined ? { percentage: finalPayload.metadata.percentage } : {}),
+            ...(finalPayload.metadata?.expected_doses !== undefined ? { expected_doses: finalPayload.metadata.expected_doses } : {}),
+            ...(finalPayload.metadata?.taken_doses !== undefined ? { taken_doses: finalPayload.metadata.taken_doses } : {}),
+            ...(finalPayload.metadata?.nudge ? { nudge: finalPayload.metadata.nudge } : {}),
+            ...(finalPayload.metadata?.storytelling ? { storytelling: finalPayload.metadata.storytelling } : {}),
+            ...(finalPayload.metadata?.details ? { details: finalPayload.metadata.details } : {}),
           },
         })
       } catch (logErr) {
@@ -197,7 +194,8 @@ export async function dispatchNotification({ userId, kind, payload, channels, co
     }
   })()
 
-  console.info('[dispatchNotification] concluído', {
+
+  logger.info('Notificação concluída', {
     correlationId,
     userId,
     kind,

--- a/server/notifications/payloads/buildNotificationPayload.js
+++ b/server/notifications/payloads/buildNotificationPayload.js
@@ -3,12 +3,13 @@
 
 import { z } from 'zod'
 
-const kindSchema = z.enum([
+export const kindSchema = z.enum([
   'dose_reminder',
   'dose_reminder_by_plan',
   'dose_reminder_misc',
   'stock_alert',
   'daily_digest',
+  'adherence_report',
 ])
 
 export function buildNotificationPayload({ kind, data }) {
@@ -76,6 +77,13 @@ export function buildNotificationPayload({ kind, data }) {
     case 'daily_digest':
       return {
         title: 'Resumo do dia',
+        body: data.summary,
+        deeplink: `dosiq://today`,
+        metadata: {},
+      }
+    case 'adherence_report':
+      return {
+        title: '📊 Relatório de Adesão',
         body: data.summary,
         deeplink: `dosiq://today`,
         metadata: {},


### PR DESCRIPTION
# 📦 feat(notifications): overhaul delivery gates and morning planner strategy

## 🎯 Resumo

Esta PR implementa uma reformulação completa no sistema de entrega de notificações do Dosiq. Centralizamos as regras de supressão no Dispatcher e implementamos a estratégia "Morning Planner" (Daily Digest) com saudações dinâmicas e payloads concisos para push mobile.

---

## 📋 Tarefas Implementadas

### 🚀 Funcionalidades Principais
- [x] **Dispatcher Centralizado**: Novo portão de supressão que unifica regras de `notification_mode` e `quiet_hours`.
- [x] **Estratégia Morning Planner**: Daily Digest reformulado com saudações baseadas no horário local ("Bom dia", etc).
- [x] **Relatório de Adesão Noturno**: Storytelling motivacional baseado no desempenho de ontem.
- [x] **Push Conciso**: Suporte a `pushBody` para evitar truncamento em dispositivos móveis.
- [x] **Elegibilidade Expandida**: Relatório de adesão agora atende a todos os usuários não-silenciosos.

### ✅ Testes e Qualidade
- [x] Refatoração de `tasks.test.js` para alinhar com o novo contrato de payload.
- [x] Verificação de `proactiveStockAlerts.test.js` (passando após correção no tasks).
- [x] Linting completo do servidor de bot e notificações (zero erros).

---

## 🔧 Arquivos Principais

```
server/
├── bot/
│   ├── tasks.js                    # Lógica de Morning Planner e Relatórios
│   └── __tests__/tasks.test.js     # Testes unitários das tarefas
└── notifications/
    ├── dispatcher/
    │   └── dispatchNotification.js  # Portão centralizado de entrega
    └── channels/
        └── expoPushChannel.js      # Suporte a pushBody conciso
```

---

## ✅ Checklist de Verificação

### Código
- [x] Todos os testes passam (`npm run test:critical` + tests manuais)
- [x] Lint sem erros (`npm run lint`)
- [x] Build bem-sucedido

### Funcionalidade
- [x] Digest ignorando quiet hours mas respeitando Silent Mode
- [x] Alertas unitários bloqueados fora do modo Realtime
- [x] Saudações dinâmicas funcionando por faixa de horário

---

## 🚀 Como Testar

```bash
# 1. Executar testes unitários das tarefas
npx vitest server/bot/__tests__/tasks.test.js

# 2. Executar testes de alertas de estoque
npx vitest apps/web/src/services/api/__tests__/proactiveStockAlerts.test.js

# 3. Validar linting
npm run lint
```

**Resultado esperado:**
- Todos os testes devem passar.
- Logs devem mostrar `isSuppressed: true` para alertas unitários quando o usuário está em modo `digest`.
- Logs devem mostrar `isSuppressed: false` para `daily_digest` mesmo em horários de silêncio (desde que não seja `silent`).

---

## 🔗 Issues Relacionadas
- Related to Wave 11 Implementation Plan

---

## 📝 Notas para Reviewers

1. **Dispatcher**: A lógica de supressão foi movida para dentro do dispatcher para garantir que NENHUM canal receba a notificação se ela for considerada suprimida, economizando recursos e garantindo consistência.
2. **Payload**: Agora o dispatcher aceita um objeto `payload` estruturado, seguindo o padrão de `buildNotificationPayload.js`.

---

/cc @reviewers
/cc @gemini-code-assist