### PR TITLE
fix(lint-wave-c2): corrigir react-hooks/exhaustive-deps (16x → 0x)

### DIFF
--- a/apps/mobile/src/features/dashboard/screens/TodayScreen.jsx
+++ b/apps/mobile/src/features/dashboard/screens/TodayScreen.jsx
@@ -41,10 +41,10 @@ export default function TodayScreen({ route, navigation }) {
 
   const { data, loading, error, stale, isDaySegregated, refresh } = useTodayData()
 
-  const timeline = data?.timeline ?? []
+  const timeline = useMemo(() => data?.timeline ?? [], [data?.timeline])
   const stockAlerts = data?.stockAlerts ?? []
-  const protocols = data?.protocols ?? []
-  const medicines = data?.medicines ?? {}
+  const protocols = useMemo(() => data?.protocols ?? [], [data?.protocols])
+  const medicines = useMemo(() => data?.medicines ?? {}, [data?.medicines])
   const stats = data?.stats ?? { expected: 0, taken: 0, score: 0 }
 
   // 1. Lógica de Persona: Threshold de complexidade adaptativa (Wave 10A)

--- a/apps/web/src/features/dashboard/hooks/_useDashboardDerived.js
+++ b/apps/web/src/features/dashboard/hooks/_useDashboardDerived.js
@@ -121,9 +121,9 @@ function _deriveDailyAdherence(protocols, logs) {
  * Extraído para reduzir linhas e complexidade do useDashboardContext.
  */
 export function useDashboardDerived(medicinesResult, protocolsResult, logsResult) {
-  const medicines = medicinesResult.data || []
-  const protocols = protocolsResult.data || []
-  const logs = logsResult.data || []
+  const medicines = useMemo(() => medicinesResult.data || [], [medicinesResult.data])
+  const protocols = useMemo(() => protocolsResult.data || [], [protocolsResult.data])
+  const logs = useMemo(() => logsResult.data || [], [logsResult.data])
 
   const rawStats = useMemo(() => _deriveRawStats(protocols, logs), [protocols, logs])
 

--- a/apps/web/src/features/settings/hooks/useSettingsState.js
+++ b/apps/web/src/features/settings/hooks/useSettingsState.js
@@ -5,12 +5,12 @@ import {
   getComplexityDisplayMode,
   generateTokenString,
   saveTelegramTokenSetting,
-  buildToggleWebPushHandler,
-  buildSaveQuietHoursHandler,
-  buildSaveDigestTimeHandler,
-  buildModeChangeHandler,
-  buildDisconnectTelegramHandler,
-  buildComplexityChangeHandler,
+  updateWebPushSetting,
+  updateNotificationModeSetting,
+  updateQuietHoursSetting,
+  updateDigestTimeSetting,
+  disconnectTelegramSetting,
+  updateComplexityModeSetting,
 } from './_settingsHelpers'
 
 function _makeShowMsg(setMessage) {
@@ -62,7 +62,10 @@ export function useSettingsState() {
   const [webPushSupported, setWebPushSupported] = useState(false)
   const [channelWebPushEnabled, setChannelWebPushEnabled] = useState(false)
 
-  const showMsg = _makeShowMsg(setMessage)
+  const showMsg = useCallback((type, text) => {
+    setMessage({ type, text })
+    setTimeout(() => setMessage({ type: '', text: '' }), 3000)
+  }, [])
 
   const fetchData = useCallback(async () => {
     try {
@@ -87,37 +90,87 @@ export function useSettingsState() {
 
   useEffect(() => { fetchData() }, [fetchData])
 
-  const handleToggleWebPush = useCallback(
-    buildToggleWebPushHandler({ setSavingChannel, channelWebPushEnabled, setChannelWebPushEnabled, showMsg }),
-    [channelWebPushEnabled]
-  )
+  const handleToggleWebPush = useCallback(async () => {
+    try {
+      setSavingChannel(true)
+      const newValue = !channelWebPushEnabled
+      if (newValue && (await Notification.requestPermission()) !== 'granted') {
+        return showMsg('error', 'Permissão de notificação negada.')
+      }
+      await updateWebPushSetting(newValue)
+      setChannelWebPushEnabled(newValue)
+      showMsg('success', `Notificações Web ${newValue ? 'ativadas' : 'desativadas'}.`)
+    } catch {
+      showMsg('error', 'Falha ao atualizar canal Web.')
+    } finally {
+      setSavingChannel(false)
+    }
+  }, [channelWebPushEnabled, showMsg])
 
-  const handleModeChange = useCallback(
-    buildModeChangeHandler({ setSavingNotification, setNotificationMode, showMsg }), []
-  )
+  const handleModeChange = useCallback(async (mode) => {
+    try {
+      setSavingNotification(true)
+      await updateNotificationModeSetting(mode)
+      setNotificationMode(mode)
+      showMsg('success', 'Modo de notificação atualizado.')
+    } catch {
+      showMsg('error', 'Erro ao salvar modo.')
+    } finally {
+      setSavingNotification(false)
+    }
+  }, [showMsg])
 
-  const saveQuietHours = useCallback(
-    buildSaveQuietHoursHandler({ setSavingQuietHours, quietHoursEnabled, quietHoursStart, quietHoursEnd, showMsg }),
-    [quietHoursEnabled, quietHoursStart, quietHoursEnd]
-  )
+  const saveQuietHours = useCallback(async () => {
+    try {
+      setSavingQuietHours(true)
+      await updateQuietHoursSetting(quietHoursEnabled, quietHoursStart, quietHoursEnd)
+      showMsg('success', 'Período silencioso salvo.')
+    } catch {
+      showMsg('error', 'Erro ao salvar período silencioso.')
+    } finally {
+      setSavingQuietHours(false)
+    }
+  }, [quietHoursEnabled, quietHoursStart, quietHoursEnd, showMsg])
 
-  const saveDigestTime = useCallback(
-    buildSaveDigestTimeHandler({ setSavingDigestTime, digestTime, showMsg }), [digestTime]
-  )
+  const saveDigestTime = useCallback(async () => {
+    try {
+      setSavingDigestTime(true)
+      await updateDigestTimeSetting(digestTime)
+      showMsg('success', 'Horário do resumo salvo.')
+    } catch {
+      showMsg('error', 'Erro ao salvar horário.')
+    } finally {
+      setSavingDigestTime(false)
+    }
+  }, [digestTime, showMsg])
 
   const generateTelegramToken = useCallback(async () => {
     const token = generateTokenString()
     setTelegramToken(token)
-    try { await saveTelegramTokenSetting(token) } catch (err) { console.error('Token gen error:', err) }
+    try { await saveTelegramTokenSetting(token) } catch (err) { void err }
   }, [])
 
-  const handleDisconnectTelegram = useCallback(
-    buildDisconnectTelegramHandler({ setIsTelegramConnected, showMsg }), []
-  )
+  const handleDisconnectTelegram = useCallback(async () => {
+    if (!window.confirm('Tem certeza que deseja desconectar o Telegram?')) return
+    try {
+      await disconnectTelegramSetting()
+      setIsTelegramConnected(false)
+      showMsg('success', 'Telegram desconectado.')
+    } catch {
+      showMsg('error', 'Erro ao desconectar.')
+    }
+  }, [showMsg])
 
-  const handleComplexityChange = useCallback(
-    buildComplexityChangeHandler({ setComplexityOverride, showMsg }), [setComplexityOverride]
-  )
+  const handleComplexityChange = useCallback(async (mode) => {
+    const value = mode === 'auto' ? null : mode
+    try {
+      await updateComplexityModeSetting(value)
+      setComplexityOverride(value)
+      showMsg('success', 'Preferência de visualização atualizada.')
+    } catch {
+      showMsg('error', 'Erro ao salvar preferência.')
+    }
+  }, [setComplexityOverride, showMsg])
 
   const displayMode = getComplexityDisplayMode(complexityMode, overrideMode)
 

--- a/apps/web/src/features/settings/hooks/useSettingsState.js
+++ b/apps/web/src/features/settings/hooks/useSettingsState.js
@@ -147,8 +147,13 @@ export function useSettingsState() {
   const generateTelegramToken = useCallback(async () => {
     const token = generateTokenString()
     setTelegramToken(token)
-    try { await saveTelegramTokenSetting(token) } catch (err) { void err }
-  }, [])
+    try {
+      await saveTelegramTokenSetting(token)
+    } catch (err) {
+      if (process.env.NODE_ENV === 'development') console.error('Erro ao salvar token Telegram:', err)
+      showMsg('error', 'Erro ao salvar token do Telegram.')
+    }
+  }, [showMsg])
 
   const handleDisconnectTelegram = useCallback(async () => {
     if (!window.confirm('Tem certeza que deseja desconectar o Telegram?')) return


### PR DESCRIPTION
## Resumo

- `_useDashboardDerived.js`: `medicines`, `protocols`, `logs` envolvidos em `useMemo` próprio — arrays `|| []` inline criavam nova referência a cada render (7 violations)
- `useSettingsState.js`: lógica dos builders (`buildToggleWebPushHandler` etc.) inlined dentro de cada `useCallback` com deps explícitas (6 violations)
- `TodayScreen.jsx` (mobile): `timeline`, `protocols`, `medicines` envolvidos em `useMemo` próprio (3 violations)

**Resultado:** `exhaustive-deps` 16x → 0x

## AI Review Response

| Sugestão | Prioridade | Decisão | Razão |
|----------|-----------|---------|-------|
| Erro Telegram silenciado (`void err`) | High | Applied | Commit fa38aea1 — loga em dev + showMsg ao usuário |
| Decompor em sub-hooks | Medium | Declined | Inlining deliberado para fixar exhaustive-deps; sub-hooks reintroduziria deps instáveis; decomposição planejada para Wave E |

## Test plan

- [x] `rtk proxy npx eslint <arquivos modificados>` → 0 violations
- [x] `rtk proxy npm run lint | grep exhaustive-deps` → sem saída
- [x] `npm run validate:agent` → 522 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)