### PR TITLE
Feat/crud foundation form kit

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -84,7 +84,8 @@ module.exports = {
           "userTrackingPermission": "Seus dados nos ajudam a manter o Dosiq gratuito por meio de anúncios personalizados e melhorias no app."
         }
       ],
-      './withFirebaseFix.js'
+      './withFirebaseFix.js',
+      '@react-native-community/datetimepicker'
     ],
     extra: {
       // RE-004: variáveis públicas via EXPO_PUBLIC_*

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@expo-google-fonts/comfortaa": "^0.4.2",
     "@react-native-async-storage/async-storage": "~2.1.2",
+    "@react-native-community/datetimepicker": "8.4.1",
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-firebase/analytics": "^21.14.0",
     "@react-native-firebase/app": "^21.14.0",
@@ -26,6 +27,7 @@
     "expo-dev-client": "~5.2.4",
     "expo-device": "~7.1.4",
     "expo-font": "~13.3.2",
+    "expo-haptics": "~14.1.4",
     "expo-linear-gradient": "~14.1.5",
     "expo-notifications": "~0.31.5",
     "expo-secure-store": "^14.0.1",

--- a/apps/mobile/src/features/_dev/screens/FormKitDemoScreen.jsx
+++ b/apps/mobile/src/features/_dev/screens/FormKitDemoScreen.jsx
@@ -28,10 +28,17 @@ export default function FormKitDemoScreen({ navigation }) {
   const [name, setName] = useState('')
   const [nameError, setNameError] = useState(undefined)
   const [dose, setDose] = useState('500')
+  const [notes, setNotes] = useState('')
   const [frequency, setFrequency] = useState(null)
+  const [frequencyErr, setFrequencyErr] = useState(null)
   const [startDate, setStartDate] = useState(null)
   const [reminderTime, setReminderTime] = useState(null)
   const [submitLoading, setSubmitLoading] = useState(false)
+
+  // Filtra apenas dígitos (demo de uso correto com keyboardType numeric)
+  function handleDoseChange(_, v) {
+    setDose(v.replace(/[^0-9]/g, ''))
+  }
 
   function toggleNameError() {
     setNameError(nameError ? undefined : 'Nome deve ter pelo menos 2 caracteres')
@@ -91,10 +98,10 @@ export default function FormKitDemoScreen({ navigation }) {
             name="dose"
             label="Dose (mg)"
             value={dose}
-            onChange={(_, v) => setDose(v)}
+            onChange={handleDoseChange}
             keyboardType="numeric"
             placeholder="0"
-            helperText="Apenas números"
+            helperText="Apenas números (filtro no onChange)"
           />
 
           <FormInput
@@ -109,8 +116,8 @@ export default function FormKitDemoScreen({ navigation }) {
             name="notes"
             label="Observações"
             placeholder="Notas sobre o medicamento…"
-            value=""
-            onChange={() => {}}
+            value={notes}
+            onChange={(_, v) => setNotes(v)}
             multiline
             numberOfLines={4}
           />
@@ -135,9 +142,11 @@ export default function FormKitDemoScreen({ navigation }) {
             name="frequencyError"
             label="Frequência (erro)"
             placeholder="Toque para abrir"
-            value={null}
+            value={frequencyErr}
             options={FREQUENCY_OPTIONS}
-            error="Campo obrigatório"
+            onChange={(_, v) => setFrequencyErr(v)}
+            error={frequencyErr ? undefined : 'Campo obrigatório'}
+            helperText="Erro some ao selecionar"
           />
         </FormSection>
 
@@ -212,7 +221,7 @@ export default function FormKitDemoScreen({ navigation }) {
           <View style={styles.debugBox}>
             <Text style={styles.debugText}>
               {JSON.stringify(
-                { name, dose, frequency, startDate, reminderTime },
+                { name, dose, notes, frequency, frequencyErr, startDate, reminderTime },
                 null,
                 2,
               )}

--- a/apps/mobile/src/features/_dev/screens/FormKitDemoScreen.jsx
+++ b/apps/mobile/src/features/_dev/screens/FormKitDemoScreen.jsx
@@ -35,9 +35,12 @@ export default function FormKitDemoScreen({ navigation }) {
   const [reminderTime, setReminderTime] = useState(null)
   const [submitLoading, setSubmitLoading] = useState(false)
 
-  // Filtra apenas dígitos (demo de uso correto com keyboardType numeric)
+  // Filtra dígitos + um único separador decimal (vírgula ou ponto)
   function handleDoseChange(_, v) {
-    setDose(v.replace(/[^0-9]/g, ''))
+    const cleaned = v.replace(/[^0-9.,]/g, '')
+    // Mantém apenas o primeiro separador decimal
+    const match = cleaned.match(/^(\d*)([.,]?)(\d*)/)
+    setDose(match ? match[1] + match[2] + match[3] : '')
   }
 
   function toggleNameError() {

--- a/apps/mobile/src/features/_dev/screens/FormKitDemoScreen.jsx
+++ b/apps/mobile/src/features/_dev/screens/FormKitDemoScreen.jsx
@@ -1,0 +1,287 @@
+// FormKitDemoScreen — playground dos primitivos do Form Kit (Sprint P.1)
+// Apenas para validação visual em ambiente DEV. Não usar em produção.
+
+import { useState } from 'react'
+import { ScrollView, View, Text, StyleSheet, TouchableOpacity } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { ChevronLeft } from 'lucide-react-native'
+import {
+  FormInput,
+  FormSelect,
+  FormDatePicker,
+  FormTimePicker,
+  FormSection,
+  FormActions,
+} from '@shared/components/form'
+import { colors, spacing } from '@shared/styles/tokens'
+
+const FREQUENCY_OPTIONS = [
+  { label: 'Diário', value: 'diario' },
+  { label: 'Dias alternados', value: 'dias_alternados' },
+  { label: 'Semanal', value: 'semanal' },
+  { label: 'Personalizado', value: 'personalizado' },
+  { label: 'Quando necessário', value: 'quando_necessario' },
+]
+
+export default function FormKitDemoScreen({ navigation }) {
+  // Inputs interativos
+  const [name, setName] = useState('')
+  const [nameError, setNameError] = useState(undefined)
+  const [dose, setDose] = useState('500')
+  const [frequency, setFrequency] = useState(null)
+  const [startDate, setStartDate] = useState(null)
+  const [reminderTime, setReminderTime] = useState(null)
+  const [submitLoading, setSubmitLoading] = useState(false)
+
+  function toggleNameError() {
+    setNameError(nameError ? undefined : 'Nome deve ter pelo menos 2 caracteres')
+  }
+
+  function handleSubmit() {
+    setSubmitLoading(true)
+    setTimeout(() => setSubmitLoading(false), 1500)
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top']}>
+      {/* Cabeçalho */}
+      <View style={styles.header}>
+        <TouchableOpacity
+          onPress={() => navigation?.goBack()}
+          style={styles.backBtn}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <ChevronLeft size={24} color={colors.text.primary} />
+        </TouchableOpacity>
+        <Text style={styles.title}>Form Kit · Demo</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scroll}>
+        {/* Seção 1 — FormInput em todos estados */}
+        <FormSection
+          title="FormInput"
+          description="Texto, número, com erro, desabilitado, helper, multiline"
+        >
+          <FormInput
+            name="nameDefault"
+            label="Nome do medicamento"
+            placeholder="Ex.: Paracetamol"
+            value={name}
+            onChange={(_, v) => setName(v)}
+            required
+            helperText="Toque no botão abaixo para alternar o estado de erro"
+          />
+          <TouchableOpacity onPress={toggleNameError} style={styles.toggleBtn}>
+            <Text style={styles.toggleBtnText}>
+              {nameError ? 'Limpar erro' : 'Forçar erro'}
+            </Text>
+          </TouchableOpacity>
+
+          <FormInput
+            name="nameError"
+            label="Nome (com erro)"
+            value={name}
+            onChange={(_, v) => setName(v)}
+            error={nameError}
+            placeholder="Digite algo curto"
+          />
+
+          <FormInput
+            name="dose"
+            label="Dose (mg)"
+            value={dose}
+            onChange={(_, v) => setDose(v)}
+            keyboardType="numeric"
+            placeholder="0"
+            helperText="Apenas números"
+          />
+
+          <FormInput
+            name="disabled"
+            label="Campo desabilitado"
+            value="Não posso editar"
+            onChange={() => {}}
+            disabled
+          />
+
+          <FormInput
+            name="notes"
+            label="Observações"
+            placeholder="Notas sobre o medicamento…"
+            value=""
+            onChange={() => {}}
+            multiline
+            numberOfLines={4}
+          />
+        </FormSection>
+
+        {/* Seção 2 — FormSelect */}
+        <FormSection
+          title="FormSelect"
+          description="Modal sheet com lista de opções"
+        >
+          <FormSelect
+            name="frequency"
+            label="Frequência"
+            placeholder="Selecione uma frequência"
+            value={frequency}
+            options={FREQUENCY_OPTIONS}
+            onChange={(_, v) => setFrequency(v)}
+            required
+          />
+
+          <FormSelect
+            name="frequencyError"
+            label="Frequência (erro)"
+            placeholder="Toque para abrir"
+            value={null}
+            options={FREQUENCY_OPTIONS}
+            error="Campo obrigatório"
+          />
+        </FormSection>
+
+        {/* Seção 3 — Pickers de data/hora */}
+        <FormSection
+          title="FormDatePicker / FormTimePicker"
+          description="iOS abre modal spinner; Android abre dialog nativo"
+        >
+          <FormDatePicker
+            name="startDate"
+            label="Data de início"
+            placeholder="dd/mm/aaaa"
+            value={startDate}
+            onChange={(_, v) => setStartDate(v)}
+            required
+          />
+
+          <FormTimePicker
+            name="reminderTime"
+            label="Horário do lembrete"
+            placeholder="--:--"
+            value={reminderTime}
+            onChange={(_, v) => setReminderTime(v)}
+            helperText="Use o formato 24h"
+          />
+        </FormSection>
+
+        {/* Seção 4 — FormActions em todas variantes */}
+        <FormSection
+          title="FormActions"
+          description="Botões primary/secondary, loading e variante destrutiva"
+        >
+          <FormActions
+            primaryLabel="Salvar"
+            onPrimary={handleSubmit}
+            secondaryLabel="Cancelar"
+            onSecondary={() => navigation?.goBack()}
+            primaryLoading={submitLoading}
+          />
+
+          <View style={styles.gap} />
+
+          <FormActions
+            primaryLabel="Excluir"
+            onPrimary={() => {}}
+            secondaryLabel="Cancelar"
+            onSecondary={() => {}}
+            destructive
+          />
+
+          <View style={styles.gap} />
+
+          <FormActions
+            primaryLabel="Apenas confirmar"
+            onPrimary={() => {}}
+          />
+
+          <View style={styles.gap} />
+
+          <FormActions
+            primaryLabel="Desabilitado"
+            onPrimary={() => {}}
+            primaryDisabled
+          />
+        </FormSection>
+
+        {/* Estado atual (debug) */}
+        <FormSection
+          title="Estado atual"
+          description="Snapshot dos valores controlados nesta tela"
+        >
+          <View style={styles.debugBox}>
+            <Text style={styles.debugText}>
+              {JSON.stringify(
+                { name, dose, frequency, startDate, reminderTime },
+                null,
+                2,
+              )}
+            </Text>
+          </View>
+        </FormSection>
+      </ScrollView>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: colors.bg.screen,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[3],
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border.light,
+    backgroundColor: colors.bg.card,
+  },
+  backBtn: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    flex: 1,
+    fontSize: 17,
+    fontWeight: '600',
+    color: colors.text.primary,
+    textAlign: 'center',
+  },
+  headerSpacer: {
+    width: 40,
+  },
+  scroll: {
+    padding: spacing[5],
+    paddingBottom: spacing[12],
+  },
+  toggleBtn: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    backgroundColor: colors.primary[50],
+    borderRadius: 8,
+    marginTop: -spacing[2],
+  },
+  toggleBtnText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.primary[700],
+  },
+  gap: {
+    height: spacing[3],
+  },
+  debugBox: {
+    backgroundColor: colors.neutral[800],
+    borderRadius: 12,
+    padding: spacing[4],
+  },
+  debugText: {
+    fontFamily: 'Courier',
+    fontSize: 12,
+    color: colors.text.inverse,
+  },
+})

--- a/apps/mobile/src/features/dashboard/screens/TodayScreen.jsx
+++ b/apps/mobile/src/features/dashboard/screens/TodayScreen.jsx
@@ -1,14 +1,16 @@
 import { useState, useMemo, useEffect, useCallback } from 'react'
-import { 
-  ScrollView, 
-  View, 
-  Text, 
-  RefreshControl, 
-  StyleSheet, 
-  LayoutAnimation, 
-  Platform, 
-  UIManager 
+import {
+  ScrollView,
+  View,
+  Text,
+  RefreshControl,
+  StyleSheet,
+  LayoutAnimation,
+  Platform,
+  UIManager,
+  TouchableOpacity
 } from 'react-native'
+import { ROUTES } from '../../../navigation/routes'
 import { Pill } from 'lucide-react-native'
 import { useTodayData } from '@dashboard/hooks/useTodayData'
 import ScreenContainer from '@shared/components/ui/ScreenContainer'
@@ -130,6 +132,7 @@ function TodayScreenContent({
   expandedShifts, toggleShift,
   modalProtocol, modalScheduledTime, medicineName, handleOpenRegister, handleRegisterSuccess, handleCloseRegister,
   bulkModal, setBulkModal,
+  navigation,
 }) {
   const priorityDoses = timeline
     .filter(d => d.timelineStatus === 'PROXIMA' || d.timelineStatus === 'ATRASADA')
@@ -149,8 +152,21 @@ function TodayScreenContent({
         refreshControl={<RefreshControl refreshing={loading && !!data} onRefresh={refresh} tintColor={colors.status.success} />}
       >
         <View style={styles.header}>
-          <Text style={styles.greeting}>{greeting}</Text>
-          <Text style={styles.date}>{todayFormatted}</Text>
+          <View style={styles.headerText}>
+            <Text style={styles.greeting}>{greeting}</Text>
+            <Text style={styles.date}>{todayFormatted}</Text>
+          </View>
+          {__DEV__ && (
+            <TouchableOpacity
+              style={styles.devBtn}
+              onPress={() => navigation?.navigate(ROUTES.FORM_KIT_DEMO)}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityRole="button"
+              accessibilityLabel="Abrir Form Kit Demo"
+            >
+              <Text style={styles.devBtnText}>DEV</Text>
+            </TouchableOpacity>
+          )}
         </View>
         <AdherenceDayCard score={stats.score} trend={adherenceTrend} />
         <StockAlertInline alerts={stockAlerts} />
@@ -324,6 +340,7 @@ export default function TodayScreen({ route, navigation }) {
       medicineName={medicineName} handleOpenRegister={handleOpenRegister}
       handleRegisterSuccess={handleRegisterSuccess} handleCloseRegister={handleCloseRegister}
       bulkModal={bulkModal} setBulkModal={setBulkModal}
+      navigation={navigation}
     />
   )
 }
@@ -336,6 +353,26 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingVertical: 16,
     marginBottom: 8,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+  },
+  headerText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  devBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 6,
+    backgroundColor: colors.status.warning,
+    marginLeft: 8,
+  },
+  devBtnText: {
+    fontSize: 11,
+    fontWeight: '800',
+    color: colors.text.inverse,
+    letterSpacing: 1,
   },
   greeting: {
     fontSize: 28,

--- a/apps/mobile/src/navigation/Navigation.jsx
+++ b/apps/mobile/src/navigation/Navigation.jsx
@@ -21,6 +21,7 @@ import SignupScreen from '../screens/SignupScreen'
 import ForgotPasswordScreen from '../screens/ForgotPasswordScreen'
 import ResetPasswordScreen from '../screens/ResetPasswordScreen'
 import RootTabs from './RootTabs'
+import FormKitDemoScreen from '../features/_dev/screens/FormKitDemoScreen'
 import { supabase } from '../platform/supabase/nativeSupabaseClient'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { usePushNotifications } from '../platform/notifications/usePushNotifications'
@@ -150,7 +151,15 @@ export default function Navigation() {
             initialParams={{ onComplete: () => setIsPasswordRecovery(false) }}
           />
         ) : session ? (
-          <Stack.Screen name={ROUTES.TABS} component={RootTabs} />
+          <>
+            <Stack.Screen name={ROUTES.TABS} component={RootTabs} />
+            {__DEV__ && (
+              <Stack.Screen
+                name={ROUTES.FORM_KIT_DEMO}
+                component={FormKitDemoScreen}
+              />
+            )}
+          </>
         ) : (
           <>
             <Stack.Screen name={ROUTES.LANDING} component={LandingScreen} />

--- a/apps/mobile/src/navigation/routes.js
+++ b/apps/mobile/src/navigation/routes.js
@@ -29,4 +29,7 @@ export const ROUTES = {
   TELEGRAM_LINK: 'TelegramLink',
   NOTIFICATION_PREFERENCES: 'NotificationPreferences',
   NOTIFICATION_INBOX: 'NotificationInbox',
+
+  // Dev-only (apenas __DEV__)
+  FORM_KIT_DEMO: 'FormKitDemo',
 }

--- a/apps/mobile/src/shared/components/form/FormActions.jsx
+++ b/apps/mobile/src/shared/components/form/FormActions.jsx
@@ -1,0 +1,94 @@
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  ActivityIndicator,
+  StyleSheet,
+} from 'react-native'
+import { colors, spacing, borderRadius } from '@shared/styles/tokens'
+
+export default function FormActions({
+  primaryLabel,
+  onPrimary,
+  primaryDisabled,
+  primaryLoading,
+  secondaryLabel,
+  onSecondary,
+  destructive,
+}) {
+  // Cor de fundo do botão primário (destruidor ou normal)
+  const primaryBgColor = destructive ? colors.status.error : colors.primary[700]
+
+  return (
+    <View style={styles.row}>
+      {/* Botão primário */}
+      <TouchableOpacity
+        style={[
+          styles.primaryButton,
+          { backgroundColor: primaryBgColor },
+          (primaryDisabled || primaryLoading) && styles.buttonDisabled,
+        ]}
+        onPress={onPrimary}
+        disabled={primaryDisabled || primaryLoading}
+        activeOpacity={0.8}
+      >
+        {primaryLoading ? (
+          <ActivityIndicator size="small" color={colors.text.inverse} />
+        ) : (
+          <Text style={styles.primaryLabel}>{primaryLabel}</Text>
+        )}
+      </TouchableOpacity>
+
+      {/* Botão secundário (opcional) */}
+      {secondaryLabel ? (
+        <TouchableOpacity
+          style={[
+            styles.secondaryButton,
+            { borderColor: colors.border.default },
+          ]}
+          onPress={onSecondary}
+          activeOpacity={0.8}
+        >
+          <Text style={styles.secondaryLabel}>{secondaryLabel}</Text>
+        </TouchableOpacity>
+      ) : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    gap: spacing[3],
+    marginTop: spacing[5],
+  },
+  primaryButton: {
+    flex: 1,
+    height: 50,
+    borderRadius: borderRadius.lg,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  primaryLabel: {
+    fontWeight: '700',
+    fontSize: 15,
+    color: colors.text.inverse,
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  secondaryButton: {
+    flex: 1,
+    height: 50,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1.5,
+    backgroundColor: colors.bg.card,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  secondaryLabel: {
+    fontWeight: '600',
+    fontSize: 15,
+    color: colors.text.primary,
+  },
+})

--- a/apps/mobile/src/shared/components/form/FormDatePicker.jsx
+++ b/apps/mobile/src/shared/components/form/FormDatePicker.jsx
@@ -1,0 +1,272 @@
+import { View, Text, TouchableOpacity, Modal, Platform, StyleSheet } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { Calendar } from 'lucide-react-native'
+import DateTimePicker, { DateTimePickerAndroid } from '@react-native-community/datetimepicker'
+import { useState } from 'react'
+import { getNow } from '@dosiq/core'
+import { colors, spacing, borderRadius } from '@shared/styles/tokens'
+
+// Formata data no padrão dd/MM/yyyy
+const defaultFormat = (d) => {
+  if (!d) return ''
+  const dd = String(d.getDate()).padStart(2, '0')
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const yyyy = d.getFullYear()
+  return `${dd}/${mm}/${yyyy}`
+}
+
+export default function FormDatePicker({
+  name,
+  label,
+  value,
+  error,
+  onChange,
+  onBlur,
+  disabled,
+  placeholder,
+  helperText,
+  required,
+  minimumDate,
+  maximumDate,
+  format,
+}) {
+  const [open, setOpen] = useState(false)
+  // Valor temporário usado no picker iOS antes de confirmar
+  const [tempValue, setTempValue] = useState(() => value ?? getNow())
+
+  const formatter = format ?? defaultFormat
+  const hasValue = value != null
+
+  // Cor da borda: erro > aberto/focused > padrão
+  const borderColor = error
+    ? colors.status.error
+    : open
+    ? colors.primary[700]
+    : colors.border.default
+
+  function handleOpen() {
+    if (disabled) return
+
+    if (Platform.OS === 'android') {
+      // Android: picker imperativo nativo (evita edge cases de JSX montado)
+      DateTimePickerAndroid.open({
+        value: value ?? getNow(),
+        mode: 'date',
+        display: 'default',
+        minimumDate,
+        maximumDate,
+        onChange: (event, date) => {
+          if (event.type === 'set' && date) {
+            onChange?.(name, date)
+          }
+          onBlur?.(name)
+        },
+      })
+    } else {
+      // iOS: abre modal com spinner
+      setTempValue(value ?? getNow())
+      setOpen(true)
+    }
+  }
+
+  function handleIOSConfirm() {
+    onChange?.(name, tempValue)
+    setOpen(false)
+    onBlur?.(name)
+  }
+
+  function handleIOSCancel() {
+    setOpen(false)
+    onBlur?.(name)
+  }
+
+  function handleIOSChange(_, date) {
+    if (date) setTempValue(date)
+  }
+
+  return (
+    <View style={[styles.wrapper, disabled && styles.wrapperDisabled]}>
+      {/* Label acima do campo */}
+      {label ? (
+        <View style={styles.labelRow}>
+          <Text style={styles.label}>{label}</Text>
+          {required && <Text style={styles.asterisk}> *</Text>}
+        </View>
+      ) : null}
+
+      {/* Trigger */}
+      <TouchableOpacity
+        style={[styles.trigger, { borderColor }]}
+        onPress={handleOpen}
+        activeOpacity={0.8}
+        disabled={disabled}
+        accessibilityRole="button"
+        accessibilityLabel={label}
+        accessibilityHint={placeholder}
+        accessibilityState={{ disabled, expanded: open }}
+      >
+        <Text
+          style={[styles.triggerText, !hasValue && styles.triggerPlaceholder]}
+          numberOfLines={1}
+        >
+          {hasValue ? formatter(value) : (placeholder ?? 'Selecionar data')}
+        </Text>
+        <Calendar size={18} color={colors.text.muted} strokeWidth={2} />
+      </TouchableOpacity>
+
+      {/* Erro / helper */}
+      {error ? (
+        <Text style={styles.errorText}>{error}</Text>
+      ) : helperText ? (
+        <Text style={styles.helperText}>{helperText}</Text>
+      ) : null}
+
+      {/* Modal iOS com spinner */}
+      {Platform.OS === 'ios' && (
+        <Modal
+          visible={open}
+          transparent
+          animationType="slide"
+          onRequestClose={handleIOSCancel}
+        >
+          {/* Backdrop semi-transparente */}
+          <TouchableOpacity
+            style={styles.backdrop}
+            activeOpacity={1}
+            onPress={handleIOSCancel}
+          />
+
+          {/* Sheet deslizante inferior */}
+          <View style={styles.sheet}>
+            <SafeAreaView edges={['bottom']}>
+              {/* Cabeçalho com ações */}
+              <View style={styles.sheetHeader}>
+                <TouchableOpacity
+                  onPress={handleIOSCancel}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  accessibilityRole="button"
+                  accessibilityLabel="Cancelar"
+                >
+                  <Text style={styles.headerActionCancel}>Cancelar</Text>
+                </TouchableOpacity>
+
+                <Text style={styles.sheetTitle}>Selecionar data</Text>
+
+                <TouchableOpacity
+                  onPress={handleIOSConfirm}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  accessibilityRole="button"
+                  accessibilityLabel="Confirmar"
+                >
+                  <Text style={styles.headerActionConfirm}>Confirmar</Text>
+                </TouchableOpacity>
+              </View>
+
+              {/* Picker spinner */}
+              <DateTimePicker
+                mode="date"
+                display="spinner"
+                value={tempValue}
+                onChange={handleIOSChange}
+                minimumDate={minimumDate}
+                maximumDate={maximumDate}
+                locale="pt-BR"
+              />
+            </SafeAreaView>
+          </View>
+        </Modal>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    opacity: 1,
+  },
+  wrapperDisabled: {
+    opacity: 0.6,
+  },
+  labelRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    marginBottom: 6,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: colors.text.secondary,
+  },
+  asterisk: {
+    fontSize: 13,
+    color: colors.status.error,
+  },
+  trigger: {
+    height: 50,
+    backgroundColor: colors.bg.card,
+    borderWidth: 1.5,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  triggerText: {
+    flex: 1,
+    fontSize: 15,
+    color: colors.text.primary,
+    marginRight: spacing[2],
+  },
+  triggerPlaceholder: {
+    color: colors.text.muted,
+  },
+  errorText: {
+    fontSize: 12,
+    color: colors.status.error,
+    marginTop: 6,
+  },
+  helperText: {
+    fontSize: 12,
+    color: colors.text.muted,
+    marginTop: 6,
+  },
+  // Modal
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: colors.bg.overlay,
+  },
+  sheet: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: colors.bg.card,
+    borderTopLeftRadius: borderRadius.xxl,
+    borderTopRightRadius: borderRadius.xxl,
+  },
+  sheetHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[4],
+    paddingBottom: spacing[3],
+  },
+  sheetTitle: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.text.primary,
+    textAlign: 'center',
+  },
+  headerActionCancel: {
+    fontSize: 15,
+    color: colors.text.muted,
+    fontWeight: '500',
+  },
+  headerActionConfirm: {
+    fontSize: 15,
+    color: colors.primary[700],
+    fontWeight: '600',
+  },
+})

--- a/apps/mobile/src/shared/components/form/FormInput.jsx
+++ b/apps/mobile/src/shared/components/form/FormInput.jsx
@@ -72,12 +72,13 @@ export default function FormInput({
       <Animated.View
         style={[
           styles.inputContainer,
+          multiline && styles.inputContainerMultiline,
           disabled && styles.inputContainerDisabled,
           { borderColor },
         ]}
       >
         <TextInput
-          style={styles.input}
+          style={[styles.input, multiline && styles.inputMultiline]}
           value={value}
           placeholder={placeholder}
           placeholderTextColor={colors.text.muted}
@@ -91,6 +92,7 @@ export default function FormInput({
           secureTextEntry={secureTextEntry}
           multiline={multiline}
           numberOfLines={numberOfLines}
+          textAlignVertical={multiline ? 'top' : 'center'}
           maxLength={maxLength}
           returnKeyType={returnKeyType}
           onSubmitEditing={onSubmitEditing}
@@ -140,6 +142,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
     justifyContent: 'center',
   },
+  inputContainerMultiline: {
+    height: undefined,
+    minHeight: 96,
+    paddingVertical: 12,
+  },
   inputContainerDisabled: {
     backgroundColor: colors.neutral[50],
   },
@@ -148,6 +155,10 @@ const styles = StyleSheet.create({
     fontSize: 15,
     color: colors.text.primary,
     padding: 0,
+  },
+  inputMultiline: {
+    minHeight: 72,
+    textAlignVertical: 'top',
   },
   errorText: {
     fontSize: 12,

--- a/apps/mobile/src/shared/components/form/FormInput.jsx
+++ b/apps/mobile/src/shared/components/form/FormInput.jsx
@@ -1,0 +1,162 @@
+import { View, Text, TextInput, Animated, StyleSheet } from 'react-native'
+import { useEffect, useState } from 'react'
+import { colors, borderRadius } from '@shared/styles/tokens'
+
+export default function FormInput({
+  name,
+  label,
+  value,
+  error,
+  onChange,
+  onBlur,
+  disabled,
+  placeholder,
+  helperText,
+  required,
+  // Pass-through para TextInput
+  keyboardType,
+  autoCapitalize,
+  autoComplete,
+  secureTextEntry,
+  multiline,
+  numberOfLines,
+  maxLength,
+  returnKeyType,
+  onSubmitEditing,
+}) {
+  const [focused, setFocused] = useState(false)
+  // Animated.Value criado uma única vez (lazy init via useState)
+  const [borderColorAnim] = useState(() => new Animated.Value(0))
+
+  // Anima transição de cor da borda quando erro muda
+  useEffect(() => {
+    Animated.spring(borderColorAnim, {
+      toValue: error ? 1 : 0,
+      useNativeDriver: false,
+      speed: 20,
+      bounciness: 0,
+    }).start()
+  }, [error, borderColorAnim])
+
+  // Interpola entre cor base (focused/default) e cor de erro
+  const baseBorder = focused ? colors.primary[700] : colors.border.default
+  const borderColor = borderColorAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [baseBorder, colors.status.error],
+  })
+
+  function handleFocus() {
+    setFocused(true)
+  }
+
+  function handleBlur() {
+    setFocused(false)
+    onBlur?.(name)
+  }
+
+  function handleChangeText(text) {
+    onChange?.(name, text)
+  }
+
+  return (
+    <View style={[styles.wrapper, disabled && styles.wrapperDisabled]}>
+      {/* Label acima do campo */}
+      {label ? (
+        <View style={styles.labelRow}>
+          <Text style={styles.label}>{label}</Text>
+          {required && <Text style={styles.asterisk}> *</Text>}
+        </View>
+      ) : null}
+
+      {/* Container animado com borda colorida */}
+      <Animated.View
+        style={[
+          styles.inputContainer,
+          disabled && styles.inputContainerDisabled,
+          { borderColor },
+        ]}
+      >
+        <TextInput
+          style={styles.input}
+          value={value}
+          placeholder={placeholder}
+          placeholderTextColor={colors.text.muted}
+          editable={!disabled}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onChangeText={handleChangeText}
+          keyboardType={keyboardType}
+          autoCapitalize={autoCapitalize}
+          autoComplete={autoComplete}
+          secureTextEntry={secureTextEntry}
+          multiline={multiline}
+          numberOfLines={numberOfLines}
+          maxLength={maxLength}
+          returnKeyType={returnKeyType}
+          onSubmitEditing={onSubmitEditing}
+          accessibilityLabel={label}
+          accessibilityHint={helperText || placeholder}
+          accessibilityState={error ? { invalid: true } : undefined}
+        />
+      </Animated.View>
+
+      {/* Mensagem de erro */}
+      {error ? (
+        <Text style={styles.errorText}>{error}</Text>
+      ) : helperText ? (
+        // Helper só aparece quando não há erro
+        <Text style={styles.helperText}>{helperText}</Text>
+      ) : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    opacity: 1,
+  },
+  wrapperDisabled: {
+    opacity: 0.6,
+  },
+  labelRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    marginBottom: 6,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: colors.text.secondary,
+  },
+  asterisk: {
+    fontSize: 13,
+    color: colors.status.error,
+  },
+  inputContainer: {
+    height: 50,
+    backgroundColor: colors.bg.card,
+    borderWidth: 1.5,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: 14,
+    justifyContent: 'center',
+  },
+  inputContainerDisabled: {
+    backgroundColor: colors.neutral[50],
+  },
+  input: {
+    flex: 1,
+    fontSize: 15,
+    color: colors.text.primary,
+    padding: 0,
+  },
+  errorText: {
+    fontSize: 12,
+    color: colors.status.error,
+    marginTop: 6,
+  },
+  helperText: {
+    fontSize: 12,
+    color: colors.text.muted,
+    marginTop: 6,
+  },
+})

--- a/apps/mobile/src/shared/components/form/FormSection.jsx
+++ b/apps/mobile/src/shared/components/form/FormSection.jsx
@@ -1,0 +1,42 @@
+import { View, Text, StyleSheet } from 'react-native'
+import { colors, spacing } from '@shared/styles/tokens'
+
+export default function FormSection({ title, description, children, style }) {
+  return (
+    <View style={[styles.wrapper, style]}>
+      {/* Título em maiúsculas com estilo eyebrow */}
+      {title ? (
+        <Text style={styles.title}>{title.toUpperCase()}</Text>
+      ) : null}
+
+      {/* Descrição (secundária) */}
+      {description ? (
+        <Text style={styles.description}>{description}</Text>
+      ) : null}
+
+      {/* Container dos campos com gap entre eles */}
+      <View style={styles.fieldsContainer}>{children}</View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    marginBottom: spacing[6],
+  },
+  title: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1,
+    color: colors.text.muted,
+    marginBottom: spacing[2],
+  },
+  description: {
+    fontSize: 13,
+    color: colors.text.secondary,
+    marginBottom: spacing[3],
+  },
+  fieldsContainer: {
+    gap: spacing[4],
+  },
+})

--- a/apps/mobile/src/shared/components/form/FormSelect.jsx
+++ b/apps/mobile/src/shared/components/form/FormSelect.jsx
@@ -1,0 +1,275 @@
+import { View, Text, TouchableOpacity, Modal, FlatList, StyleSheet, Dimensions } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { ChevronDown, Check, X } from 'lucide-react-native'
+import { useState } from 'react'
+import { colors, spacing, borderRadius } from '@shared/styles/tokens'
+
+const SCREEN_HEIGHT = Dimensions.get('window').height
+
+export default function FormSelect({
+  name,
+  label,
+  value,
+  options,
+  error,
+  onChange,
+  onBlur,
+  disabled,
+  placeholder,
+  helperText,
+  required,
+}) {
+  const [open, setOpen] = useState(false)
+
+  const selectedOption = options?.find(o => o.value === value)
+  const hasValue = selectedOption != null
+
+  function handleOpen() {
+    if (!disabled) setOpen(true)
+  }
+
+  function handleClose() {
+    setOpen(false)
+    onBlur?.(name)
+  }
+
+  function handleSelect(option) {
+    onChange?.(name, option.value)
+    handleClose()
+  }
+
+  // Cor da borda: erro > aberto/focused > padrão
+  const borderColor = error
+    ? colors.status.error
+    : open
+    ? colors.primary[700]
+    : colors.border.default
+
+  function renderOption({ item }) {
+    const isSelected = item.value === value
+    return (
+      <TouchableOpacity
+        style={[styles.optionRow, isSelected && styles.optionRowSelected]}
+        onPress={() => handleSelect(item)}
+        activeOpacity={0.7}
+        accessibilityRole="menuitem"
+        accessibilityState={{ selected: isSelected }}
+      >
+        <Text style={[styles.optionText, isSelected && styles.optionTextSelected]}>
+          {item.label}
+        </Text>
+        {isSelected && (
+          <Check size={18} color={colors.primary[700]} strokeWidth={2.5} />
+        )}
+      </TouchableOpacity>
+    )
+  }
+
+  return (
+    <View style={[styles.wrapper, disabled && styles.wrapperDisabled]}>
+      {/* Label */}
+      {label ? (
+        <View style={styles.labelRow}>
+          <Text style={styles.label}>{label}</Text>
+          {required && <Text style={styles.asterisk}> *</Text>}
+        </View>
+      ) : null}
+
+      {/* Trigger */}
+      <TouchableOpacity
+        style={[styles.trigger, { borderColor }]}
+        onPress={handleOpen}
+        activeOpacity={0.8}
+        disabled={disabled}
+        accessibilityRole="button"
+        accessibilityLabel={label}
+        accessibilityHint={placeholder}
+        accessibilityState={{ disabled, expanded: open }}
+      >
+        <Text style={[styles.triggerText, !hasValue && styles.triggerPlaceholder]} numberOfLines={1}>
+          {hasValue ? selectedOption.label : (placeholder ?? 'Selecionar')}
+        </Text>
+        <ChevronDown size={18} color={colors.text.muted} strokeWidth={2} />
+      </TouchableOpacity>
+
+      {/* Erro / helper */}
+      {error ? (
+        <Text style={styles.errorText}>{error}</Text>
+      ) : helperText ? (
+        <Text style={styles.helperText}>{helperText}</Text>
+      ) : null}
+
+      {/* Modal */}
+      <Modal
+        visible={open}
+        transparent
+        animationType="slide"
+        onRequestClose={handleClose}
+      >
+        {/* Backdrop */}
+        <TouchableOpacity
+          style={styles.backdrop}
+          activeOpacity={1}
+          onPress={handleClose}
+        />
+
+        {/* Sheet */}
+        <View style={styles.sheet}>
+          <SafeAreaView edges={['bottom']}>
+            {/* Cabeçalho */}
+            <View style={styles.sheetHeader}>
+              <View style={styles.sheetHeaderSpacer} />
+              <Text style={styles.sheetTitle}>
+                {label ? `Selecionar ${label}` : 'Selecionar'}
+              </Text>
+              <TouchableOpacity
+                style={styles.closeButton}
+                onPress={handleClose}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                accessibilityRole="button"
+                accessibilityLabel="Fechar"
+              >
+                <X size={20} color={colors.text.secondary} strokeWidth={2} />
+              </TouchableOpacity>
+            </View>
+
+            {/* Divisor */}
+            <View style={styles.divider} />
+
+            {/* Lista de opções */}
+            <FlatList
+              data={options}
+              keyExtractor={(item, idx) => String(item.value ?? idx)}
+              renderItem={renderOption}
+              style={styles.list}
+              contentContainerStyle={styles.listContent}
+              showsVerticalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled"
+            />
+          </SafeAreaView>
+        </View>
+      </Modal>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    opacity: 1,
+  },
+  wrapperDisabled: {
+    opacity: 0.6,
+  },
+  labelRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    marginBottom: 6,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: colors.text.secondary,
+  },
+  asterisk: {
+    fontSize: 13,
+    color: colors.status.error,
+  },
+  trigger: {
+    height: 50,
+    backgroundColor: colors.bg.card,
+    borderWidth: 1.5,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  triggerText: {
+    flex: 1,
+    fontSize: 15,
+    color: colors.text.primary,
+    marginRight: spacing[2],
+  },
+  triggerPlaceholder: {
+    color: colors.text.muted,
+  },
+  errorText: {
+    fontSize: 12,
+    color: colors.status.error,
+    marginTop: 6,
+  },
+  helperText: {
+    fontSize: 12,
+    color: colors.text.muted,
+    marginTop: 6,
+  },
+  // Modal
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: colors.bg.overlay,
+  },
+  sheet: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    maxHeight: SCREEN_HEIGHT * 0.6,
+    backgroundColor: colors.bg.card,
+    borderTopLeftRadius: borderRadius.xxl,
+    borderTopRightRadius: borderRadius.xxl,
+  },
+  sheetHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[4],
+    paddingBottom: spacing[3],
+  },
+  sheetHeaderSpacer: {
+    width: 32,
+  },
+  sheetTitle: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.text.primary,
+    textAlign: 'center',
+  },
+  closeButton: {
+    width: 32,
+    alignItems: 'flex-end',
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.border.light,
+    marginHorizontal: spacing[4],
+  },
+  list: {
+    flexGrow: 0,
+  },
+  listContent: {
+    paddingVertical: spacing[2],
+  },
+  optionRow: {
+    height: 52,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing[4],
+    backgroundColor: colors.bg.card,
+  },
+  optionRowSelected: {
+    backgroundColor: colors.primary[50],
+  },
+  optionText: {
+    flex: 1,
+    fontSize: 15,
+    color: colors.text.primary,
+    marginRight: spacing[2],
+  },
+  optionTextSelected: {
+    color: colors.primary[700],
+    fontWeight: '600',
+  },
+})

--- a/apps/mobile/src/shared/components/form/FormTimePicker.jsx
+++ b/apps/mobile/src/shared/components/form/FormTimePicker.jsx
@@ -1,0 +1,265 @@
+import { View, Text, TouchableOpacity, Modal, Platform, StyleSheet } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { Clock } from 'lucide-react-native'
+import DateTimePicker, { DateTimePickerAndroid } from '@react-native-community/datetimepicker'
+import { useState } from 'react'
+import { getNow } from '@dosiq/core'
+import { colors, spacing, borderRadius } from '@shared/styles/tokens'
+
+// Formata horário no padrão HH:mm (24h)
+const defaultFormat = (d) => {
+  if (!d) return ''
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  return `${hh}:${mm}`
+}
+
+export default function FormTimePicker({
+  name,
+  label,
+  value,
+  error,
+  onChange,
+  onBlur,
+  disabled,
+  placeholder,
+  helperText,
+  required,
+  format,
+}) {
+  const [open, setOpen] = useState(false)
+  // Valor temporário usado no picker iOS antes de confirmar
+  const [tempValue, setTempValue] = useState(() => value ?? getNow())
+
+  const formatter = format ?? defaultFormat
+  const hasValue = value != null
+
+  // Cor da borda: erro > aberto/focused > padrão
+  const borderColor = error
+    ? colors.status.error
+    : open
+    ? colors.primary[700]
+    : colors.border.default
+
+  function handleOpen() {
+    if (disabled) return
+
+    if (Platform.OS === 'android') {
+      // Android: picker imperativo nativo (evita edge cases de JSX montado)
+      DateTimePickerAndroid.open({
+        value: value ?? getNow(),
+        mode: 'time',
+        display: 'default',
+        onChange: (event, date) => {
+          if (event.type === 'set' && date) {
+            onChange?.(name, date)
+          }
+          onBlur?.(name)
+        },
+      })
+    } else {
+      // iOS: abre modal com spinner
+      setTempValue(value ?? getNow())
+      setOpen(true)
+    }
+  }
+
+  function handleIOSConfirm() {
+    onChange?.(name, tempValue)
+    setOpen(false)
+    onBlur?.(name)
+  }
+
+  function handleIOSCancel() {
+    setOpen(false)
+    onBlur?.(name)
+  }
+
+  function handleIOSChange(_, date) {
+    if (date) setTempValue(date)
+  }
+
+  return (
+    <View style={[styles.wrapper, disabled && styles.wrapperDisabled]}>
+      {/* Label acima do campo */}
+      {label ? (
+        <View style={styles.labelRow}>
+          <Text style={styles.label}>{label}</Text>
+          {required && <Text style={styles.asterisk}> *</Text>}
+        </View>
+      ) : null}
+
+      {/* Trigger */}
+      <TouchableOpacity
+        style={[styles.trigger, { borderColor }]}
+        onPress={handleOpen}
+        activeOpacity={0.8}
+        disabled={disabled}
+        accessibilityRole="button"
+        accessibilityLabel={label}
+        accessibilityHint={placeholder}
+        accessibilityState={{ disabled, expanded: open }}
+      >
+        <Text
+          style={[styles.triggerText, !hasValue && styles.triggerPlaceholder]}
+          numberOfLines={1}
+        >
+          {hasValue ? formatter(value) : (placeholder ?? 'Selecionar horário')}
+        </Text>
+        <Clock size={18} color={colors.text.muted} strokeWidth={2} />
+      </TouchableOpacity>
+
+      {/* Erro / helper */}
+      {error ? (
+        <Text style={styles.errorText}>{error}</Text>
+      ) : helperText ? (
+        <Text style={styles.helperText}>{helperText}</Text>
+      ) : null}
+
+      {/* Modal iOS com spinner */}
+      {Platform.OS === 'ios' && (
+        <Modal
+          visible={open}
+          transparent
+          animationType="slide"
+          onRequestClose={handleIOSCancel}
+        >
+          {/* Backdrop semi-transparente */}
+          <TouchableOpacity
+            style={styles.backdrop}
+            activeOpacity={1}
+            onPress={handleIOSCancel}
+          />
+
+          {/* Sheet deslizante inferior */}
+          <View style={styles.sheet}>
+            <SafeAreaView edges={['bottom']}>
+              {/* Cabeçalho com ações */}
+              <View style={styles.sheetHeader}>
+                <TouchableOpacity
+                  onPress={handleIOSCancel}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  accessibilityRole="button"
+                  accessibilityLabel="Cancelar"
+                >
+                  <Text style={styles.headerActionCancel}>Cancelar</Text>
+                </TouchableOpacity>
+
+                <Text style={styles.sheetTitle}>Selecionar horário</Text>
+
+                <TouchableOpacity
+                  onPress={handleIOSConfirm}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  accessibilityRole="button"
+                  accessibilityLabel="Confirmar"
+                >
+                  <Text style={styles.headerActionConfirm}>Confirmar</Text>
+                </TouchableOpacity>
+              </View>
+
+              {/* Picker spinner */}
+              <DateTimePicker
+                mode="time"
+                display="spinner"
+                value={tempValue}
+                onChange={handleIOSChange}
+                locale="pt-BR"
+              />
+            </SafeAreaView>
+          </View>
+        </Modal>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    opacity: 1,
+  },
+  wrapperDisabled: {
+    opacity: 0.6,
+  },
+  labelRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    marginBottom: 6,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: colors.text.secondary,
+  },
+  asterisk: {
+    fontSize: 13,
+    color: colors.status.error,
+  },
+  trigger: {
+    height: 50,
+    backgroundColor: colors.bg.card,
+    borderWidth: 1.5,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  triggerText: {
+    flex: 1,
+    fontSize: 15,
+    color: colors.text.primary,
+    marginRight: spacing[2],
+  },
+  triggerPlaceholder: {
+    color: colors.text.muted,
+  },
+  errorText: {
+    fontSize: 12,
+    color: colors.status.error,
+    marginTop: 6,
+  },
+  helperText: {
+    fontSize: 12,
+    color: colors.text.muted,
+    marginTop: 6,
+  },
+  // Modal
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: colors.bg.overlay,
+  },
+  sheet: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: colors.bg.card,
+    borderTopLeftRadius: borderRadius.xxl,
+    borderTopRightRadius: borderRadius.xxl,
+  },
+  sheetHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[4],
+    paddingBottom: spacing[3],
+  },
+  sheetTitle: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.text.primary,
+    textAlign: 'center',
+  },
+  headerActionCancel: {
+    fontSize: 15,
+    color: colors.text.muted,
+    fontWeight: '500',
+  },
+  headerActionConfirm: {
+    fontSize: 15,
+    color: colors.primary[700],
+    fontWeight: '600',
+  },
+})

--- a/apps/mobile/src/shared/components/form/index.js
+++ b/apps/mobile/src/shared/components/form/index.js
@@ -1,0 +1,9 @@
+// Barrel export do Form Kit (Fase 0 — Pré-Requisitos)
+// Uso: import { FormInput, FormSelect, ... } from '@shared/components/form'
+
+export { default as FormInput } from './FormInput'
+export { default as FormSelect } from './FormSelect'
+export { default as FormDatePicker } from './FormDatePicker'
+export { default as FormTimePicker } from './FormTimePicker'
+export { default as FormSection } from './FormSection'
+export { default as FormActions } from './FormActions'

--- a/apps/mobile/src/shared/hooks/__tests__/useFormState.test.js
+++ b/apps/mobile/src/shared/hooks/__tests__/useFormState.test.js
@@ -1,0 +1,207 @@
+import { act, renderHook } from '@testing-library/react-native'
+import { z } from 'zod'
+import { useFormState } from '../useFormState'
+
+// Schema mínimo para isolar os testes do hook (sem dependência de schemas reais)
+const schema = z.object({
+  name: z.string().min(2, 'Nome deve ter pelo menos 2 caracteres'),
+  age: z.number().int().positive('Idade deve ser positiva'),
+  email: z.string().email('Email inválido').optional(),
+})
+
+const initialValues = { name: '', age: 0, email: undefined }
+
+describe('useFormState', () => {
+  it('inicializa com valores fornecidos e estado limpo', () => {
+    const { result } = renderHook(() =>
+      useFormState(schema, { initialValues }),
+    )
+
+    expect(result.current.values).toEqual(initialValues)
+    expect(result.current.errors).toEqual({})
+    expect(result.current.touched).toEqual({})
+    expect(result.current.isDirty).toBe(false)
+    expect(result.current.isValid).toBe(true)
+  })
+
+  it('handleChange atualiza valor e marca isDirty', () => {
+    const { result } = renderHook(() =>
+      useFormState(schema, { initialValues }),
+    )
+
+    act(() => {
+      result.current.handleChange('name', 'Ana')
+    })
+
+    expect(result.current.values.name).toBe('Ana')
+    expect(result.current.isDirty).toBe(true)
+  })
+
+  it('handleChange limpa o erro do campo modificado', () => {
+    const { result } = renderHook(() =>
+      useFormState(schema, { initialValues }),
+    )
+
+    act(() => {
+      result.current.validate()
+    })
+    expect(result.current.errors.name).toBeDefined()
+
+    act(() => {
+      result.current.handleChange('name', 'Ana')
+    })
+
+    expect(result.current.errors.name).toBeUndefined()
+  })
+
+  it('handleBlur marca touched e valida o campo', () => {
+    const { result } = renderHook(() =>
+      useFormState(schema, { initialValues }),
+    )
+
+    act(() => {
+      result.current.handleChange('name', 'A')
+    })
+    act(() => {
+      result.current.handleBlur('name')
+    })
+
+    expect(result.current.touched.name).toBe(true)
+    expect(result.current.errors.name).toBe(
+      'Nome deve ter pelo menos 2 caracteres',
+    )
+  })
+
+  it('handleBlur com valor válido limpa erro pré-existente do campo', () => {
+    const { result } = renderHook(() =>
+      useFormState(schema, { initialValues }),
+    )
+
+    act(() => {
+      result.current.validate()
+    })
+    expect(result.current.errors.name).toBeDefined()
+
+    act(() => {
+      result.current.handleChange('name', 'Ana')
+    })
+    act(() => {
+      result.current.handleBlur('name')
+    })
+
+    expect(result.current.errors.name).toBeUndefined()
+  })
+
+  it('validate() retorna false e popula errors quando inválido', () => {
+    const { result } = renderHook(() =>
+      useFormState(schema, { initialValues }),
+    )
+
+    let isValid
+    act(() => {
+      isValid = result.current.validate()
+    })
+
+    expect(isValid).toBe(false)
+    expect(result.current.errors.name).toBeDefined()
+    expect(result.current.errors.age).toBeDefined()
+    expect(result.current.touched.name).toBe(true)
+    expect(result.current.touched.age).toBe(true)
+    expect(result.current.isValid).toBe(false)
+  })
+
+  it('validate() retorna true e zera errors quando válido', () => {
+    const { result } = renderHook(() =>
+      useFormState(schema, { initialValues: { name: 'Ana', age: 30 } }),
+    )
+
+    let isValid
+    act(() => {
+      isValid = result.current.validate()
+    })
+
+    expect(isValid).toBe(true)
+    expect(result.current.errors).toEqual({})
+    expect(result.current.isValid).toBe(true)
+  })
+
+  it('reset() restaura valores iniciais e limpa erros/touched', () => {
+    const { result } = renderHook(() =>
+      useFormState(schema, { initialValues }),
+    )
+
+    act(() => {
+      result.current.handleChange('name', 'Ana')
+      result.current.validate()
+    })
+    expect(result.current.isDirty).toBe(true)
+    expect(Object.keys(result.current.errors).length).toBeGreaterThan(0)
+
+    act(() => {
+      result.current.reset()
+    })
+
+    expect(result.current.values).toEqual(initialValues)
+    expect(result.current.errors).toEqual({})
+    expect(result.current.touched).toEqual({})
+    expect(result.current.isDirty).toBe(false)
+  })
+
+  it('reset(newInitial) atualiza initial e isDirty passa a comparar com novo', () => {
+    const { result } = renderHook(() =>
+      useFormState(schema, { initialValues }),
+    )
+
+    const next = { name: 'Ana', age: 30, email: undefined }
+    act(() => {
+      result.current.reset(next)
+    })
+
+    expect(result.current.values).toEqual(next)
+    expect(result.current.isDirty).toBe(false)
+  })
+
+  it('setValues faz merge parcial e limpa erros dos campos sobrescritos', () => {
+    const { result } = renderHook(() =>
+      useFormState(schema, { initialValues }),
+    )
+
+    act(() => {
+      result.current.validate()
+    })
+    expect(result.current.errors.name).toBeDefined()
+
+    act(() => {
+      result.current.setValues({ name: 'Ana' })
+    })
+
+    expect(result.current.values.name).toBe('Ana')
+    expect(result.current.values.age).toBe(0) // preservado
+    expect(result.current.errors.name).toBeUndefined()
+    expect(result.current.errors.age).toBeDefined() // não sobrescrito
+  })
+
+  it('isDirty retorna false quando valores voltam ao inicial manualmente', () => {
+    const { result } = renderHook(() =>
+      useFormState(schema, { initialValues }),
+    )
+
+    act(() => {
+      result.current.handleChange('name', 'Ana')
+    })
+    expect(result.current.isDirty).toBe(true)
+
+    act(() => {
+      result.current.handleChange('name', '')
+    })
+    expect(result.current.isDirty).toBe(false)
+  })
+
+  it('scrollToFirstError é função (NOP na v1)', () => {
+    const { result } = renderHook(() =>
+      useFormState(schema, { initialValues }),
+    )
+    expect(typeof result.current.scrollToFirstError).toBe('function')
+    expect(() => result.current.scrollToFirstError()).not.toThrow()
+  })
+})

--- a/apps/mobile/src/shared/hooks/useFormState.js
+++ b/apps/mobile/src/shared/hooks/useFormState.js
@@ -1,0 +1,148 @@
+import { useCallback, useMemo, useState } from 'react'
+
+// Hook genérico de estado de formulário com validação Zod.
+// Retorna API estável compatível com FormInput/Select/DatePicker (P1.2+).
+//
+// Uso:
+//   const form = useFormState(medicineCreateSchema, { initialValues: {...} })
+//   <FormInput name="name" value={form.values.name} error={form.errors.name}
+//              onChange={form.handleChange} onBlur={form.handleBlur} />
+
+const EMPTY = Object.freeze({})
+
+const deepEqual = (a, b) => {
+  if (a === b) return true
+  if (a == null || b == null) return a === b
+  if (typeof a !== 'object' || typeof b !== 'object') return a === b
+  const ka = Object.keys(a)
+  const kb = Object.keys(b)
+  if (ka.length !== kb.length) return false
+  return ka.every((k) => deepEqual(a[k], b[k]))
+}
+
+// Mapeia ZodError.issues -> { [path]: mensagem }
+const mapIssues = (issues) => {
+  const out = {}
+  for (const issue of issues) {
+    const path = issue.path.join('.')
+    if (path && !out[path]) out[path] = issue.message
+  }
+  return out
+}
+
+// Valida campo isolado. Tenta schema.pick({[field]:true}); se Hermes não
+// suportar, faz fallback para parse completo + filtra issues do campo.
+const validateField = (schema, field, value, allValues) => {
+  try {
+    const picked = schema.pick({ [field]: true })
+    const result = picked.safeParse({ [field]: value })
+    if (result.success) return null
+    const issue = result.error.issues.find((i) => i.path[0] === field)
+    return issue ? issue.message : null
+  } catch {
+    const result = schema.safeParse({ ...allValues, [field]: value })
+    if (result.success) return null
+    const issue = result.error.issues.find((i) => i.path[0] === field)
+    return issue ? issue.message : null
+  }
+}
+
+export function useFormState(schema, { initialValues = EMPTY } = {}) {
+  const [initial, setInitial] = useState(initialValues)
+  const [values, setValuesState] = useState(initialValues)
+  const [errors, setErrors] = useState(EMPTY)
+  const [touched, setTouched] = useState(EMPTY)
+
+  const handleChange = useCallback((field, value) => {
+    setValuesState((prev) => ({ ...prev, [field]: value }))
+    setErrors((prev) => {
+      if (!prev[field]) return prev
+      const next = { ...prev }
+      delete next[field]
+      return next
+    })
+  }, [])
+
+  const handleBlur = useCallback(
+    (field) => {
+      setTouched((prev) => (prev[field] ? prev : { ...prev, [field]: true }))
+      const msg = validateField(schema, field, values[field], values)
+      setErrors((prev) => {
+        if (msg) return { ...prev, [field]: msg }
+        if (!prev[field]) return prev
+        const next = { ...prev }
+        delete next[field]
+        return next
+      })
+    },
+    [schema, values],
+  )
+
+  const validate = useCallback(() => {
+    const result = schema.safeParse(values)
+    if (result.success) {
+      setErrors(EMPTY)
+      return true
+    }
+    setErrors(mapIssues(result.error.issues))
+    // Marca todos campos com erro como touched (UX: mostra mensagens)
+    setTouched((prev) => {
+      const next = { ...prev }
+      for (const issue of result.error.issues) {
+        const path = issue.path[0]
+        if (path) next[path] = true
+      }
+      return next
+    })
+    return false
+  }, [schema, values])
+
+  const reset = useCallback(
+    (nextInitial) => {
+      const init = nextInitial ?? initial
+      setInitial(init)
+      setValuesState(init)
+      setErrors(EMPTY)
+      setTouched(EMPTY)
+    },
+    [initial],
+  )
+
+  const setValues = useCallback((partial) => {
+    setValuesState((prev) => ({ ...prev, ...partial }))
+    // Limpa erros dos campos sobrescritos (auto-fill ANVISA)
+    setErrors((prev) => {
+      const keys = Object.keys(partial)
+      if (!keys.some((k) => prev[k])) return prev
+      const next = { ...prev }
+      for (const k of keys) delete next[k]
+      return next
+    })
+  }, [])
+
+  const isDirty = useMemo(
+    () => !deepEqual(values, initial),
+    [values, initial],
+  )
+
+  const isValid = useMemo(() => Object.keys(errors).length === 0, [errors])
+
+  // Placeholder v1; refs serão acopladas via FormInput em P1.2+.
+  const scrollToFirstError = useCallback(() => {}, [])
+
+  return {
+    values,
+    errors,
+    touched,
+    isDirty,
+    isValid,
+    handleChange,
+    handleBlur,
+    validate,
+    reset,
+    setValues,
+    scrollToFirstError,
+  }
+}
+
+export default useFormState

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
       "dependencies": {
         "@expo-google-fonts/comfortaa": "^0.4.2",
         "@react-native-async-storage/async-storage": "~2.1.2",
+        "@react-native-community/datetimepicker": "8.4.1",
         "@react-native-community/netinfo": "11.4.1",
         "@react-native-firebase/analytics": "^21.14.0",
         "@react-native-firebase/app": "^21.14.0",
@@ -78,6 +79,7 @@
         "expo-dev-client": "~5.2.4",
         "expo-device": "~7.1.4",
         "expo-font": "~13.3.2",
+        "expo-haptics": "~14.1.4",
         "expo-linear-gradient": "~14.1.5",
         "expo-notifications": "~0.31.5",
         "expo-secure-store": "^14.0.1",
@@ -5476,6 +5478,29 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.4.1.tgz",
+      "integrity": "sha512-DrK+CUS5fZnz8dhzBezirkzQTcNDdaXer3oDLh0z4nc2tbdIdnzwvXCvi8IEOIvleoc9L95xS5tKUl0/Xv71Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@react-native-community/netinfo": {
       "version": "11.4.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-11.4.1.tgz",
@@ -10775,6 +10800,15 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-haptics": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-14.1.4.tgz",
+      "integrity": "sha512-QZdE3NMX74rTuIl82I+n12XGwpDWKb8zfs5EpwsnGi/D/n7O2Jd4tO5ivH+muEG/OCJOMq5aeaVDqqaQOhTkcA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-json-utils": {


### PR DESCRIPTION
# 📦 feat(mobile/form-kit): Sprint P.1 — Form Kit Core

## 🎯 Resumo

Primeira sprint da Fase 0 (Pré-Requisitos) do projeto **Evolução CRUD Native**. Entrega bloco 1 de 3 da fundação CRUD nativa: **Form Kit** — hook genérico de estado de formulário com validação Zod e 6 componentes UI reutilizáveis. Sem este bloco, fases 1–6 (Medicamentos, Protocolos, Estoque) não podem começar.

---

## 📋 Tarefas Implementadas

### ✅ Hook Core (P1.1, P1.8)
- [x] `useFormState(schema, { initialValues })` — values/errors/touched/isDirty/isValid + handleChange/handleBlur/validate/reset/setValues/scrollToFirstError
- [x] Validação on-blur por campo via `schema.pick({[field]:true}).safeParse()` com fallback Hermes
- [x] `setValues()` faz merge parcial e limpa erros dos campos sobrescritos (suporta auto-fill ANVISA Sprint P.2)
- [x] 12 testes unitários cobrindo todos os métodos e estados

### ✅ Componentes Form Kit (P1.2-P1.7)
- [x] `FormInput` — controlled TextInput, animação spring na borda em erro, multiline editável, a11y completa
- [x] `FormSelect` — modal sheet com FlatList de opções, ChevronDown, estado selecionado destacado
- [x] `FormDatePicker` — branching iOS modal spinner / Android dialog imperativo
- [x] `FormTimePicker` — idem mode='time', formatador HH:mm 24h
- [x] `FormSection` — wrapper title/description com gap entre filhos
- [x] `FormActions` — primary/secondary, loading spinner, variante destructive
- [x] Barrel export `form/index.js`

### ✅ Dev Playground
- [x] `FormKitDemoScreen` interativo com todos os 6 componentes em todos os estados
- [x] Botão "DEV" no header da aba Hoje (gate `__DEV__`) abrindo o playground
- [x] Registro condicional `__DEV__` em `Navigation.jsx` — não vaza em build de produção

### ✅ Validação Visual (worktree manual)
- [x] FormInput — texto, focus, erro animado, disabled, multiline editável
- [x] FormSelect — modal abre, lista funciona, erro some ao selecionar
- [x] FormDatePicker / FormTimePicker — picker nativo iOS funciona, formatadores corretos
- [x] FormActions — primary/secondary, loading, destrutivo, disabled

---

## 📊 Métricas

| Métrica | Valor |
|---------|-------|
| Arquivos novos | 11 |
| Arquivos modificados | 4 |
| LOC adicionadas | ~1500 |
| Testes mobile | 12/12 (jest-expo, ~0.5s) |
| Testes web zero-regressão | 530/530 |
| Bundle iOS | 6.76 MB hbc |
| Modelos usados | 1 opus, 4 sonnet, 1 haiku (cavecrew) |

---

## 🔧 Arquivos Principais

```
apps/mobile/
├── app.config.js                                    # +plugin datetimepicker
├── package.json                                     # +expo-haptics, +datetimepicker
└── src/
    ├── shared/
    │   ├── hooks/
    │   │   ├── useFormState.js                      # ⭐ hook core
    │   │   └── __tests__/useFormState.test.js
    │   └── components/form/
    │       ├── FormInput.jsx
    │       ├── FormSelect.jsx
    │       ├── FormDatePicker.jsx
    │       ├── FormTimePicker.jsx
    │       ├── FormSection.jsx
    │       ├── FormActions.jsx
    │       └── index.js
    ├── features/
    │   ├── _dev/screens/FormKitDemoScreen.jsx       # playground __DEV__
    │   └── dashboard/screens/TodayScreen.jsx        # botão DEV no header
    └── navigation/
        ├── routes.js                                # +FORM_KIT_DEMO
        └── Navigation.jsx                           # registro __DEV__
```

---

## ✅ Checklist de Verificação

### Código
- [x] Lint sem erros (`rtk lint apps/mobile/src/shared/components/form apps/mobile/src/shared/hooks`)
- [x] Testes mobile passam (12/12)
- [x] Testes web zero-regressão (530/530)
- [x] Build mobile bem-sucedido (`npx expo export --platform ios` → 6.76 MB hbc)

### Funcionalidade
- [x] Multiline aceita texto continuamente (bug corrigido durante validação)
- [x] FormInput com erro mostra animação de borda
- [x] FormSelect modal abre/fecha, opções selecionáveis
- [x] DatePicker/TimePicker nativos funcionam no iOS
- [x] Botão DEV invisível em build de produção (gate `__DEV__`)

### Conformidade com regras do projeto
- [x] R-020: zero `new Date()` direto — usa `getNow()` de `@dosiq/core`
- [x] Lint sem `react-native/no-color-literals`
- [x] Lint sem `react-hooks/refs`
- [x] Comentários PT, identifiers EN
- [x] `StyleSheet.create()` em todos os componentes

---

## 🚀 Como Testar

```bash
# 1. Pull no worktree
git fetch origin
git checkout feat/crud-foundation-form-kit
git pull

# 2. Instalar deps novas (módulos nativos)
cd apps/mobile
npm install

# 3. Rebuild dev client (haptics + datetimepicker são módulos nativos)
npx expo prebuild --clean
npx expo run:ios

# 4. Testes do hook
npx jest --testPathPattern="useFormState"

# 5. Validação visual
# Login → aba Hoje → botão amarelo "DEV" canto superior direito
# FormKitDemoScreen abre → testar todos os primitivos interativamente
```

---

## 🔗 Specs Relacionadas

- Spec: `plans/backlog-native_app/EXEC_SPEC_PRE_REQUISITOS.md` §Sprint P.1
- Master plan: `plans/backlog-native_app/MASTER_PLAN_HIBRIDO_EVOLUCAO_CRUD.md` §9
- Mocks: `plans/backlog-native_app/MOCKS_CRUD_FASE_0-1/`
- SQP: `plans/backlog-native_app/INDEX_EXEC_SPECS.md` §SQP

---

## 📝 Notas para Reviewers

1. **Multi-modelo cavecrew**: Primeira sprint usando `caveman:cavecrew-builder` (sonnet/haiku) para tasks ⭐⭐ e ⭐ enquanto opus ficou com ⭐⭐⭐. Round-trip lint pós-spawn aplicado pelo arquiteto: 2 retrabalhos (R-020 timezone + ref-leak). Qualidade final 100% conformidade.

2. **Tokens visuais**: Primitivos extraídos do bundle Claude Design (`MOCKS_CRUD_FASE_0-1/project/dosiq-mocks/dosiq-primitives.jsx`). Paleta teal compatível com `tokens.colors.primary[700]` existente — zero ajuste no design system.

3. **`__DEV__` strict**: Demo screen e botão DEV gate `__DEV__` (Metro substitui em produção). Auditável via build production + ausência da string `FormKitDemo` no bytecode.

4. **Próximos passos**: Sprint P.2 (`useMutation` + ANVISA), Sprint P.3 (Toast/Delete/haptics). Após Fase 0 completa: PR `feat/crud-foundation` → `main`.

5. **Branch strategy**: PR aponta para `feat/crud-foundation` (mãe da Fase 0), não para `main`. Mãe acumula sprints e só vira PR contra `main` no gate de transição de fase.

---

## 🏷️ Versionamento

**Tipo:** Minor (mobile) — adiciona infra sem breaking change
**Versão anterior:** 0.3.7
**Versão sugerida:** mantém 0.3.7 (bump na Sprint P.3)

---

/cc @coelhotv
/cc @gemini-code-assist
