### PR TITLE
feat(mobile/mutations-anvisa): Sprint P.2 — useMutation + ANVISA Infra

### DIFF
--- a/apps/mobile/src/features/_dev/screens/FormKitDemoScreen.jsx
+++ b/apps/mobile/src/features/_dev/screens/FormKitDemoScreen.jsx
@@ -1,7 +1,7 @@
 // FormKitDemoScreen — playground dos primitivos do Form Kit (Sprint P.1)
 // Apenas para validação visual em ambiente DEV. Não usar em produção.
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ScrollView, View, Text, StyleSheet, TouchableOpacity } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { ChevronLeft } from 'lucide-react-native'
@@ -24,8 +24,18 @@ const FREQUENCY_OPTIONS = [
   { label: 'Quando necessário', value: 'quando_necessario' },
 ]
 
-export default function FormKitDemoScreen({ navigation }) {
+export default function FormKitDemoScreen({ navigation, route }) {
   const [selectedAnvisa, setSelectedAnvisa] = useState(null)
+
+  // Captura medicamento devolvido pela AnvisaSearchScreen via params (serializável)
+  useEffect(() => {
+    const picked = route?.params?.selectedMedicine
+    if (picked) {
+      setSelectedAnvisa(picked)
+      // Limpa o param para evitar re-aplicação em re-render
+      navigation?.setParams({ selectedMedicine: undefined })
+    }
+  }, [route?.params?.selectedMedicine, navigation])
 
   // Inputs interativos
   const [name, setName] = useState('')
@@ -227,7 +237,7 @@ export default function FormKitDemoScreen({ navigation }) {
           <TouchableOpacity
             onPress={() =>
               navigation?.navigate(ROUTES.ANVISA_SEARCH, {
-                onSelect: (m) => setSelectedAnvisa(m),
+                returnRoute: ROUTES.FORM_KIT_DEMO,
               })
             }
             style={styles.linkBtn}

--- a/apps/mobile/src/features/_dev/screens/FormKitDemoScreen.jsx
+++ b/apps/mobile/src/features/_dev/screens/FormKitDemoScreen.jsx
@@ -13,6 +13,7 @@ import {
   FormSection,
   FormActions,
 } from '@shared/components/form'
+import { ROUTES } from '../../../navigation/routes'
 import { colors, spacing } from '@shared/styles/tokens'
 
 const FREQUENCY_OPTIONS = [
@@ -24,6 +25,8 @@ const FREQUENCY_OPTIONS = [
 ]
 
 export default function FormKitDemoScreen({ navigation }) {
+  const [selectedAnvisa, setSelectedAnvisa] = useState(null)
+
   // Inputs interativos
   const [name, setName] = useState('')
   const [nameError, setNameError] = useState(undefined)
@@ -216,6 +219,33 @@ export default function FormKitDemoScreen({ navigation }) {
           />
         </FormSection>
 
+        {/* Seção 5 — Integração ANVISA (Sprint P.2) */}
+        <FormSection
+          title="ANVISA Search"
+          description="Abre tela de busca real (useMedicineDatabase + FormAutocomplete)"
+        >
+          <TouchableOpacity
+            onPress={() =>
+              navigation?.navigate(ROUTES.ANVISA_SEARCH, {
+                onSelect: (m) => setSelectedAnvisa(m),
+              })
+            }
+            style={styles.linkBtn}
+          >
+            <Text style={styles.linkBtnText}>Abrir busca ANVISA →</Text>
+          </TouchableOpacity>
+          {selectedAnvisa ? (
+            <View style={styles.selectedBox}>
+              <Text style={styles.selectedTitle}>
+                Selecionado: {selectedAnvisa.name}
+              </Text>
+              <Text style={styles.selectedSubtitle}>
+                {selectedAnvisa.activeIngredient} · {selectedAnvisa.laboratory}
+              </Text>
+            </View>
+          ) : null}
+        </FormSection>
+
         {/* Estado atual (debug) */}
         <FormSection
           title="Estado atual"
@@ -290,6 +320,35 @@ const styles = StyleSheet.create({
     backgroundColor: colors.neutral[800],
     borderRadius: 12,
     padding: spacing[4],
+  },
+  linkBtn: {
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[4],
+    backgroundColor: colors.primary[50],
+    borderRadius: 8,
+  },
+  linkBtnText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.primary[700],
+  },
+  selectedBox: {
+    marginTop: spacing[3],
+    padding: spacing[3],
+    backgroundColor: colors.bg.card,
+    borderRadius: 8,
+    borderLeftWidth: 4,
+    borderLeftColor: colors.status.success,
+  },
+  selectedTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.text.primary,
+  },
+  selectedSubtitle: {
+    fontSize: 12,
+    color: colors.text.secondary,
+    marginTop: 2,
   },
   debugText: {
     fontFamily: 'Courier',

--- a/apps/mobile/src/features/medications/screens/AnvisaSearchScreen.jsx
+++ b/apps/mobile/src/features/medications/screens/AnvisaSearchScreen.jsx
@@ -1,46 +1,125 @@
-import { useState } from 'react'
-import { View, Text, StyleSheet, ActivityIndicator, FlatList, Pressable } from 'react-native'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  Keyboard,
+} from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { ChevronLeft, Pill } from 'lucide-react-native'
+import { ChevronLeft, Pill, Search, X } from 'lucide-react-native'
 import { useMedicineDatabase } from '@shared/hooks/useMedicineDatabase'
-import FormAutocomplete from '@shared/components/form/FormAutocomplete'
 import { colors, spacing, borderRadius } from '@shared/styles/tokens'
+
+// Tela dedicada de busca ANVISA. Layout único: input no topo + lista
+// ocupando o resto da tela (sem overlay sobreposto). Para uso inline em
+// formulários, prefira FormAutocomplete (overlay) ou um bottom sheet.
+
+const DEBOUNCE_MS = 200
+const MAX_RESULTS = 30
+const MIN_CHARS = 3
 
 export default function AnvisaSearchScreen({ navigation, route }) {
   const [query, setQuery] = useState('')
+  const [debouncedQuery, setDebouncedQuery] = useState('')
   const { search, isReady, isLoading, error, lastUpdated } = useMedicineDatabase()
-  const results = isReady && query.trim().length >= 3 ? search(query, 20) : []
 
+  // Debounce do termo de busca
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(query), DEBOUNCE_MS)
+    return () => clearTimeout(t)
+  }, [query])
+
+  const trimmed = debouncedQuery.trim()
+  const results = useMemo(() => {
+    if (!isReady || trimmed.length < MIN_CHARS) return []
+    return search(trimmed, MAX_RESULTS)
+  }, [isReady, trimmed, search])
+
+  // Retorna o medicamento via params serializáveis (React Navigation v7 best practice)
   function handleSelect(medicine) {
-    route?.params?.onSelect?.(medicine)
-    navigation?.goBack()
+    Keyboard.dismiss()
+    const returnRoute = route?.params?.returnRoute
+    if (returnRoute) {
+      navigation?.navigate({
+        name: returnRoute,
+        params: { selectedMedicine: medicine },
+        merge: true,
+      })
+    } else {
+      navigation?.goBack()
+    }
   }
 
-  function renderResultItem({ item }) {
+  function renderItem({ item }) {
     return (
       <Pressable
-        style={({ pressed }) => [styles.resultRow, pressed && styles.resultRowPressed]}
+        style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
         onPress={() => handleSelect(item)}
         accessibilityRole="button"
         accessibilityLabel={item.name}
       >
-        <Pill size={18} color={colors.primary[500]} strokeWidth={2} style={styles.pillIcon} />
-        <View style={styles.resultText}>
-          <Text style={styles.resultName} numberOfLines={1}>{item.name}</Text>
+        <View style={styles.cardIcon}>
+          <Pill size={18} color={colors.primary[700]} strokeWidth={2} />
+        </View>
+        <View style={styles.cardText}>
+          <Text style={styles.cardName} numberOfLines={1}>
+            {item.name}
+          </Text>
           {item.activeIngredient ? (
-            <Text style={styles.resultSub} numberOfLines={1}>{item.activeIngredient}</Text>
+            <Text style={styles.cardSub} numberOfLines={1}>
+              {item.activeIngredient}
+            </Text>
           ) : null}
           {item.laboratory ? (
-            <Text style={styles.resultLab} numberOfLines={1}>{item.laboratory}</Text>
+            <Text style={styles.cardLab} numberOfLines={1}>
+              {item.laboratory}
+            </Text>
           ) : null}
         </View>
       </Pressable>
     )
   }
 
+  function renderEmpty() {
+    if (!isReady) {
+      if (isLoading) {
+        return (
+          <View style={styles.statusCenter}>
+            <ActivityIndicator color={colors.primary[700]} />
+            <Text style={styles.statusText}>Baixando base ANVISA…</Text>
+          </View>
+        )
+      }
+      if (error) {
+        return (
+          <Text style={styles.errorText}>
+            {`Falha ao baixar base: ${error}. Verifique sua conexão e tente novamente.`}
+          </Text>
+        )
+      }
+      return null
+    }
+    if (trimmed.length < MIN_CHARS) {
+      return (
+        <Text style={styles.hintText}>
+          Digite ao menos {MIN_CHARS} caracteres para buscar.
+        </Text>
+      )
+    }
+    return (
+      <Text style={styles.hintText}>
+        Nenhum medicamento encontrado para "{trimmed}".
+      </Text>
+    )
+  }
+
   return (
     <SafeAreaView style={styles.safe} edges={['top']}>
-      {/* Cabeçalho com botão voltar e título centralizado */}
+      {/* Cabeçalho */}
       <View style={styles.header}>
         <Pressable
           style={({ pressed }) => [styles.backBtn, pressed && styles.backBtnPressed]}
@@ -51,64 +130,54 @@ export default function AnvisaSearchScreen({ navigation, route }) {
           <ChevronLeft size={24} color={colors.text.primary} strokeWidth={2} />
         </Pressable>
         <Text style={styles.headerTitle}>Buscar medicamento</Text>
-        {/* Espaçador para simetria do título centralizado */}
         <View style={styles.headerSpacer} />
       </View>
 
-      <View style={styles.body}>
-        {/* Campo de busca com overlay de sugestões */}
-        <FormAutocomplete
-          name="anvisa"
-          label="Nome do medicamento"
-          placeholder="Digite ao menos 3 letras"
-          value={query}
-          onChange={(_, v) => setQuery(v)}
-          search={search}
-          getItemLabel={(m) => m.name}
-          getItemSubtitle={(m) => m.activeIngredient}
-          onSelect={handleSelect}
-        />
-
-        {/* Bloco de status enquanto a base não está pronta */}
-        {!isReady && (
-          <View style={styles.statusBlock}>
-            {isLoading ? (
-              <View style={styles.statusRow}>
-                <ActivityIndicator color={colors.primary[700]} />
-                <Text style={styles.statusText}>Baixando base ANVISA…</Text>
-              </View>
-            ) : error ? (
-              <Text style={styles.errorText}>
-                {`Falha ao baixar base: ${error}. Verifique sua conexão e tente novamente.`}
-              </Text>
-            ) : null}
-          </View>
-        )}
-
-        {/* Dica quando base está pronta mas query curta */}
-        {isReady && query.trim().length < 3 && (
-          <Text style={styles.hintText}>Digite ao menos 3 caracteres para buscar.</Text>
-        )}
-
-        {/* Lista de resultados expandida (top 20) */}
-        {results.length > 0 && (
-          <FlatList
-            data={results}
-            keyExtractor={(item, idx) => `${item.name}-${idx}`}
-            renderItem={renderResultItem}
-            keyboardShouldPersistTaps="handled"
-            style={styles.list}
-            contentContainerStyle={styles.listContent}
+      {/* Input de busca */}
+      <View style={styles.searchWrapper}>
+        <View style={styles.searchBox}>
+          <Search size={18} color={colors.text.muted} strokeWidth={2} />
+          <TextInput
+            style={styles.searchInput}
+            value={query}
+            onChangeText={setQuery}
+            placeholder="Digite o nome ou princípio ativo"
+            placeholderTextColor={colors.text.muted}
+            autoCorrect={false}
+            autoCapitalize="words"
+            returnKeyType="search"
+            accessibilityLabel="Buscar medicamento"
           />
-        )}
-
-        {/* Atualização da base (quando disponível) */}
-        {isReady && lastUpdated ? (
-          <Text style={styles.updatedText}>
-            {`Base atualizada em ${lastUpdated.toLocaleDateString('pt-BR')}`}
-          </Text>
-        ) : null}
+          {query ? (
+            <Pressable
+              onPress={() => setQuery('')}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityRole="button"
+              accessibilityLabel="Limpar"
+            >
+              <X size={18} color={colors.text.muted} strokeWidth={2} />
+            </Pressable>
+          ) : null}
+        </View>
       </View>
+
+      {/* Lista única ocupando o restante da tela */}
+      <FlatList
+        data={results}
+        keyExtractor={(item, idx) => `${item.name}-${idx}`}
+        renderItem={renderItem}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
+        contentContainerStyle={styles.listContent}
+        ListEmptyComponent={renderEmpty}
+        ListFooterComponent={
+          isReady && lastUpdated ? (
+            <Text style={styles.updatedText}>
+              {`Base atualizada em ${lastUpdated.toLocaleDateString('pt-BR')}`}
+            </Text>
+          ) : null
+        }
+      />
     </SafeAreaView>
   )
 }
@@ -147,17 +216,80 @@ const styles = StyleSheet.create({
   headerSpacer: {
     width: 40,
   },
-  body: {
-    flex: 1,
-    padding: spacing[5],
+  searchWrapper: {
+    paddingHorizontal: spacing[5],
+    paddingTop: spacing[4],
+    paddingBottom: spacing[3],
+    backgroundColor: colors.bg.card,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border.light,
   },
-  statusBlock: {
-    marginTop: spacing[4],
-  },
-  statusRow: {
+  searchBox: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing[2],
+    height: 44,
+    paddingHorizontal: spacing[3],
+    backgroundColor: colors.neutral[100],
+    borderRadius: borderRadius.md,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 15,
+    color: colors.text.primary,
+    padding: 0,
+  },
+  listContent: {
+    padding: spacing[5],
+    paddingBottom: spacing[10],
+    flexGrow: 1,
+  },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    padding: spacing[3],
+    backgroundColor: colors.bg.card,
+    borderRadius: borderRadius.md,
+    marginBottom: spacing[2],
+    borderWidth: 1,
+    borderColor: colors.border.light,
+    gap: spacing[3],
+  },
+  cardPressed: {
+    backgroundColor: colors.primary[50],
+    borderColor: colors.primary[200],
+  },
+  cardIcon: {
+    width: 32,
+    height: 32,
+    borderRadius: borderRadius.sm,
+    backgroundColor: colors.primary[50],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cardText: {
+    flex: 1,
+  },
+  cardName: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.text.primary,
+  },
+  cardSub: {
+    fontSize: 13,
+    color: colors.text.muted,
+    marginTop: 2,
+  },
+  cardLab: {
+    fontSize: 11,
+    color: colors.text.muted,
+    marginTop: 2,
+  },
+  statusCenter: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing[8],
+    gap: spacing[3],
   },
   statusText: {
     fontSize: 14,
@@ -167,54 +299,14 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: colors.status.error,
     lineHeight: 20,
+    textAlign: 'center',
+    marginTop: spacing[4],
   },
   hintText: {
-    marginTop: spacing[4],
     fontSize: 14,
     color: colors.text.muted,
     textAlign: 'center',
-  },
-  list: {
-    marginTop: spacing[4],
-  },
-  listContent: {
-    gap: 0,
-  },
-  resultRow: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    paddingVertical: spacing[3],
-    paddingHorizontal: spacing[4],
-    backgroundColor: colors.bg.card,
-    borderRadius: borderRadius.md,
-    marginBottom: spacing[2],
-    borderWidth: 1,
-    borderColor: colors.border.light,
-    gap: spacing[3],
-  },
-  resultRowPressed: {
-    backgroundColor: colors.primary[50],
-  },
-  pillIcon: {
-    marginTop: 2,
-  },
-  resultText: {
-    flex: 1,
-  },
-  resultName: {
-    fontSize: 15,
-    fontWeight: '600',
-    color: colors.text.primary,
-  },
-  resultSub: {
-    fontSize: 13,
-    color: colors.text.muted,
-    marginTop: 2,
-  },
-  resultLab: {
-    fontSize: 11,
-    color: colors.text.muted,
-    marginTop: 2,
+    marginTop: spacing[8],
   },
   updatedText: {
     marginTop: spacing[4],

--- a/apps/mobile/src/features/medications/screens/AnvisaSearchScreen.jsx
+++ b/apps/mobile/src/features/medications/screens/AnvisaSearchScreen.jsx
@@ -1,0 +1,225 @@
+import { useState } from 'react'
+import { View, Text, StyleSheet, ActivityIndicator, FlatList, Pressable } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { ChevronLeft, Pill } from 'lucide-react-native'
+import { useMedicineDatabase } from '@shared/hooks/useMedicineDatabase'
+import FormAutocomplete from '@shared/components/form/FormAutocomplete'
+import { colors, spacing, borderRadius } from '@shared/styles/tokens'
+
+export default function AnvisaSearchScreen({ navigation, route }) {
+  const [query, setQuery] = useState('')
+  const { search, isReady, isLoading, error, lastUpdated } = useMedicineDatabase()
+  const results = isReady && query.trim().length >= 3 ? search(query, 20) : []
+
+  function handleSelect(medicine) {
+    route?.params?.onSelect?.(medicine)
+    navigation?.goBack()
+  }
+
+  function renderResultItem({ item }) {
+    return (
+      <Pressable
+        style={({ pressed }) => [styles.resultRow, pressed && styles.resultRowPressed]}
+        onPress={() => handleSelect(item)}
+        accessibilityRole="button"
+        accessibilityLabel={item.name}
+      >
+        <Pill size={18} color={colors.primary[500]} strokeWidth={2} style={styles.pillIcon} />
+        <View style={styles.resultText}>
+          <Text style={styles.resultName} numberOfLines={1}>{item.name}</Text>
+          {item.activeIngredient ? (
+            <Text style={styles.resultSub} numberOfLines={1}>{item.activeIngredient}</Text>
+          ) : null}
+          {item.laboratory ? (
+            <Text style={styles.resultLab} numberOfLines={1}>{item.laboratory}</Text>
+          ) : null}
+        </View>
+      </Pressable>
+    )
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top']}>
+      {/* Cabeçalho com botão voltar e título centralizado */}
+      <View style={styles.header}>
+        <Pressable
+          style={({ pressed }) => [styles.backBtn, pressed && styles.backBtnPressed]}
+          onPress={() => navigation?.goBack()}
+          accessibilityRole="button"
+          accessibilityLabel="Voltar"
+        >
+          <ChevronLeft size={24} color={colors.text.primary} strokeWidth={2} />
+        </Pressable>
+        <Text style={styles.headerTitle}>Buscar medicamento</Text>
+        {/* Espaçador para simetria do título centralizado */}
+        <View style={styles.headerSpacer} />
+      </View>
+
+      <View style={styles.body}>
+        {/* Campo de busca com overlay de sugestões */}
+        <FormAutocomplete
+          name="anvisa"
+          label="Nome do medicamento"
+          placeholder="Digite ao menos 3 letras"
+          value={query}
+          onChange={(_, v) => setQuery(v)}
+          search={search}
+          getItemLabel={(m) => m.name}
+          getItemSubtitle={(m) => m.activeIngredient}
+          onSelect={handleSelect}
+        />
+
+        {/* Bloco de status enquanto a base não está pronta */}
+        {!isReady && (
+          <View style={styles.statusBlock}>
+            {isLoading ? (
+              <View style={styles.statusRow}>
+                <ActivityIndicator color={colors.primary[700]} />
+                <Text style={styles.statusText}>Baixando base ANVISA…</Text>
+              </View>
+            ) : error ? (
+              <Text style={styles.errorText}>
+                {`Falha ao baixar base: ${error}. Verifique sua conexão e tente novamente.`}
+              </Text>
+            ) : null}
+          </View>
+        )}
+
+        {/* Dica quando base está pronta mas query curta */}
+        {isReady && query.trim().length < 3 && (
+          <Text style={styles.hintText}>Digite ao menos 3 caracteres para buscar.</Text>
+        )}
+
+        {/* Lista de resultados expandida (top 20) */}
+        {results.length > 0 && (
+          <FlatList
+            data={results}
+            keyExtractor={(item, idx) => `${item.name}-${idx}`}
+            renderItem={renderResultItem}
+            keyboardShouldPersistTaps="handled"
+            style={styles.list}
+            contentContainerStyle={styles.listContent}
+          />
+        )}
+
+        {/* Atualização da base (quando disponível) */}
+        {isReady && lastUpdated ? (
+          <Text style={styles.updatedText}>
+            {`Base atualizada em ${lastUpdated.toLocaleDateString('pt-BR')}`}
+          </Text>
+        ) : null}
+      </View>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: colors.bg.screen,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border.light,
+    backgroundColor: colors.bg.card,
+  },
+  backBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  backBtnPressed: {
+    backgroundColor: colors.neutral[100],
+  },
+  headerTitle: {
+    flex: 1,
+    textAlign: 'center',
+    fontSize: 17,
+    fontWeight: '600',
+    color: colors.text.primary,
+  },
+  headerSpacer: {
+    width: 40,
+  },
+  body: {
+    flex: 1,
+    padding: spacing[5],
+  },
+  statusBlock: {
+    marginTop: spacing[4],
+  },
+  statusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  statusText: {
+    fontSize: 14,
+    color: colors.text.muted,
+  },
+  errorText: {
+    fontSize: 14,
+    color: colors.status.error,
+    lineHeight: 20,
+  },
+  hintText: {
+    marginTop: spacing[4],
+    fontSize: 14,
+    color: colors.text.muted,
+    textAlign: 'center',
+  },
+  list: {
+    marginTop: spacing[4],
+  },
+  listContent: {
+    gap: 0,
+  },
+  resultRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[4],
+    backgroundColor: colors.bg.card,
+    borderRadius: borderRadius.md,
+    marginBottom: spacing[2],
+    borderWidth: 1,
+    borderColor: colors.border.light,
+    gap: spacing[3],
+  },
+  resultRowPressed: {
+    backgroundColor: colors.primary[50],
+  },
+  pillIcon: {
+    marginTop: 2,
+  },
+  resultText: {
+    flex: 1,
+  },
+  resultName: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.text.primary,
+  },
+  resultSub: {
+    fontSize: 13,
+    color: colors.text.muted,
+    marginTop: 2,
+  },
+  resultLab: {
+    fontSize: 11,
+    color: colors.text.muted,
+    marginTop: 2,
+  },
+  updatedText: {
+    marginTop: spacing[4],
+    fontSize: 11,
+    color: colors.text.muted,
+    textAlign: 'center',
+  },
+})

--- a/apps/mobile/src/features/medications/screens/AnvisaSearchScreen.jsx
+++ b/apps/mobile/src/features/medications/screens/AnvisaSearchScreen.jsx
@@ -23,21 +23,24 @@ const MAX_RESULTS = 30
 const MIN_CHARS = 3
 
 export default function AnvisaSearchScreen({ navigation, route }) {
+  // States
   const [query, setQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')
   const { search, isReady, isLoading, error, lastUpdated } = useMedicineDatabase()
 
-  // Debounce do termo de busca
-  useEffect(() => {
-    const t = setTimeout(() => setDebouncedQuery(query), DEBOUNCE_MS)
-    return () => clearTimeout(t)
-  }, [query])
-
+  // Memos (R-010: declarados antes de Effects)
   const trimmed = debouncedQuery.trim()
   const results = useMemo(() => {
     if (!isReady || trimmed.length < MIN_CHARS) return []
     return search(trimmed, MAX_RESULTS)
   }, [isReady, trimmed, search])
+
+  // Effects
+  // Debounce do termo de busca
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(query), DEBOUNCE_MS)
+    return () => clearTimeout(t)
+  }, [query])
 
   // Retorna o medicamento via params serializáveis (React Navigation v7 best practice)
   function handleSelect(medicine) {

--- a/apps/mobile/src/navigation/Navigation.jsx
+++ b/apps/mobile/src/navigation/Navigation.jsx
@@ -22,6 +22,7 @@ import ForgotPasswordScreen from '../screens/ForgotPasswordScreen'
 import ResetPasswordScreen from '../screens/ResetPasswordScreen'
 import RootTabs from './RootTabs'
 import FormKitDemoScreen from '../features/_dev/screens/FormKitDemoScreen'
+import AnvisaSearchScreen from '../features/medications/screens/AnvisaSearchScreen'
 import { supabase } from '../platform/supabase/nativeSupabaseClient'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { usePushNotifications } from '../platform/notifications/usePushNotifications'
@@ -153,6 +154,10 @@ export default function Navigation() {
         ) : session ? (
           <>
             <Stack.Screen name={ROUTES.TABS} component={RootTabs} />
+            <Stack.Screen
+              name={ROUTES.ANVISA_SEARCH}
+              component={AnvisaSearchScreen}
+            />
             {__DEV__ && (
               <Stack.Screen
                 name={ROUTES.FORM_KIT_DEMO}

--- a/apps/mobile/src/navigation/routes.js
+++ b/apps/mobile/src/navigation/routes.js
@@ -30,6 +30,9 @@ export const ROUTES = {
   NOTIFICATION_PREFERENCES: 'NotificationPreferences',
   NOTIFICATION_INBOX: 'NotificationInbox',
 
+  // ANVISA search (Sprint P.2)
+  ANVISA_SEARCH: 'AnvisaSearch',
+
   // Dev-only (apenas __DEV__)
   FORM_KIT_DEMO: 'FormKitDemo',
 }

--- a/apps/mobile/src/shared/components/form/FormAutocomplete.jsx
+++ b/apps/mobile/src/shared/components/form/FormAutocomplete.jsx
@@ -172,42 +172,39 @@ export default function FormAutocomplete({
         </View>
       ) : null}
 
-      <View style={[styles.inputContainer, { borderColor }]}>
-        <Search size={18} color={colors.text.muted} strokeWidth={2} />
-        <TextInput
-          style={styles.input}
-          value={value}
-          placeholder={placeholder}
-          placeholderTextColor={colors.text.muted}
-          editable={!disabled}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
-          onChangeText={handleChangeText}
-          autoCorrect={false}
-          autoCapitalize="words"
-          accessibilityLabel={label}
-          accessibilityHint={helperText || placeholder}
-          accessibilityState={error ? { invalid: true } : undefined}
-        />
-        {value ? (
-          <Pressable
-            onPress={handleClear}
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            accessibilityRole="button"
-            accessibilityLabel="Limpar"
-          >
-            <X size={18} color={colors.text.muted} strokeWidth={2} />
-          </Pressable>
-        ) : null}
-      </View>
+      {/* Wrapper relativo isolando input+overlay — overlay ancora via
+          top: '100%' do inputContainer, independente da altura do label. */}
+      <View style={styles.inputBlock}>
+        <View style={[styles.inputContainer, { borderColor }]}>
+          <Search size={18} color={colors.text.muted} strokeWidth={2} />
+          <TextInput
+            style={styles.input}
+            value={value}
+            placeholder={placeholder}
+            placeholderTextColor={colors.text.muted}
+            editable={!disabled}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onChangeText={handleChangeText}
+            autoCorrect={false}
+            autoCapitalize="words"
+            accessibilityLabel={label}
+            accessibilityHint={helperText || placeholder}
+            accessibilityState={error ? { invalid: true } : undefined}
+          />
+          {value ? (
+            <Pressable
+              onPress={handleClear}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityRole="button"
+              accessibilityLabel="Limpar"
+            >
+              <X size={18} color={colors.text.muted} strokeWidth={2} />
+            </Pressable>
+          ) : null}
+        </View>
 
-      {error ? (
-        <Text style={styles.errorText}>{error}</Text>
-      ) : helperText ? (
-        <Text style={styles.helperText}>{helperText}</Text>
-      ) : null}
-
-      {showOverlay && (
+        {showOverlay && (
         <View style={styles.overlay}>
           {searching ? (
             <View style={styles.statusRow}>
@@ -228,7 +225,14 @@ export default function FormAutocomplete({
             />
           )}
         </View>
-      )}
+        )}
+      </View>
+
+      {error ? (
+        <Text style={styles.errorText}>{error}</Text>
+      ) : helperText ? (
+        <Text style={styles.helperText}>{helperText}</Text>
+      ) : null}
     </View>
   )
 }
@@ -254,6 +258,10 @@ const styles = StyleSheet.create({
   asterisk: {
     fontSize: 13,
     color: colors.status.error,
+  },
+  inputBlock: {
+    // Wrapper relativo para ancorar o overlay (top: '100%' do input)
+    position: 'relative',
   },
   inputContainer: {
     height: 50,
@@ -282,8 +290,11 @@ const styles = StyleSheet.create({
     marginTop: 6,
   },
   overlay: {
+    // Ancorado ao bottom do inputContainer via wrapper relativo inputBlock,
+    // imune a alterações na altura do label (sem magic number).
     position: 'absolute',
-    top: 78, // label (~24) + container (50) + gap (4)
+    top: '100%',
+    marginTop: 4,
     left: 0,
     right: 0,
     backgroundColor: colors.bg.card,

--- a/apps/mobile/src/shared/components/form/FormAutocomplete.jsx
+++ b/apps/mobile/src/shared/components/form/FormAutocomplete.jsx
@@ -1,0 +1,334 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  FlatList,
+  ActivityIndicator,
+  StyleSheet,
+} from 'react-native'
+import { Search, X } from 'lucide-react-native'
+import { colors, spacing, borderRadius } from '@shared/styles/tokens'
+
+// Componente de busca com sugestões em overlay (estilo autocomplete).
+// Pensado para a busca ANVISA: usuário digita, hook search() retorna lista,
+// tap em sugestão dispara onChange(name, value) e onSelect(item) para auto-fill.
+//
+// Props:
+//   name        chave do campo
+//   label       label visual
+//   value       string controlado
+//   error       mensagem de erro
+//   placeholder
+//   helperText
+//   required
+//   disabled
+//   search      (query, limit) => Array<item>
+//   getItemLabel(item)  string visível na lista (default: item.name)
+//   getItemSubtitle(item) opcional, segunda linha
+//   getItemValue(item)  default: item.name (passado para onChange)
+//   onChange    (name, value) => void
+//   onSelect    (item) => void  (callback completo p/ auto-fill via setValues)
+//   onBlur      (name) => void
+//   minChars    default 3
+//   maxResults  default 8
+//   debounceMs  default 200
+
+const DEFAULT_DEBOUNCE_MS = 200
+const DEFAULT_MIN_CHARS = 3
+const DEFAULT_MAX_RESULTS = 8
+
+function defaultGetLabel(item) {
+  return item?.name ?? ''
+}
+
+function defaultGetValue(item) {
+  return item?.name ?? ''
+}
+
+export default function FormAutocomplete({
+  name,
+  label,
+  value,
+  error,
+  placeholder,
+  helperText,
+  required,
+  disabled,
+  search,
+  getItemLabel = defaultGetLabel,
+  getItemSubtitle,
+  getItemValue = defaultGetValue,
+  onChange,
+  onSelect,
+  onBlur,
+  minChars = DEFAULT_MIN_CHARS,
+  maxResults = DEFAULT_MAX_RESULTS,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+}) {
+  const [focused, setFocused] = useState(false)
+  const [results, setResults] = useState([])
+  const [searching, setSearching] = useState(false)
+  const debounceRef = useRef(null)
+
+  // Roda busca debounced quando value muda + foco está no campo
+  useEffect(() => {
+    if (!focused) return undefined
+    const trimmed = value?.trim() ?? ''
+    if (trimmed.length < minChars) {
+      // Limpa via timeout (evita setState síncrono no effect)
+      const t = setTimeout(() => {
+        setResults([])
+        setSearching(false)
+      }, 0)
+      return () => clearTimeout(t)
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    // Marca "buscando" no próximo tick + roda busca após debounce
+    const startTimer = setTimeout(() => setSearching(true), 0)
+    debounceRef.current = setTimeout(() => {
+      try {
+        const out = search?.(value, maxResults) ?? []
+        setResults(Array.isArray(out) ? out : [])
+      } catch {
+        setResults([])
+      } finally {
+        setSearching(false)
+      }
+    }, debounceMs)
+
+    return () => {
+      clearTimeout(startTimer)
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [value, focused, minChars, maxResults, debounceMs, search])
+
+  const showOverlay = focused && value && value.trim().length >= minChars
+
+  const borderColor = error
+    ? colors.status.error
+    : focused
+    ? colors.primary[700]
+    : colors.border.default
+
+  function handleChangeText(text) {
+    onChange?.(name, text)
+  }
+
+  function handleClear() {
+    onChange?.(name, '')
+    setResults([])
+  }
+
+  function handleFocus() {
+    setFocused(true)
+  }
+
+  function handleBlur() {
+    // Delay para permitir tap na sugestão antes de fechar overlay
+    setTimeout(() => {
+      setFocused(false)
+      onBlur?.(name)
+    }, 150)
+  }
+
+  function handleSelect(item) {
+    const v = getItemValue(item)
+    onChange?.(name, v)
+    onSelect?.(item)
+    setResults([])
+    setFocused(false)
+  }
+
+  function renderItem({ item }) {
+    const label = getItemLabel(item)
+    const subtitle = getItemSubtitle?.(item)
+    return (
+      <Pressable
+        style={({ pressed }) => [styles.item, pressed && styles.itemPressed]}
+        onPress={() => handleSelect(item)}
+        accessibilityRole="button"
+        accessibilityLabel={label}
+      >
+        <Text style={styles.itemTitle} numberOfLines={1}>
+          {label}
+        </Text>
+        {subtitle ? (
+          <Text style={styles.itemSubtitle} numberOfLines={1}>
+            {subtitle}
+          </Text>
+        ) : null}
+      </Pressable>
+    )
+  }
+
+  return (
+    <View style={[styles.wrapper, disabled && styles.wrapperDisabled]}>
+      {label ? (
+        <View style={styles.labelRow}>
+          <Text style={styles.label}>{label}</Text>
+          {required && <Text style={styles.asterisk}> *</Text>}
+        </View>
+      ) : null}
+
+      <View style={[styles.inputContainer, { borderColor }]}>
+        <Search size={18} color={colors.text.muted} strokeWidth={2} />
+        <TextInput
+          style={styles.input}
+          value={value}
+          placeholder={placeholder}
+          placeholderTextColor={colors.text.muted}
+          editable={!disabled}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onChangeText={handleChangeText}
+          autoCorrect={false}
+          autoCapitalize="words"
+          accessibilityLabel={label}
+          accessibilityHint={helperText || placeholder}
+          accessibilityState={error ? { invalid: true } : undefined}
+        />
+        {value ? (
+          <Pressable
+            onPress={handleClear}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            accessibilityRole="button"
+            accessibilityLabel="Limpar"
+          >
+            <X size={18} color={colors.text.muted} strokeWidth={2} />
+          </Pressable>
+        ) : null}
+      </View>
+
+      {error ? (
+        <Text style={styles.errorText}>{error}</Text>
+      ) : helperText ? (
+        <Text style={styles.helperText}>{helperText}</Text>
+      ) : null}
+
+      {showOverlay && (
+        <View style={styles.overlay}>
+          {searching ? (
+            <View style={styles.statusRow}>
+              <ActivityIndicator color={colors.primary[700]} />
+              <Text style={styles.statusText}>Buscando…</Text>
+            </View>
+          ) : results.length === 0 ? (
+            <View style={styles.statusRow}>
+              <Text style={styles.statusText}>Nenhum resultado</Text>
+            </View>
+          ) : (
+            <FlatList
+              data={results}
+              keyExtractor={(item, idx) => `${getItemValue(item)}-${idx}`}
+              renderItem={renderItem}
+              keyboardShouldPersistTaps="handled"
+              style={styles.list}
+            />
+          )}
+        </View>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    opacity: 1,
+    position: 'relative',
+  },
+  wrapperDisabled: {
+    opacity: 0.6,
+  },
+  labelRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    marginBottom: 6,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: colors.text.secondary,
+  },
+  asterisk: {
+    fontSize: 13,
+    color: colors.status.error,
+  },
+  inputContainer: {
+    height: 50,
+    backgroundColor: colors.bg.card,
+    borderWidth: 1.5,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  input: {
+    flex: 1,
+    fontSize: 15,
+    color: colors.text.primary,
+    padding: 0,
+  },
+  errorText: {
+    fontSize: 12,
+    color: colors.status.error,
+    marginTop: 6,
+  },
+  helperText: {
+    fontSize: 12,
+    color: colors.text.muted,
+    marginTop: 6,
+  },
+  overlay: {
+    position: 'absolute',
+    top: 78, // label (~24) + container (50) + gap (4)
+    left: 0,
+    right: 0,
+    backgroundColor: colors.bg.card,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+    borderRadius: borderRadius.md,
+    maxHeight: 280,
+    zIndex: 10,
+    elevation: 8,
+    shadowColor: colors.neutral[900],
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+  },
+  list: {
+    flexGrow: 0,
+  },
+  item: {
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[4],
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border.light,
+  },
+  itemPressed: {
+    backgroundColor: colors.primary[50],
+  },
+  itemTitle: {
+    fontSize: 15,
+    fontWeight: '500',
+    color: colors.text.primary,
+  },
+  itemSubtitle: {
+    fontSize: 12,
+    color: colors.text.muted,
+    marginTop: 2,
+  },
+  statusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[4],
+  },
+  statusText: {
+    fontSize: 13,
+    color: colors.text.muted,
+  },
+})

--- a/apps/mobile/src/shared/components/form/FormDatePicker.jsx
+++ b/apps/mobile/src/shared/components/form/FormDatePicker.jsx
@@ -162,7 +162,10 @@ export default function FormDatePicker({
                 </TouchableOpacity>
               </View>
 
-              {/* Picker spinner */}
+              {/* Picker spinner.
+                  textColor + themeVariant explícitos previnem texto invisível
+                  em alguns devices iOS (dark mode forçado, accessibility,
+                  iOS 14+ herdando cor do sistema). */}
               <DateTimePicker
                 mode="date"
                 display="spinner"
@@ -171,6 +174,8 @@ export default function FormDatePicker({
                 minimumDate={minimumDate}
                 maximumDate={maximumDate}
                 locale="pt-BR"
+                textColor={colors.text.primary}
+                themeVariant="light"
               />
             </SafeAreaView>
           </View>

--- a/apps/mobile/src/shared/components/form/FormTimePicker.jsx
+++ b/apps/mobile/src/shared/components/form/FormTimePicker.jsx
@@ -157,13 +157,18 @@ export default function FormTimePicker({
                 </TouchableOpacity>
               </View>
 
-              {/* Picker spinner */}
+              {/* Picker spinner.
+                  textColor + themeVariant explícitos previnem texto invisível
+                  em alguns devices iOS (dark mode forçado, accessibility,
+                  iOS 14+ herdando cor do sistema). */}
               <DateTimePicker
                 mode="time"
                 display="spinner"
                 value={tempValue}
                 onChange={handleIOSChange}
                 locale="pt-BR"
+                textColor={colors.text.primary}
+                themeVariant="light"
               />
             </SafeAreaView>
           </View>

--- a/apps/mobile/src/shared/components/form/index.js
+++ b/apps/mobile/src/shared/components/form/index.js
@@ -3,6 +3,7 @@
 
 export { default as FormInput } from './FormInput'
 export { default as FormSelect } from './FormSelect'
+export { default as FormAutocomplete } from './FormAutocomplete'
 export { default as FormDatePicker } from './FormDatePicker'
 export { default as FormTimePicker } from './FormTimePicker'
 export { default as FormSection } from './FormSection'

--- a/apps/mobile/src/shared/hooks/__tests__/useMedicineDatabase.test.js
+++ b/apps/mobile/src/shared/hooks/__tests__/useMedicineDatabase.test.js
@@ -27,6 +27,10 @@ const mockData = [
   { name: 'Paracetamol', activeIngredient: 'Paracetamol', therapeuticClass: 'Analgésico', laboratory: 'Lab A' },
   { name: 'Dipirona', activeIngredient: 'Dipirona Sódica', therapeuticClass: 'Analgésico', laboratory: 'Lab B' },
   { name: 'Ácido Acetilsalicílico', activeIngredient: 'AAS', therapeuticClass: 'Anti-inflamatório', laboratory: 'Lab C' },
+  // Casos para testar word-boundary prefix
+  { name: 'Maleato de Trimebutina', activeIngredient: 'Trimebutina', therapeuticClass: 'Antiespasmódico', laboratory: 'Lab D' },
+  { name: 'Sumatriptana', activeIngredient: 'Sumatriptana', therapeuticClass: 'Antimigranoso', laboratory: 'Lab E' },
+  { name: 'Aparat', activeIngredient: 'Aparat', therapeuticClass: 'Misc', laboratory: 'Lab F' },
 ]
 
 function mockFetchOk(body) {
@@ -228,9 +232,9 @@ describe('search()', () => {
 
   it('respeita o limite', async () => {
     const result = await getReadyHook()
-    // 'ana' aparece em Paracetamol (ativa ingredient) e Dipirona
-    const res = result.current.search('ana', 1)
-    expect(res.length).toBeLessThanOrEqual(1)
+    // 'dip' casa Dipirona (name + ingredient) — limit 1 deve cortar
+    const res = result.current.search('dip', 1)
+    expect(res.length).toBe(1)
   })
 
   it('retorna [] para query com menos de 3 caracteres', async () => {
@@ -243,6 +247,42 @@ describe('search()', () => {
     const result = await getReadyHook()
     expect(result.current.search(null, 10)).toEqual([])
     expect(result.current.search(undefined, 10)).toEqual([])
+  })
+
+  it('match word-boundary: "trime" casa "Maleato de Trimebutina" (segunda palavra)', async () => {
+    const result = await getReadyHook()
+    const res = result.current.search('trime', 10)
+    expect(res.some((m) => m.name === 'Maleato de Trimebutina')).toBe(true)
+  })
+
+  it('match word-boundary: "trime" casa via activeIngredient "Trimebutina"', async () => {
+    const result = await getReadyHook()
+    const res = result.current.search('trime', 10)
+    expect(res.length).toBeGreaterThan(0)
+  })
+
+  it('NÃO match mid-word: "trip" não casa "Suma**trip**tana"', async () => {
+    const result = await getReadyHook()
+    const res = result.current.search('trip', 10)
+    expect(res.some((m) => m.name === 'Sumatriptana')).toBe(false)
+  })
+
+  it('NÃO match mid-word: "para" não casa "A**para**t"', async () => {
+    const result = await getReadyHook()
+    const res = result.current.search('para', 10)
+    expect(res.some((m) => m.name === 'Aparat')).toBe(false)
+    // Mas DEVE casar Paracetamol (prefixo do início)
+    expect(res.some((m) => m.name === 'Paracetamol')).toBe(true)
+  })
+
+  it('ranking: name-prefix vem antes de só-activeIngredient-prefix', async () => {
+    const result = await getReadyHook()
+    // 'trime' casa name "Maleato de Trimebutina" (segunda palavra do name)
+    // E também casa activeIngredient "Trimebutina"
+    // Como ambos têm match no name, primeiro deve ser quem tem match no name
+    const res = result.current.search('dipi', 10)
+    // Dipirona casa por name; nenhum outro registro casa por nada
+    expect(res[0].name).toBe('Dipirona')
   })
 })
 

--- a/apps/mobile/src/shared/hooks/__tests__/useMedicineDatabase.test.js
+++ b/apps/mobile/src/shared/hooks/__tests__/useMedicineDatabase.test.js
@@ -1,0 +1,295 @@
+// Mocks declarados antes dos imports (obrigatório para jest.mock hoisting)
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  multiGet: jest.fn(),
+  multiSet: jest.fn().mockResolvedValue(undefined),
+  getItem: jest.fn(),
+}))
+
+jest.mock('@dosiq/core', () => ({
+  getNow: () => new Date('2026-05-14T12:00:00.000Z'),
+  parseISO: (s) => new Date(s),
+}))
+
+import { act, renderHook, waitFor } from '@testing-library/react-native'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { useMedicineDatabase } from '../useMedicineDatabase'
+
+// Fetch global mockado
+global.fetch = jest.fn()
+
+const mockManifest = {
+  version: '1.0.0',
+  generatedAt: '2026-05-14T10:00:00Z',
+  files: { medicineDatabase: { path: 'anvisa/v1/medicineDatabase.json' } },
+}
+
+const mockData = [
+  { name: 'Paracetamol', activeIngredient: 'Paracetamol', therapeuticClass: 'Analgésico', laboratory: 'Lab A' },
+  { name: 'Dipirona', activeIngredient: 'Dipirona Sódica', therapeuticClass: 'Analgésico', laboratory: 'Lab B' },
+  { name: 'Ácido Acetilsalicílico', activeIngredient: 'AAS', therapeuticClass: 'Anti-inflamatório', laboratory: 'Lab C' },
+]
+
+function mockFetchOk(body) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(body) })
+}
+
+function mockFetchError() {
+  return Promise.reject(new Error('Network down'))
+}
+
+// Retorna multiGet simulando cache populado
+function buildCacheMultiGet(manifestOverrides = {}, data = mockData) {
+  const cachedManifest = { ...mockManifest, cachedAt: '2026-05-14T11:50:00Z', ...manifestOverrides }
+  return [
+    ['@dosiq/anvisa-manifest', JSON.stringify(cachedManifest)],
+    ['@dosiq/anvisa-data', JSON.stringify(data)],
+  ]
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  // Estado padrão: sem cache
+  AsyncStorage.multiGet.mockResolvedValue([
+    ['@dosiq/anvisa-manifest', null],
+    ['@dosiq/anvisa-data', null],
+  ])
+  global.fetch.mockReset()
+})
+
+// -------------------------------------------------------------------
+// 1. Cold start — rede OK: baixa manifest + data, popula AsyncStorage
+// -------------------------------------------------------------------
+describe('cold start — rede OK', () => {
+  it('deve baixar manifest e data, expor isReady=true e salvar no AsyncStorage', async () => {
+    global.fetch.mockImplementation((url) =>
+      url.endsWith('manifest.json') ? mockFetchOk(mockManifest) : mockFetchOk(mockData),
+    )
+
+    const { result } = renderHook(() => useMedicineDatabase())
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.error).toBeNull()
+    expect(AsyncStorage.multiSet).toHaveBeenCalledTimes(1)
+
+    // Ambas as chaves devem ter sido salvas
+    const [[pairs]] = AsyncStorage.multiSet.mock.calls
+    const keys = pairs.map(([k]) => k)
+    expect(keys).toContain('@dosiq/anvisa-manifest')
+    expect(keys).toContain('@dosiq/anvisa-data')
+  })
+})
+
+// -------------------------------------------------------------------
+// 2. Warm start — cache recente: não faz re-download
+// -------------------------------------------------------------------
+describe('warm start — cache fresco', () => {
+  it('não deve chamar multiSet quando versão e TTL estão ok', async () => {
+    AsyncStorage.multiGet.mockResolvedValue(buildCacheMultiGet())
+
+    // Manifest remoto com mesma versão
+    global.fetch.mockImplementation(() => mockFetchOk(mockManifest))
+
+    const { result } = renderHook(() => useMedicineDatabase())
+
+    // Cache carrega imediatamente; aguarda fetch background terminar
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.isReady).toBe(true)
+    expect(AsyncStorage.multiSet).not.toHaveBeenCalled()
+  })
+})
+
+// -------------------------------------------------------------------
+// 3. Warm start — versão mudou: re-download e atualiza cache
+// -------------------------------------------------------------------
+describe('warm start — versão remota diferente', () => {
+  it('deve re-baixar e atualizar AsyncStorage com dados novos', async () => {
+    // Cache com versão 1.0.0
+    AsyncStorage.multiGet.mockResolvedValue(buildCacheMultiGet({ version: '1.0.0' }))
+
+    const newManifest = { ...mockManifest, version: '2.0.0' }
+    const newData = [...mockData, { name: 'Ibuprofeno', activeIngredient: 'Ibuprofeno', therapeuticClass: 'AINE', laboratory: 'Lab D' }]
+
+    global.fetch.mockImplementation((url) =>
+      url.endsWith('manifest.json') ? mockFetchOk(newManifest) : mockFetchOk(newData),
+    )
+
+    const { result } = renderHook(() => useMedicineDatabase())
+
+    await waitFor(() => {
+      // Após re-download o dado novo (Ibuprofeno) deve estar acessível
+      const res = result.current.search('ibuprofe', 5)
+      return res.length > 0
+    })
+
+    expect(AsyncStorage.multiSet).toHaveBeenCalledTimes(1)
+    // Manifest persistido deve ter versão 2.0.0
+    const [[pairs]] = AsyncStorage.multiSet.mock.calls
+    const manifestEntry = pairs.find(([k]) => k === '@dosiq/anvisa-manifest')
+    expect(JSON.parse(manifestEntry[1]).version).toBe('2.0.0')
+  })
+})
+
+// -------------------------------------------------------------------
+// 4. Warm start — cache expirado pelo TTL
+// -------------------------------------------------------------------
+describe('warm start — cache expirado pelo TTL', () => {
+  it('deve re-baixar quando cachedAt está além do TTL', async () => {
+    // cachedAt muito antigo
+    AsyncStorage.multiGet.mockResolvedValue(buildCacheMultiGet({ cachedAt: '2025-01-01T00:00:00Z' }))
+
+    global.fetch.mockImplementation((url) =>
+      url.endsWith('manifest.json') ? mockFetchOk(mockManifest) : mockFetchOk(mockData),
+    )
+
+    const { result } = renderHook(() => useMedicineDatabase())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(AsyncStorage.multiSet).toHaveBeenCalledTimes(1)
+  })
+})
+
+// -------------------------------------------------------------------
+// 5. Falha de rede com cache disponível — degradação graciosa
+// -------------------------------------------------------------------
+describe('falha de rede — cache disponível', () => {
+  it('não deve expor erro e deve manter busca funcional', async () => {
+    AsyncStorage.multiGet.mockResolvedValue(buildCacheMultiGet())
+
+    global.fetch.mockImplementation(() => mockFetchError())
+
+    const { result } = renderHook(() => useMedicineDatabase())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.error).toBeNull()
+    expect(result.current.isReady).toBe(true)
+    expect(result.current.search('para', 5).length).toBeGreaterThan(0)
+  })
+})
+
+// -------------------------------------------------------------------
+// 6. Falha de rede sem cache — estado de erro
+// -------------------------------------------------------------------
+describe('falha de rede — sem cache', () => {
+  it('deve expor error e isReady=false', async () => {
+    // multiGet já retorna null por padrão no beforeEach
+    global.fetch.mockImplementation(() => mockFetchError())
+
+    const { result } = renderHook(() => useMedicineDatabase())
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.isReady).toBe(false)
+    expect(result.current.error).toBeTruthy()
+  })
+})
+
+// -------------------------------------------------------------------
+// 7. search()
+// -------------------------------------------------------------------
+describe('search()', () => {
+  beforeEach(() => {
+    // Cache fresco, sem fetch necessário
+    AsyncStorage.multiGet.mockResolvedValue(buildCacheMultiGet())
+    global.fetch.mockImplementation(() => mockFetchOk(mockManifest))
+  })
+
+  async function getReadyHook() {
+    const { result } = renderHook(() => useMedicineDatabase())
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    return result
+  }
+
+  it('encontra por nome (case insensitive)', async () => {
+    const result = await getReadyHook()
+    const res = result.current.search('PARACETAMOL', 10)
+    expect(res.length).toBeGreaterThan(0)
+    expect(res[0].name).toBe('Paracetamol')
+  })
+
+  it('encontra por nome com acento normalizado', async () => {
+    const result = await getReadyHook()
+    // 'Ácido' normalizado → 'acido'
+    const res = result.current.search('acido', 10)
+    expect(res.length).toBeGreaterThan(0)
+    expect(res[0].name).toBe('Ácido Acetilsalicílico')
+  })
+
+  it('encontra por activeIngredient', async () => {
+    const result = await getReadyHook()
+    const res = result.current.search('dipirona sodica', 10)
+    expect(res.length).toBeGreaterThan(0)
+    expect(res[0].name).toBe('Dipirona')
+  })
+
+  it('respeita o limite', async () => {
+    const result = await getReadyHook()
+    // 'ana' aparece em Paracetamol (ativa ingredient) e Dipirona
+    const res = result.current.search('ana', 1)
+    expect(res.length).toBeLessThanOrEqual(1)
+  })
+
+  it('retorna [] para query com menos de 3 caracteres', async () => {
+    const result = await getReadyHook()
+    expect(result.current.search('pa', 10)).toEqual([])
+    expect(result.current.search('', 10)).toEqual([])
+  })
+
+  it('retorna [] para query undefined/null', async () => {
+    const result = await getReadyHook()
+    expect(result.current.search(null, 10)).toEqual([])
+    expect(result.current.search(undefined, 10)).toEqual([])
+  })
+})
+
+// -------------------------------------------------------------------
+// 8. getByName()
+// -------------------------------------------------------------------
+describe('getByName()', () => {
+  beforeEach(() => {
+    AsyncStorage.multiGet.mockResolvedValue(buildCacheMultiGet())
+    global.fetch.mockImplementation(() => mockFetchOk(mockManifest))
+  })
+
+  async function getReadyHook() {
+    const { result } = renderHook(() => useMedicineDatabase())
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    return result
+  }
+
+  it('retorna match exato (case insensitive)', async () => {
+    const result = await getReadyHook()
+    const med = result.current.getByName('paracetamol')
+    expect(med).not.toBeNull()
+    expect(med.name).toBe('Paracetamol')
+  })
+
+  it('retorna match exato com acento normalizado', async () => {
+    const result = await getReadyHook()
+    const med = result.current.getByName('acido acetilsalicilico')
+    expect(med).not.toBeNull()
+    expect(med.name).toBe('Ácido Acetilsalicílico')
+  })
+
+  it('prefere match exato sobre parcial', async () => {
+    // Dipirona corresponde a exact; não deve retornar Dipirona Sódica (activeIngredient)
+    const result = await getReadyHook()
+    const med = result.current.getByName('Dipirona')
+    expect(med.name).toBe('Dipirona')
+  })
+
+  it('retorna null quando não encontrado', async () => {
+    const result = await getReadyHook()
+    expect(result.current.getByName('Inexistente')).toBeNull()
+  })
+
+  it('retorna null para name vazio/null', async () => {
+    const result = await getReadyHook()
+    expect(result.current.getByName('')).toBeNull()
+    expect(result.current.getByName(null)).toBeNull()
+  })
+})

--- a/apps/mobile/src/shared/hooks/__tests__/useMutation.test.js
+++ b/apps/mobile/src/shared/hooks/__tests__/useMutation.test.js
@@ -1,0 +1,197 @@
+jest.mock('expo-haptics', () => ({
+  notificationAsync: jest.fn().mockResolvedValue(undefined),
+  NotificationFeedbackType: { Success: 'success', Error: 'error' },
+}))
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  multiRemove: jest.fn().mockResolvedValue(undefined),
+}))
+
+import { act, renderHook, waitFor } from '@testing-library/react-native'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import * as Haptics from 'expo-haptics'
+import { useMutation } from '../useMutation'
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+// 1. Estado inicial
+test('estado inicial: isLoading=false, error=null', () => {
+  const { result } = renderHook(() => useMutation())
+  expect(result.current.isLoading).toBe(false)
+  expect(result.current.error).toBeNull()
+})
+
+// 2. Caminho de sucesso
+test('sucesso: onSuccess chamado, isLoading volta false, retorna resultado', async () => {
+  const onSuccess = jest.fn()
+  const { result } = renderHook(() => useMutation({ onSuccess }))
+
+  let returnValue
+  await act(async () => {
+    returnValue = await result.current.mutate(async () => 'ok')
+  })
+
+  expect(onSuccess).toHaveBeenCalledWith('ok')
+  expect(returnValue).toBe('ok')
+  expect(result.current.isLoading).toBe(false)
+})
+
+// 3. Caminho de erro
+test('erro: onError chamado, error state definido, retorna undefined', async () => {
+  const onError = jest.fn()
+  const { result } = renderHook(() => useMutation({ onError }))
+
+  const boom = new Error('fail')
+  let returnValue
+  await act(async () => {
+    returnValue = await result.current.mutate(async () => { throw boom })
+  })
+
+  expect(onError).toHaveBeenCalledWith(boom)
+  expect(result.current.error).toBe(boom)
+  expect(returnValue).toBeUndefined()
+  expect(result.current.isLoading).toBe(false)
+})
+
+// 4. Guard double-submit
+test('double-submit: segunda chamada retorna undefined, fn executada uma vez', async () => {
+  const { result } = renderHook(() => useMutation())
+
+  let resolveFn
+  const slowFn = jest.fn(() => new Promise((r) => { resolveFn = r }))
+
+  let firstReturn
+  let secondReturn
+
+  // Inicia primeira chamada sem await
+  act(() => {
+    result.current.mutate(slowFn).then((v) => { firstReturn = v })
+  })
+
+  // Segunda chamada síncrona enquanto a primeira ainda está em voo
+  await act(async () => {
+    secondReturn = await result.current.mutate(slowFn)
+  })
+
+  expect(secondReturn).toBeUndefined()
+  expect(slowFn).toHaveBeenCalledTimes(1)
+
+  // Resolve a primeira para limpeza
+  await act(async () => {
+    resolveFn('done')
+  })
+
+  expect(firstReturn).toBe('done')
+})
+
+// 5. invalidateKeys: multiRemove chamado com chaves corretas
+test('invalidateKeys: AsyncStorage.multiRemove chamado com as chaves', async () => {
+  const { result } = renderHook(() =>
+    useMutation({ invalidateKeys: ['k1', 'k2'] }),
+  )
+
+  await act(async () => {
+    await result.current.mutate(async () => 'dados')
+  })
+
+  expect(AsyncStorage.multiRemove).toHaveBeenCalledWith(['k1', 'k2'])
+})
+
+// 6. Falha em invalidateKeys não impede sucesso
+test('falha em multiRemove não derruba onSuccess', async () => {
+  AsyncStorage.multiRemove.mockRejectedValueOnce(new Error('storage falhou'))
+  const onSuccess = jest.fn()
+
+  const { result } = renderHook(() =>
+    useMutation({ onSuccess, invalidateKeys: ['k1'] }),
+  )
+
+  let returnValue
+  await act(async () => {
+    returnValue = await result.current.mutate(async () => 'resultado')
+  })
+
+  expect(onSuccess).toHaveBeenCalledWith('resultado')
+  expect(returnValue).toBe('resultado')
+})
+
+// 7. Haptics no sucesso
+test('haptics: notificationAsync chamado com Success no sucesso', async () => {
+  const { result } = renderHook(() => useMutation())
+
+  await act(async () => {
+    await result.current.mutate(async () => 42)
+  })
+
+  expect(Haptics.notificationAsync).toHaveBeenCalledWith(
+    Haptics.NotificationFeedbackType.Success,
+  )
+})
+
+// 8. Haptics no erro
+test('haptics: notificationAsync chamado com Error no erro', async () => {
+  const { result } = renderHook(() => useMutation())
+
+  await act(async () => {
+    await result.current.mutate(async () => { throw new Error('x') })
+  })
+
+  expect(Haptics.notificationAsync).toHaveBeenCalledWith(
+    Haptics.NotificationFeedbackType.Error,
+  )
+})
+
+// 9. reset() limpa error
+test('reset: limpa estado de erro', async () => {
+  const { result } = renderHook(() => useMutation())
+
+  await act(async () => {
+    await result.current.mutate(async () => { throw new Error('err') })
+  })
+
+  expect(result.current.error).not.toBeNull()
+
+  act(() => {
+    result.current.reset()
+  })
+
+  expect(result.current.error).toBeNull()
+})
+
+// 10. Timeout: rejeita após timeoutMs
+test('timeout: error.message contém "Timeout: operação excedeu"', async () => {
+  const onError = jest.fn()
+  const { result } = renderHook(() =>
+    useMutation({ onError, timeoutMs: 50 }),
+  )
+
+  // Promise que nunca resolve
+  await act(async () => {
+    await result.current.mutate(() => new Promise(() => {}))
+  })
+
+  expect(result.current.error).not.toBeNull()
+  expect(result.current.error.message).toMatch(/Timeout: operação excedeu/)
+  expect(onError).toHaveBeenCalled()
+}, 3000)
+
+// 11. onSuccess e onError opcionais: não lança quando omitidos
+test('callbacks opcionais: não lança sem onSuccess/onError', async () => {
+  const { result } = renderHook(() => useMutation())
+
+  // Sucesso sem callbacks
+  await expect(
+    act(async () => {
+      await result.current.mutate(async () => 'sem callback')
+    }),
+  ).resolves.not.toThrow()
+
+  // Erro sem callbacks
+  await expect(
+    act(async () => {
+      await result.current.mutate(async () => { throw new Error('sem handler') })
+    }),
+  ).resolves.not.toThrow()
+})

--- a/apps/mobile/src/shared/hooks/useMedicineDatabase.js
+++ b/apps/mobile/src/shared/hooks/useMedicineDatabase.js
@@ -35,6 +35,22 @@ function normalizeText(text) {
     .replace(/[̀-ͯ]/g, '')
 }
 
+// Match por prefixo com word-boundary: "trime" casa "Maleato de Trimebutina"
+// (após espaço) e "Trimetoprima" (início), mas NÃO "Sumatripta**" (mid-word).
+// Boundaries reconhecidos: início, espaço, hífen, ponto, parêntese, slash, vírgula.
+function matchesPrefix(normalizedText, normalizedQuery) {
+  if (!normalizedText || !normalizedQuery) return false
+  if (normalizedText.startsWith(normalizedQuery)) return true
+  // Procura ocorrências após boundary
+  const boundaryChars = ' -.,(/\\'
+  for (let i = 1; i < normalizedText.length; i += 1) {
+    if (boundaryChars.includes(normalizedText[i - 1])) {
+      if (normalizedText.startsWith(normalizedQuery, i)) return true
+    }
+  }
+  return false
+}
+
 // Fetch JSON com timeout (R-168) e tratamento de erro silencioso para o caller.
 async function fetchJson(url, timeoutMs = 30_000) {
   const controller = new AbortController()
@@ -164,21 +180,26 @@ export function useMedicineDatabase({
     }
   }, [baseUrl, ttlMs])
 
+  // Busca autocomplete: word-boundary prefix em name OU activeIngredient.
+  // Ranking: matches no name vêm antes dos só-em-activeIngredient.
   const search = useCallback(
     (query, limit = 10) => {
       if (!database || !query || query.trim().length < 3) return []
       const q = normalizeText(query)
-      const results = []
+      const nameMatches = []
+      const ingredientMatches = []
       for (const med of database) {
-        if (
-          normalizeText(med.name).includes(q) ||
-          normalizeText(med.activeIngredient).includes(q)
-        ) {
-          results.push(med)
-          if (results.length >= limit) break
+        const nameHit = matchesPrefix(normalizeText(med.name), q)
+        if (nameHit) {
+          nameMatches.push(med)
+          if (nameMatches.length >= limit) break
+          continue
+        }
+        if (matchesPrefix(normalizeText(med.activeIngredient), q)) {
+          ingredientMatches.push(med)
         }
       }
-      return results
+      return [...nameMatches, ...ingredientMatches].slice(0, limit)
     },
     [database],
   )

--- a/apps/mobile/src/shared/hooks/useMedicineDatabase.js
+++ b/apps/mobile/src/shared/hooks/useMedicineDatabase.js
@@ -1,0 +1,212 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { getNow, parseISO } from '@dosiq/core'
+
+// Hook que baixa, faz cache local e expõe busca na base ANVISA de medicamentos.
+// Fluxo:
+//   1. Mount: lê manifest cacheado em AsyncStorage
+//   2. Busca remoto manifest.json em background
+//   3. Se versão remota difere ou cache vazio: baixa medicineDatabase.json
+//      e atualiza AsyncStorage
+//   4. TTL 7 dias força re-check mesmo com versão igual
+//
+// Falha de rede → degradação graciosa: form continua funcional sem autocomplete.
+//
+// Uso:
+//   const { search, getByName, isReady, isLoading, lastUpdated, error } = useMedicineDatabase()
+//   const results = search('paracetamol', 10)
+
+const ANVISA_BASE_URL =
+  'https://kwqjtdsqkkbebfiaxubb.supabase.co/storage/v1/object/public/dosiq-assets/anvisa/v1'
+
+const STORAGE_KEYS = {
+  manifest: '@dosiq/anvisa-manifest',
+  data: '@dosiq/anvisa-data',
+}
+
+const TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 dias
+
+// Normaliza texto para busca (remove diacríticos + lowercase). Idêntico à web.
+function normalizeText(text) {
+  if (!text) return ''
+  return text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+}
+
+// Fetch JSON com timeout (R-168) e tratamento de erro silencioso para o caller.
+async function fetchJson(url, timeoutMs = 30_000) {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, { signal: controller.signal })
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} em ${url}`)
+    }
+    return await res.json()
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+// Lê manifest+data cacheados em AsyncStorage. Retorna { manifest, data } ou null.
+async function readCachedDatabase() {
+  try {
+    const entries = await AsyncStorage.multiGet([
+      STORAGE_KEYS.manifest,
+      STORAGE_KEYS.data,
+    ])
+    const [rawManifest, rawData] = entries.map(([, v]) => v)
+    if (!rawManifest || !rawData) return null
+    return {
+      manifest: JSON.parse(rawManifest),
+      data: JSON.parse(rawData),
+    }
+  } catch (cacheErr) {
+    console.warn('[useMedicineDatabase] cache read falhou:', cacheErr?.message)
+    return null
+  }
+}
+
+// Decide se cache atual precisa ser substituído. Boolean.
+function shouldRefreshCache({ remoteManifest, cachedManifest, ttlMs, hasData }) {
+  if (!cachedManifest) return true
+  if (!hasData) return true
+  if (cachedManifest.version !== remoteManifest.version) return true
+  const cachedAtMs = cachedManifest.cachedAt
+    ? parseISO(cachedManifest.cachedAt).getTime()
+    : 0
+  return Date.now() - cachedAtMs > ttlMs
+}
+
+// Resolve URL absoluto do medicineDatabase.json a partir do manifest remoto.
+function resolveDataUrl(baseUrl, remoteManifest) {
+  const fileName =
+    remoteManifest?.files?.medicineDatabase?.path?.split('/').pop() ||
+    'medicineDatabase.json'
+  return `${baseUrl}/${fileName}`
+}
+
+// Persiste novo manifest+data em AsyncStorage; retorna manifestToCache.
+async function persistRemote(remoteManifest, remoteData) {
+  const manifestToCache = {
+    ...remoteManifest,
+    cachedAt: getNow().toISOString(),
+  }
+  await AsyncStorage.multiSet([
+    [STORAGE_KEYS.manifest, JSON.stringify(manifestToCache)],
+    [STORAGE_KEYS.data, JSON.stringify(remoteData)],
+  ])
+  return manifestToCache
+}
+
+export function useMedicineDatabase({
+  baseUrl = ANVISA_BASE_URL,
+  ttlMs = TTL_MS,
+} = {}) {
+  const [database, setDatabase] = useState(null)
+  const [manifest, setManifest] = useState(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  // Carrega cache local (rápido) e dispara background sync (atualização)
+  useEffect(() => {
+    let canceled = false
+
+    async function bootstrap() {
+      // 1. Cache local primeiro (UX instantânea)
+      const cached = await readCachedDatabase()
+      let hasData = false
+      if (cached && !canceled) {
+        setManifest(cached.manifest)
+        setDatabase(cached.data)
+        setIsLoading(false)
+        hasData = true
+      }
+
+      // 2. Background: busca remoto e decide se re-download é necessário
+      try {
+        const remoteManifest = await fetchJson(`${baseUrl}/manifest.json`)
+        if (canceled) return
+
+        const refresh = shouldRefreshCache({
+          remoteManifest,
+          cachedManifest: cached?.manifest,
+          ttlMs,
+          hasData,
+        })
+
+        if (refresh) {
+          const remoteData = await fetchJson(resolveDataUrl(baseUrl, remoteManifest))
+          if (canceled) return
+          const manifestToCache = await persistRemote(remoteManifest, remoteData)
+          if (!canceled) {
+            setManifest(manifestToCache)
+            setDatabase(remoteData)
+            setError(null)
+          }
+        }
+      } catch (fetchErr) {
+        if (canceled) return
+        // Degradação graciosa: se já tem cache, ignora erro de rede
+        if (!hasData) {
+          setError(fetchErr?.message || 'Falha ao baixar base ANVISA')
+        }
+      } finally {
+        if (!canceled) setIsLoading(false)
+      }
+    }
+
+    bootstrap()
+    return () => {
+      canceled = true
+    }
+  }, [baseUrl, ttlMs])
+
+  const search = useCallback(
+    (query, limit = 10) => {
+      if (!database || !query || query.trim().length < 3) return []
+      const q = normalizeText(query)
+      const results = []
+      for (const med of database) {
+        if (
+          normalizeText(med.name).includes(q) ||
+          normalizeText(med.activeIngredient).includes(q)
+        ) {
+          results.push(med)
+          if (results.length >= limit) break
+        }
+      }
+      return results
+    },
+    [database],
+  )
+
+  const getByName = useCallback(
+    (name) => {
+      if (!database || !name) return null
+      const n = normalizeText(name)
+      const exact = database.find((med) => normalizeText(med.name) === n)
+      if (exact) return exact
+      return database.find((med) => normalizeText(med.name).includes(n)) || null
+    },
+    [database],
+  )
+
+  const lastUpdated = useMemo(
+    () => (manifest?.cachedAt ? parseISO(manifest.cachedAt) : null),
+    [manifest],
+  )
+
+  return {
+    search,
+    getByName,
+    isReady: database !== null,
+    isLoading,
+    lastUpdated,
+    error,
+  }
+}
+
+export default useMedicineDatabase

--- a/apps/mobile/src/shared/hooks/useMedicineDatabase.js
+++ b/apps/mobile/src/shared/hooks/useMedicineDatabase.js
@@ -93,7 +93,8 @@ function shouldRefreshCache({ remoteManifest, cachedManifest, ttlMs, hasData }) 
   const cachedAtMs = cachedManifest.cachedAt
     ? parseISO(cachedManifest.cachedAt).getTime()
     : 0
-  return Date.now() - cachedAtMs > ttlMs
+  // R-020: usa getNow() em vez de Date.now() para consistência com regras gerais
+  return getNow().getTime() - cachedAtMs > ttlMs
 }
 
 // Resolve URL absoluto do medicineDatabase.json a partir do manifest remoto.
@@ -121,11 +122,30 @@ export function useMedicineDatabase({
   baseUrl = ANVISA_BASE_URL,
   ttlMs = TTL_MS,
 } = {}) {
+  // States
   const [database, setDatabase] = useState(null)
   const [manifest, setManifest] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState(null)
 
+  // Memos (R-010: declarados antes de Effects e Handlers)
+  // Pré-normaliza nome e princípio ativo uma única vez quando a base carrega.
+  // Evita executar normalize('NFD') + regex em ~6800 registros a cada keystroke.
+  const normalizedDatabase = useMemo(() => {
+    if (!database) return null
+    return database.map((med) => ({
+      med,
+      nName: normalizeText(med.name),
+      nIngredient: normalizeText(med.activeIngredient),
+    }))
+  }, [database])
+
+  const lastUpdated = useMemo(
+    () => (manifest?.cachedAt ? parseISO(manifest.cachedAt) : null),
+    [manifest],
+  )
+
+  // Effects
   // Carrega cache local (rápido) e dispara background sync (atualização)
   useEffect(() => {
     let canceled = false
@@ -180,44 +200,42 @@ export function useMedicineDatabase({
     }
   }, [baseUrl, ttlMs])
 
+  // Handlers
   // Busca autocomplete: word-boundary prefix em name OU activeIngredient.
   // Ranking: matches no name vêm antes dos só-em-activeIngredient.
+  // Early break: para de iterar assim que atinge o limite total.
   const search = useCallback(
     (query, limit = 10) => {
-      if (!database || !query || query.trim().length < 3) return []
+      if (!normalizedDatabase || !query || query.trim().length < 3) return []
       const q = normalizeText(query)
       const nameMatches = []
       const ingredientMatches = []
-      for (const med of database) {
-        const nameHit = matchesPrefix(normalizeText(med.name), q)
-        if (nameHit) {
-          nameMatches.push(med)
-          if (nameMatches.length >= limit) break
+      for (const entry of normalizedDatabase) {
+        if (matchesPrefix(entry.nName, q)) {
+          nameMatches.push(entry.med)
+          if (nameMatches.length + ingredientMatches.length >= limit) break
           continue
         }
-        if (matchesPrefix(normalizeText(med.activeIngredient), q)) {
-          ingredientMatches.push(med)
+        if (matchesPrefix(entry.nIngredient, q)) {
+          ingredientMatches.push(entry.med)
+          if (nameMatches.length + ingredientMatches.length >= limit) break
         }
       }
       return [...nameMatches, ...ingredientMatches].slice(0, limit)
     },
-    [database],
+    [normalizedDatabase],
   )
 
   const getByName = useCallback(
     (name) => {
-      if (!database || !name) return null
+      if (!normalizedDatabase || !name) return null
       const n = normalizeText(name)
-      const exact = database.find((med) => normalizeText(med.name) === n)
-      if (exact) return exact
-      return database.find((med) => normalizeText(med.name).includes(n)) || null
+      const exact = normalizedDatabase.find((entry) => entry.nName === n)
+      if (exact) return exact.med
+      const partial = normalizedDatabase.find((entry) => entry.nName.includes(n))
+      return partial ? partial.med : null
     },
-    [database],
-  )
-
-  const lastUpdated = useMemo(
-    () => (manifest?.cachedAt ? parseISO(manifest.cachedAt) : null),
-    [manifest],
+    [normalizedDatabase],
   )
 
   return {

--- a/apps/mobile/src/shared/hooks/useMutation.js
+++ b/apps/mobile/src/shared/hooks/useMutation.js
@@ -1,0 +1,97 @@
+import { useCallback, useRef, useState } from 'react'
+import * as Haptics from 'expo-haptics'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+// Hook para mutations C/U/D (create/update/delete) com:
+// - guard contra double-submit
+// - timeout configurável (R-168 Hermes safety)
+// - haptic feedback automático (TODO: extrair p/ utils/haptics.js na P3.3)
+// - invalidação de snapshots AsyncStorage para forçar re-fetch
+//
+// Uso:
+//   const { mutate, isLoading, error, reset } = useMutation({
+//     onSuccess: (data) => navigation.goBack(),
+//     onError: (err) => Alert.alert('Erro', err.message),
+//     invalidateKeys: ['@dosiq/treatments-snapshot'],
+//   })
+//   const handleSubmit = () => mutate(() => medicineService.create(values))
+
+const DEFAULT_TIMEOUT_MS = 15_000
+
+// Promise que rejeita após N ms (Hermes-safe; sem AbortController em fn arbitrária)
+function withTimeout(promise, ms) {
+  let timeoutId
+  const timeout = new Promise((_, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new Error(`Timeout: operação excedeu ${ms / 1000}s`)),
+      ms,
+    )
+  })
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timeoutId))
+}
+
+export function useMutation({
+  onSuccess,
+  onError,
+  invalidateKeys = [],
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+} = {}) {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState(null)
+  // Ref para guard de double-submit (sincrono, antes do re-render de isLoading)
+  const inFlightRef = useRef(false)
+
+  const reset = useCallback(() => {
+    setError(null)
+  }, [])
+
+  const mutate = useCallback(
+    async (asyncFn) => {
+      if (inFlightRef.current) return undefined
+      inFlightRef.current = true
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        const result = await withTimeout(
+          Promise.resolve().then(() => asyncFn()),
+          timeoutMs,
+        )
+
+        // Invalida snapshots locais (best-effort — falha aqui não derruba a operação)
+        if (invalidateKeys.length > 0) {
+          try {
+            await AsyncStorage.multiRemove(invalidateKeys)
+          } catch (cacheErr) {
+            // Falha em cache não invalida sucesso da mutation
+            console.warn('[useMutation] invalidateKeys falhou:', cacheErr?.message)
+          }
+        }
+
+        // Haptic success — fire-and-forget (não bloqueia callback)
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success).catch(
+          () => {},
+        )
+
+        setIsLoading(false)
+        inFlightRef.current = false
+        onSuccess?.(result)
+        return result
+      } catch (err) {
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error).catch(
+          () => {},
+        )
+        setError(err)
+        setIsLoading(false)
+        inFlightRef.current = false
+        onError?.(err)
+        return undefined
+      }
+    },
+    [onSuccess, onError, invalidateKeys, timeoutMs],
+  )
+
+  return { mutate, isLoading, error, reset }
+}
+
+export default useMutation

--- a/apps/web/src/features/medications/data/manifest.json
+++ b/apps/web/src/features/medications/data/manifest.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.0.0",
+  "generatedAt": "2026-05-15T03:36:16Z",
+  "files": {
+    "medicineDatabase": {
+      "path": "anvisa/v1/medicineDatabase.json",
+      "size": 1340397,
+      "count": 6807
+    },
+    "laboratoryDatabase": {
+      "path": "anvisa/v1/laboratoryDatabase.json",
+      "size": 14378,
+      "count": 278
+    }
+  },
+  "source": "ANVISA · base interna Dosiq",
+  "ttlDays": 7
+}

--- a/docs/operations/GUIA_UPLOAD_ANVISA_SUPABASE_STORAGE.md
+++ b/docs/operations/GUIA_UPLOAD_ANVISA_SUPABASE_STORAGE.md
@@ -1,0 +1,203 @@
+# Guia — Upload da Base ANVISA para Supabase Storage
+
+> **Contexto**: Sprint P.2 (Fase 0 CRUD Native) — disponibiliza a base de medicamentos ANVISA via Supabase Storage para que o app mobile faça download + cache local (`useMedicineDatabase`).
+> **Tarefa**: P2.3 do `EXEC_SPEC_PRE_REQUISITOS.md`
+> **Executor**: Humano (PO)
+> **Tempo estimado**: 10 minutos
+
+---
+
+## 1. Pré-requisitos
+
+- Acesso ao projeto Supabase **`kwqjtdsqkkbebfiaxubb`** (dashboard web)
+- Permissão de admin no projeto
+- Arquivos locais disponíveis em:
+  - `apps/web/src/features/medications/data/medicineDatabase.json` (≈ 1.34 MB)
+  - `apps/web/src/features/medications/data/laboratoryDatabase.json` (≈ 14 KB)
+
+---
+
+## 2. Estrutura final esperada no bucket
+
+```
+dosiq-assets/                 ← bucket (público, leitura anônima)
+└── anvisa/
+    └── v1/                   ← versão do dataset
+        ├── manifest.json     ← metadados (versão + timestamps + tamanhos)
+        ├── medicineDatabase.json
+        └── laboratoryDatabase.json
+```
+
+URLs públicas resultantes:
+
+```
+https://kwqjtdsqkkbebfiaxubb.supabase.co/storage/v1/object/public/dosiq-assets/anvisa/v1/manifest.json
+https://kwqjtdsqkkbebfiaxubb.supabase.co/storage/v1/object/public/dosiq-assets/anvisa/v1/medicineDatabase.json
+https://kwqjtdsqkkbebfiaxubb.supabase.co/storage/v1/object/public/dosiq-assets/anvisa/v1/laboratoryDatabase.json
+```
+
+---
+
+## 3. Passo a passo (Dashboard Supabase)
+
+### 3.1 — Criar o bucket `dosiq-assets`
+
+1. Abra https://supabase.com/dashboard/project/kwqjtdsqkkbebfiaxubb/storage/buckets
+2. Clique em **"New bucket"**
+3. Configure:
+   - **Name**: `dosiq-assets`
+   - **Public bucket**: ✅ ATIVADO (leitura anônima — clientes mobile precisam baixar sem auth)
+   - **File size limit**: deixe em branco (default 50 MB cobre nossos arquivos)
+   - **Allowed MIME types**: deixe em branco
+4. Clique em **"Save"**
+
+> ⚠️ **Atenção**: Bucket público permite leitura anônima de TUDO dentro dele. Não suba arquivos sensíveis aqui.
+
+### 3.2 — Criar a estrutura de pastas
+
+1. Entre no bucket `dosiq-assets` recém-criado
+2. Clique em **"Create folder"** → digite `anvisa` → Save
+3. Entre em `anvisa/`, clique em **"Create folder"** → digite `v1` → Save
+4. Você deve estar agora em `dosiq-assets/anvisa/v1/`
+
+### 3.3 — Gerar o `manifest.json` localmente
+
+No teu Mac, no diretório do projeto:
+
+```bash
+cd "/Users/coelhotv/git-icloud/dosiq/apps/web/src/features/medications/data"
+
+cat > manifest.json <<EOF
+{
+  "version": "1.0.0",
+  "generatedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "files": {
+    "medicineDatabase": {
+      "path": "anvisa/v1/medicineDatabase.json",
+      "size": $(wc -c < medicineDatabase.json),
+      "count": $(node -e "console.log(JSON.parse(require('fs').readFileSync('medicineDatabase.json','utf8')).length)")
+    },
+    "laboratoryDatabase": {
+      "path": "anvisa/v1/laboratoryDatabase.json",
+      "size": $(wc -c < laboratoryDatabase.json),
+      "count": $(node -e "console.log(JSON.parse(require('fs').readFileSync('laboratoryDatabase.json','utf8')).length)")
+    }
+  },
+  "source": "ANVISA · base interna Dosiq",
+  "ttlDays": 7
+}
+EOF
+
+cat manifest.json
+```
+
+Resultado esperado (exemplo):
+
+```json
+{
+  "version": "1.0.0",
+  "generatedAt": "2026-05-14T20:55:00Z",
+  "files": {
+    "medicineDatabase": {
+      "path": "anvisa/v1/medicineDatabase.json",
+      "size": 1340397,
+      "count": 4521
+    },
+    "laboratoryDatabase": {
+      "path": "anvisa/v1/laboratoryDatabase.json",
+      "size": 14378,
+      "count": 213
+    }
+  },
+  "source": "ANVISA · base interna Dosiq",
+  "ttlDays": 7
+}
+```
+
+### 3.4 — Upload dos 3 arquivos
+
+Ainda dentro de `dosiq-assets/anvisa/v1/` no dashboard:
+
+1. Clique em **"Upload file"** (botão no canto superior direito)
+2. Selecione os 3 arquivos:
+   - `manifest.json` (recém-gerado)
+   - `medicineDatabase.json`
+   - `laboratoryDatabase.json`
+3. Aguarde upload (≈ 5-10s para o `medicineDatabase.json`)
+4. Confirme que aparecem na listagem
+
+### 3.5 — Validar leitura anônima
+
+Abra cada URL no browser (sem estar logado no Supabase):
+
+```
+https://kwqjtdsqkkbebfiaxubb.supabase.co/storage/v1/object/public/dosiq-assets/anvisa/v1/manifest.json
+```
+
+Deve retornar o JSON do manifest. Se voltar `403` ou `not found`, o bucket não está público — volte ao 3.1.
+
+```
+https://kwqjtdsqkkbebfiaxubb.supabase.co/storage/v1/object/public/dosiq-assets/anvisa/v1/medicineDatabase.json
+```
+
+Deve baixar/renderizar 1.34 MB de JSON.
+
+```
+https://kwqjtdsqkkbebfiaxubb.supabase.co/storage/v1/object/public/dosiq-assets/anvisa/v1/laboratoryDatabase.json
+```
+
+Deve baixar/renderizar 14 KB de JSON.
+
+### 3.6 — (Opcional) Configurar cache CDN
+
+No dashboard do bucket → **"Configuration"** → **"Cache control"**:
+
+- `manifest.json`: cache `max-age=3600` (1h — manifest muda raramente, mas controla invalidação)
+- `medicineDatabase.json` / `laboratoryDatabase.json`: cache `max-age=604800, immutable` (7 dias — dados versionados via path `/v1/`, novas versões ficarão em `/v2/`)
+
+> Se preferir não configurar, o default Supabase já é razoável (60s).
+
+---
+
+## 4. Atualizações futuras (versionamento)
+
+Quando atualizar a base ANVISA:
+
+1. Substitua os arquivos em `anvisa/v1/` (mesma versão) → app mobile detecta via `manifest.generatedAt` e re-baixa em background
+2. **OU** crie nova pasta `anvisa/v2/` para mudança breaking → bump da constante `ANVISA_VERSION` no código mobile (`useMedicineDatabase.js`) → app mobile reseta cache e baixa do zero
+
+---
+
+## 5. Validação no app mobile (após Sprint P.2 implementada)
+
+Quando o hook `useMedicineDatabase` estiver pronto e a tela `AnvisaSearchScreen` integrada ao `FormAutocomplete`:
+
+1. Build dev client mobile com a Sprint P.2 mergeada
+2. No app, ir para tela de cadastro de medicamento → digitar 3+ caracteres no autocomplete
+3. Resultados ANVISA devem aparecer
+4. Verificar logs no Metro: `[useMedicineDatabase] manifest fetched` + `[useMedicineDatabase] data cached (1.34 MB)`
+5. Force-quit + reopen → resultados aparecem instantaneamente (cache local AsyncStorage)
+
+---
+
+## 6. Rollback
+
+Se algo der errado:
+
+- **Bucket criado errado**: Storage → `dosiq-assets` → Delete bucket (perde tudo dentro)
+- **Arquivo errado**: Storage → bucket → arquivo → Delete file
+- **App mobile cacheou versão errada**: bump `ANVISA_VERSION` no código → próximo build invalida cache
+
+---
+
+## 7. Checklist final
+
+- [ ] Bucket `dosiq-assets` criado como **public**
+- [ ] Pasta `anvisa/v1/` criada
+- [ ] `manifest.json` gerado localmente e uploaded
+- [ ] `medicineDatabase.json` (1.34 MB) uploaded
+- [ ] `laboratoryDatabase.json` (14 KB) uploaded
+- [ ] 3 URLs públicas retornam conteúdo correto em browser anônimo
+- [ ] (Opcional) Cache CDN configurado
+
+Quando todos os ✅ estiverem marcados, avise o time/agente para destravar P2.8 (smoke test E2E).

--- a/docs/operations/GUIA_UPLOAD_ANVISA_SUPABASE_STORAGE.md
+++ b/docs/operations/GUIA_UPLOAD_ANVISA_SUPABASE_STORAGE.md
@@ -192,12 +192,12 @@ Se algo der errado:
 
 ## 7. Checklist final
 
-- [ ] Bucket `dosiq-assets` criado como **public**
-- [ ] Pasta `anvisa/v1/` criada
-- [ ] `manifest.json` gerado localmente e uploaded
-- [ ] `medicineDatabase.json` (1.34 MB) uploaded
-- [ ] `laboratoryDatabase.json` (14 KB) uploaded
-- [ ] 3 URLs públicas retornam conteúdo correto em browser anônimo
+- [x] Bucket `dosiq-assets` criado como **public**
+- [x] Pasta `anvisa/v1/` criada
+- [x] `manifest.json` gerado localmente e uploaded
+- [x] `medicineDatabase.json` (1.34 MB) uploaded
+- [x] `laboratoryDatabase.json` (14 KB) uploaded
+- [x] 3 URLs públicas retornam conteúdo correto em browser anônimo
 - [ ] (Opcional) Cache CDN configurado
 
 Quando todos os ✅ estiverem marcados, avise o time/agente para destravar P2.8 (smoke test E2E).


### PR DESCRIPTION
# 📦 feat(mobile/mutations-anvisa): Sprint P.2 — useMutation + ANVISA Infra

## 🎯 Resumo

Segunda sprint da Fase 0 (Pré-Requisitos) do projeto **Evolução CRUD Native**. Entrega bloco 2 de 3 da fundação CRUD nativa: **`useMutation`** (hook genérico para C/U/D operations) + **infraestrutura ANVISA** (Supabase Storage para distribuição da base + hook `useMedicineDatabase` com cache local + componente `FormAutocomplete` + tela dedicada `AnvisaSearchScreen`). Sem este bloco, fluxos de cadastro/edição da Fase 1 (Medicamentos) não podem começar.

---

## 📋 Tarefas Implementadas

### ✅ Hooks (P2.1, P2.4)
- [x] **P2.1** — `useMutation({ onSuccess, onError, invalidateKeys, timeoutMs })`
  - Guard de double-submit via ref síncrono (antes do re-render de `isLoading`)
  - `Promise.race` com timeout de 15s default (R-168 Hermes safety)
  - `AsyncStorage.multiRemove(invalidateKeys)` best-effort para invalidar snapshots
  - `expo-haptics` Success/Error fire-and-forget
  - Pattern de erro: `throw raw` (matching web — sem central error parser)
- [x] **P2.4** — `useMedicineDatabase({ baseUrl?, ttlMs? })`
  - Cache local AsyncStorage (UX instantânea no warm start)
  - Background sync com remote manifest
  - Re-download quando: versão mudou OU TTL 7d expirado OU dados ausentes
  - Degradação graciosa: rede falha + cache existe → `error=null`, busca segue funcionando
  - Helpers extraídos: `readCachedDatabase`, `shouldRefreshCache`, `resolveDataUrl`, `persistRemote` (reduz complexidade ciclomática)
  - `search(q, limit)` e `getByName(name)` com `normalizeText` idêntico ao web (NFD + diacríticos + lowercase)

### ✅ Match autocomplete word-boundary (refinamento durante validação)
- [x] `search()` mudou de **substring** para **word-boundary prefix**
  - "trime" casa `Maleato de Trimebutina` (segunda palavra) ✅
  - "trime" casa `Trimebutina` (início) ✅
  - "trip" NÃO casa `Sumatriptana` (mid-word) ❌
  - "para" NÃO casa `Aparat` (mid-word) ❌
  - Boundaries: início, espaço, hífen, ponto, vírgula, parêntese, slash
  - Ranking: name-prefix matches vêm antes de só-activeIngredient

### ✅ Componentes (P2.6)
- [x] **P2.6** — `FormAutocomplete` (componente reutilizável)
  - Trigger igual `FormInput` (text + focus + clear button)
  - Debounce 200ms via `useEffect` com cleanup
  - Overlay `FlatList` (max 8 sugestões) abaixo do input
  - Estados: vazio (sem busca), buscando, sem resultados, com sugestões
  - Auto-fill via `onSelect(item)` callback (consumidor decide se usa `setValues` do `useFormState`)
  - A11y completa: `accessibilityRole`, `accessibilityLabel`, `accessibilityState`
  - Mantido **intacto** para uso inline em forms da Fase 1+

### ✅ Telas (P2.7)
- [x] **P2.7** — `AnvisaSearchScreen` (tela dedicada de busca)
  - Refatorada durante validação para layout único (TextInput + FlatList ocupando toda tela, sem overlay sobreposto — feedback do PO)
  - Debounce 200ms via `useEffect`, `useMemo` nos resultados
  - `Keyboard.dismiss()` ao selecionar
  - Cards com Pill icon + nome + ingrediente + laboratório
  - 4 estados via `ListEmptyComponent`: baixando ANVISA / erro / hint <3 chars / sem resultados
  - Footer com timestamp da última atualização da base

### ✅ Infraestrutura externa (P2.3 — executado pelo PO)
- [x] Bucket `dosiq-assets` criado público no Supabase
- [x] Pasta `anvisa/v1/` com `manifest.json` + `medicineDatabase.json` (1.34 MB) + `laboratoryDatabase.json` (14 KB)
- [x] URLs públicas validadas em browser anônimo
- [x] Guia documentado em `docs/operations/GUIA_UPLOAD_ANVISA_SUPABASE_STORAGE.md`
- [x] `manifest.json` versionado também em `apps/web/src/features/medications/data/` para reprodutibilidade

### ✅ Integração e fluxo de retorno
- [x] Rota `ANVISA_SEARCH` registrada em `routes.js` (não-DEV — produção)
- [x] `Navigation.jsx` registra `AnvisaSearchScreen` no stack pós-sessão
- [x] `FormKitDemoScreen` recebe nova seção "ANVISA Search" com link para a tela + box de feedback do medicamento selecionado
- [x] Padrão de retorno **serializável** (React Navigation v7 best practice): source passa `returnRoute` (string), tela devolve via `navigation.navigate({ name, params: { selectedMedicine }, merge: true })`, source consome via `useEffect` em `route.params.selectedMedicine` + `setParams` para limpar — corrige warn "Non-serializable values were found in navigation state"

### ✅ Bug fix iPhone físico
- [x] `DateTimePicker` no iOS spinner aparecia "em branco" (texto invisível) em iPhone físico mas funcionava no simulador
- [x] Fix: `textColor={colors.text.primary}` + `themeVariant="light"` explícitos em `FormDatePicker` e `FormTimePicker` (iOS 14+ herdava cor do tema do sistema, falhando em devices com dark mode forçado / accessibility)

### ✅ Testes (P2.2, P2.5)
- [x] **P2.2** — 11 testes do `useMutation`: estado inicial, success/error, double-submit guard, invalidateKeys com falha tolerada, haptics Success/Error, reset, timeout, callbacks opcionais
- [x] **P2.5** — 22 testes do `useMedicineDatabase`: cold start, warm start (cache fresco/version-changed/TTL-stale), falha de rede com/sem cache, search por nome/activeIngredient/case/acento/limit/min-chars, **5 novos para word-boundary**: "trime"+segunda-palavra, "trime"+ingredient, NÃO mid-word "trip"→Sumatriptana, NÃO mid-word "para"→Aparat, ranking name-first, getByName exato/parcial/normalizado/null

### ✅ Validação visual (smoke E2E P2.8 — executado pelo PO)
- [x] iOS simulador: pickers, autocomplete, busca ANVISA real funcionando
- [x] Android simulador: idem
- [x] iPhone físico: pickers (após fix textColor), autocomplete, busca ANVISA real funcionando

---

## 📊 Métricas

| Métrica | Valor |
|---------|-------|
| Arquivos novos | 7 |
| Arquivos modificados | 5 |
| LOC adicionadas | ~1700 |
| Testes mobile novos | 33 (11 useMutation + 22 useMedicineDatabase) |
| Testes mobile total | 113/113 passando (15 suites) |
| Testes web (zero-regressão) | 530/530 |
| Bundle iOS | 6.76 MB hbc (sem regressão) |
| Modelos usados | 1 opus (arquiteto + ⭐⭐⭐), 3 sonnet (cavecrew ⭐⭐) |

---

## 🔧 Arquivos Principais

```
apps/mobile/src/
├── shared/
│   ├── hooks/
│   │   ├── useMutation.js                            # ⭐ hook C/U/D
│   │   ├── useMedicineDatabase.js                    # ⭐ ANVISA cache+sync
│   │   └── __tests__/
│   │       ├── useMutation.test.js                   # 11 testes
│   │       └── useMedicineDatabase.test.js           # 22 testes
│   └── components/form/
│       ├── FormAutocomplete.jsx                      # ⭐ overlay autocomplete
│       ├── index.js                                  # +export FormAutocomplete
│       ├── FormDatePicker.jsx                        # fix textColor iOS
│       └── FormTimePicker.jsx                        # fix textColor iOS
├── features/
│   ├── medications/screens/AnvisaSearchScreen.jsx    # ⭐ tela dedicada busca
│   └── _dev/screens/FormKitDemoScreen.jsx            # +seção ANVISA + serializable params
└── navigation/
    ├── routes.js                                     # +ANVISA_SEARCH
    └── Navigation.jsx                                # registra AnvisaSearchScreen

docs/operations/
└── GUIA_UPLOAD_ANVISA_SUPABASE_STORAGE.md            # guia P2.3 (PO)

apps/web/src/features/medications/data/
└── manifest.json                                     # gerado durante P2.3 (versioned)
```

---

## ✅ Checklist de Verificação

### Código
- [x] Lint sem erros (`rtk lint apps/mobile/src` — 0 errors, warnings pré-existentes)
- [x] Testes mobile passam (113/113, 15 suites)
- [x] Testes web zero-regressão (530/530)
- [x] Build mobile bem-sucedido (`npx expo export --platform ios` → 6.76 MB hbc)

### Funcionalidade
- [x] `useMutation` valida → loading/error/success cycle, guard double-submit, invalidateKeys best-effort, haptics
- [x] `useMedicineDatabase` baixa base, cacheia, re-baixa quando muda version/TTL, degradação graciosa em offline
- [x] `FormAutocomplete` overlay funciona inline em forms (componente reutilizável intacto)
- [x] `AnvisaSearchScreen` busca ANVISA real funciona em iOS sim, Android sim, iPhone físico
- [x] Word-boundary prefix: "trime" casa `Maleato de Trimebutina` ✅, "trip" NÃO casa `Sumatriptana` ❌
- [x] DateTimePicker visível em iPhone físico (após fix textColor)
- [x] Retorno de medicamento sem warn React Navigation (params serializáveis)

### Conformidade com regras do projeto
- [x] R-020: zero `new Date()` direto — usa `getNow()` / `parseISO` de `@dosiq/core`
- [x] R-168: timeout em fetch via AbortController + `Promise.race`
- [x] Lint sem `react-native/no-color-literals`
- [x] Lint sem `react-hooks/refs`
- [x] Lint sem `react-hooks/set-state-in-effect` (deferred via `setTimeout(..., 0)` onde necessário)
- [x] Comentários PT, identifiers EN
- [x] `StyleSheet.create()` em todos os componentes

---

## 🚀 Como Testar

```bash
# 1. Pull no worktree
git fetch origin
git checkout feat/crud-foundation-mutations-anvisa
git pull

# 2. Sem deps novas — apenas npm install se a sua pasta está fresca
cd apps/mobile
npm install

# 3. Não precisa rebuild se a Sprint P.1 já está buildada (só JS).
# Se for primeiro build da Fase 0:
npx expo prebuild --clean
npx expo run:ios   # ou run:android

# 4. Rodar testes
npx jest --testPathPattern="useMutation|useMedicineDatabase"

# 5. Validação visual
# Login → aba Hoje → botão amarelo "DEV" → seção "ANVISA Search"
# Tap "Abrir busca ANVISA →"
# - Tela abre com "Baixando base ANVISA…" (~2s no primeiro acesso)
# - Hint "Digite ao menos 3 caracteres"
# - Digite "trime" → deve aparecer "Maleato de Trimebutina"
# - Digite "trip" → NÃO deve aparecer "Sumatriptana"
# - Tap medicamento → volta pro demo, box verde "Selecionado: X"
# - Force-quit + reopen demo + reabre busca → instantâneo (cache AsyncStorage)
```

**Resultado esperado:**
- 33 novos testes passando em <2s
- Tela ANVISA usa layout único (TextInput + FlatList), sem overlay duplo
- Pickers data/hora visíveis em iPhone físico
- Sem warn "Non-serializable values" no console

---

## 🔗 Specs Relacionadas

- Spec: `plans/backlog-native_app/EXEC_SPEC_PRE_REQUISITOS.md` §Sprint P.2
- Master plan: `plans/backlog-native_app/MASTER_PLAN_HIBRIDO_EVOLUCAO_CRUD.md` §9
- Guia ANVISA: `docs/operations/GUIA_UPLOAD_ANVISA_SUPABASE_STORAGE.md`
- SQP: `plans/backlog-native_app/INDEX_EXEC_SPECS.md` §SQP

---

## 📝 Notas para Reviewers

1. **Cavecrew 2ª rodada**: 3 spawns sonnet (P2.2 testes, P2.5 testes, P2.7 tela) — **0 retrabalhos** desta vez. Padrão "brief detalhado + read-only refs + exemplos de código" funciona consistentemente.

2. **Refinamentos durante validação visual** (todos commitados nesta branch após o trabalho inicial):
   - Word-boundary prefix em vez de substring (PO percebeu confusão de UX)
   - `AnvisaSearchScreen` refatorada de "overlay + cards" para layout único (PO percebeu sobreposição confusa)
   - `route.params.onSelect` callback substituído por padrão serializável (warn React Navigation legítimo)
   - `textColor` explícito nos DateTimePicker (bug só reproduziu em iPhone físico — simulador escondia)

3. **Decisão de produto registrada para Fase 1**: Busca ANVISA dentro do `MedicineCreateScreen` (Fase 1) será **bottom sheet**, NÃO fullscreen — preserva contexto do form aberto. `AnvisaSearchScreen` (esta sprint) é a versão fullscreen para browse standalone. `FormAutocomplete` (esta sprint) é a versão overlay inline para forms onde overlay basta. Os 3 padrões coexistem com propósitos distintos.

4. **`useMutation` com timeout via `Promise.race`**: AbortController não conecta a `fn` arbitrária (não sabemos se é fetch, supabase, ou outra coisa). Padrão `Promise.race` cobre todos os casos sem requerer cooperação do caller.

5. **`useMedicineDatabase` graceful degradation**: Se rede falha mas cache local existe, `error` permanece `null` — usuário não vê erro e busca continua funcionando. Só seta `error` se NÃO há cache (fluxo cold-start sem rede).

6. **Próximos passos** (não nesta PR):
   - Sprint P.3 — `DeleteConfirmation` bottom sheet, `Toast`, `haptics.js` wrapper, integration tests
   - Após Fase 0 completa: PR `feat/crud-foundation` → `main`
   - Fase 1 começa: `MedicineCreateScreen` consumindo `useFormState` + `useMutation` + `useMedicineDatabase` (via bottom sheet)

7. **Branch strategy**: PR aponta para `feat/crud-foundation` (mãe), não `main`.

---

## 🏷️ Versionamento

**Tipo:** Minor (mobile) — adiciona infra sem breaking change
**Versão anterior:** 0.3.7
**Versão sugerida:** mantém 0.3.7 (bump na Sprint P.3, fechamento da Fase 0)

---

/cc @coelhotv
/cc @gemini-code-assist


---

## 🤖 AI Review Response (round 1)

Comments processed: 7/7 (all applied).

| # | File:Line | Priority | Decision | Commit |
|---|-----------|----------|----------|--------|
| 1 | useMedicineDatabase.js:205 — search perf + early break | High | Applied | b31c665f |
| 2 | AnvisaSearchScreen.jsx:40 — R-010 hook order | Medium | Applied | b6d5f3f1 |
| 3 | useMedicineDatabase.js:96 — R-020 Date.now → getNow | Medium | Applied | b31c665f |
| 4 | useMedicineDatabase.js:221 — R-010 hook order | Medium | Applied | b31c665f |
| 5 | useMedicineDatabase.js:201 — pre-normalize via useMemo | High | Applied | b31c665f |
| 6 | useMedicineDatabase.js:215 — getByName use normalized | Medium | Applied | b31c665f |
| 7 | FormAutocomplete.jsx:286 — overlay magic number | Medium | Applied | 72a7b2cd |

Validation: 113/113 mobile tests passing, lint clean, expo build green.
