### PR TITLE
ci(test): allow feat/** target branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,10 @@ on:
       - 'scripts/**'
       - 'scratches/**'
   pull_request:
-    branches: [main, develop]
+    # Inclui feat/** para suportar estratégia de "branch de branch":
+    # sprint branches (feat/<area>-<topico>) targetam mãe (feat/<area>)
+    # antes de mergear na main. Sem isso, PRs sprint→mãe não rodam CI.
+    branches: [main, develop, "feat/**"]
     paths-ignore:
       - 'docs/**'
       - '.agent/**'


### PR DESCRIPTION
Permite que PRs sprint → mãe (estratégia branch-de-branch da Evolução CRUD Native) disparem CI. Sem isso, PRs intermediários (ex: PR #548, PR #549) não rodam Test Suite.