### PR TITLE
feat(mobile/treatments): Fase 2 T2.1 parcial — helpers @dosiq/core + protocolService mobile

### DIFF
--- a/.agent/state.json
+++ b/.agent/state.json
@@ -2,10 +2,10 @@
   "project": "dosiq",
   "sprint": "2026-W20",
   "session": {
-    "mode": "distillation",
-    "status": "distilled",
-    "goal": "compress and distill project memory — pós Fase 1 CRUD Medicamentos",
-    "goal_type": "chore"
+    "mode": "coding",
+    "status": "coding",
+    "goal": "Fase 2 T2.1 — helpers @dosiq/core/utils + protocolService mobile (copy + DI)",
+    "goal_type": "feature"
   },
   "memory": {
     "last_distillation": "2026-05-16T13:35:00Z",

--- a/apps/mobile/src/features/treatments/services/__tests__/protocolService.test.js
+++ b/apps/mobile/src/features/treatments/services/__tests__/protocolService.test.js
@@ -1,0 +1,249 @@
+import { protocolService } from '../protocolService'
+import { supabase } from '../../../../platform/supabase/nativeSupabaseClient'
+
+// Mock supabase mobile client com cadeia fluente completa para protocolos.
+jest.mock('../../../../platform/supabase/nativeSupabaseClient', () => {
+  // getAll/getActive: from→select→eq[user_id]→order  OR  from→select→eq→eq→lte→or→order
+  const orderMock = jest.fn()
+  const orMock = jest.fn(() => ({ order: orderMock }))
+  const lteMock = jest.fn(() => ({ or: orMock }))
+  const eqActive2Mock = jest.fn(() => ({ lte: lteMock }))
+  // getById/getByMedicineId: from→select→eq→eq→single  OR  →eq→eq (no single)
+  const singleGetByIdMock = jest.fn()
+  const eqGetByIdInnerMock = jest.fn(() => ({ single: singleGetByIdMock }))
+  const eqByMedInnerMock = jest.fn()
+  // create: from→insert→select→single
+  const singleCreateMock = jest.fn()
+  const selectCreateMock = jest.fn(() => ({ single: singleCreateMock }))
+  const insertMock = jest.fn(() => ({ select: selectCreateMock }))
+  // update: from→update→eq→eq→select→single
+  const singleUpdateMock = jest.fn()
+  const selectUpdateMock = jest.fn(() => ({ single: singleUpdateMock }))
+  const eqUpdate2Mock = jest.fn(() => ({ select: selectUpdateMock }))
+  // delete: from→delete→eq→eq
+  const eqDelete2Mock = jest.fn()
+
+  // select() retorna objeto com várias entradas possíveis dependendo da operação.
+  const selectMock = jest.fn(() => {
+    // Primeira eq decide o caminho:
+    return {
+      eq: jest.fn((field) => {
+        if (field === 'user_id') {
+          // getAll: termina em .order
+          // getActive: continua com .eq('active').lte().or().order
+          return {
+            order: orderMock,
+            eq: eqActive2Mock,
+          }
+        }
+        if (field === 'id') {
+          // getById: id→user_id→single
+          return { eq: eqGetByIdInnerMock }
+        }
+        if (field === 'medicine_id') {
+          // getByMedicineId: medicine_id→user_id
+          return { eq: eqByMedInnerMock }
+        }
+        return {}
+      }),
+    }
+  })
+
+  const updateMock = jest.fn(() => ({
+    eq: jest.fn(() => ({ eq: eqUpdate2Mock })),
+  }))
+  const deleteMock = jest.fn(() => ({
+    eq: jest.fn(() => ({ eq: eqDelete2Mock })),
+  }))
+
+  const fromMock = jest.fn(() => ({
+    select: selectMock,
+    insert: insertMock,
+    update: updateMock,
+    delete: deleteMock,
+  }))
+
+  return {
+    supabase: {
+      auth: { getUser: jest.fn() },
+      from: fromMock,
+      __mocks: {
+        orderMock,
+        orMock,
+        lteMock,
+        singleGetByIdMock,
+        eqGetByIdInnerMock,
+        eqByMedInnerMock,
+        singleCreateMock,
+        insertMock,
+        singleUpdateMock,
+        updateMock,
+        deleteMock,
+        eqDelete2Mock,
+        fromMock,
+      },
+    },
+  }
+})
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440000'
+const MED_ID = '660e8400-e29b-41d4-a716-446655440111'
+
+const VALID_PROTOCOL = {
+  medicine_id: MED_ID,
+  name: 'SeloZok manhã/noite',
+  frequency: 'diário',
+  time_schedule: ['08:00', '20:00'],
+  dosage_per_intake: 2,
+  start_date: '2026-05-16',
+}
+
+describe('protocolService (mobile)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    supabase.auth.getUser.mockResolvedValue({
+      data: { user: { id: USER_ID } },
+      error: null,
+    })
+  })
+
+  describe('getAll', () => {
+    it('retorna lista de protocolos do usuário', async () => {
+      const fixtures = [{ id: 'p1', name: 'SeloZok' }]
+      supabase.__mocks.orderMock.mockResolvedValue({ data: fixtures, error: null })
+
+      const result = await protocolService.getAll()
+      expect(supabase.from).toHaveBeenCalledWith('protocols')
+      expect(result).toEqual(fixtures)
+    })
+
+    it('retorna [] quando data é null', async () => {
+      supabase.__mocks.orderMock.mockResolvedValue({ data: null, error: null })
+      expect(await protocolService.getAll()).toEqual([])
+    })
+
+    it('lança erro quando supabase falha', async () => {
+      supabase.__mocks.orderMock.mockResolvedValue({
+        data: null,
+        error: new Error('db down'),
+      })
+      await expect(protocolService.getAll()).rejects.toThrow('db down')
+    })
+
+    it('lança erro quando sessão expirou', async () => {
+      supabase.auth.getUser.mockResolvedValue({ data: { user: null }, error: null })
+      await expect(protocolService.getAll()).rejects.toThrow(/Sessão expirada/)
+    })
+  })
+
+  describe('getActive', () => {
+    it('retorna protocolos ativos filtrados por data', async () => {
+      const fixtures = [{ id: 'p1', active: true }]
+      supabase.__mocks.orderMock.mockResolvedValue({ data: fixtures, error: null })
+
+      const result = await protocolService.getActive('2026-05-16')
+      expect(result).toEqual(fixtures)
+      expect(supabase.__mocks.lteMock).toHaveBeenCalledWith('start_date', '2026-05-16')
+      expect(supabase.__mocks.orMock).toHaveBeenCalledWith(
+        'end_date.is.null,end_date.gte.2026-05-16'
+      )
+    })
+
+    it('retorna [] quando data nulo', async () => {
+      supabase.__mocks.orderMock.mockResolvedValue({ data: null, error: null })
+      expect(await protocolService.getActive('2026-05-16')).toEqual([])
+    })
+  })
+
+  describe('getById', () => {
+    it('retorna protocolo por id', async () => {
+      const fixture = { id: 'p1', name: 'SeloZok' }
+      supabase.__mocks.singleGetByIdMock.mockResolvedValue({ data: fixture, error: null })
+
+      const result = await protocolService.getById('p1')
+      expect(result).toEqual(fixture)
+    })
+
+    it('lança erro quando supabase falha', async () => {
+      supabase.__mocks.singleGetByIdMock.mockResolvedValue({
+        data: null,
+        error: new Error('not found'),
+      })
+      await expect(protocolService.getById('p1')).rejects.toThrow('not found')
+    })
+  })
+
+  describe('create', () => {
+    it('cria protocolo válido com user_id injetado', async () => {
+      const fixture = { id: 'p2', ...VALID_PROTOCOL }
+      supabase.__mocks.singleCreateMock.mockResolvedValue({ data: fixture, error: null })
+
+      const result = await protocolService.create(VALID_PROTOCOL)
+      expect(result).toEqual(fixture)
+      const payload = supabase.__mocks.insertMock.mock.calls[0][0][0]
+      expect(payload.user_id).toBe(USER_ID)
+      expect(payload.name).toBe('SeloZok manhã/noite')
+      expect(payload.titration_schedule).toEqual([])
+      expect(payload.current_stage_index).toBe(0)
+      expect(payload.stage_started_at).toBeNull()
+    })
+
+    it('lança erro de validação para payload inválido', async () => {
+      await expect(protocolService.create({ name: '' })).rejects.toThrow(/Erro de validação/)
+    })
+
+    it('lança erro quando supabase falha', async () => {
+      supabase.__mocks.singleCreateMock.mockResolvedValue({
+        data: null,
+        error: new Error('fk violation'),
+      })
+      await expect(protocolService.create(VALID_PROTOCOL)).rejects.toThrow('fk violation')
+    })
+  })
+
+  describe('update', () => {
+    it('atualiza protocolo existente', async () => {
+      const fixture = { id: 'p1', name: 'SeloZok renomeado' }
+      supabase.__mocks.singleUpdateMock.mockResolvedValue({ data: fixture, error: null })
+
+      const result = await protocolService.update('p1', { name: 'SeloZok renomeado' })
+      expect(result).toEqual(fixture)
+      expect(supabase.__mocks.updateMock).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'SeloZok renomeado' })
+      )
+    })
+
+    it('lança erro de validação para update inválido', async () => {
+      await expect(
+        protocolService.update('p1', { dosage_per_intake: -10 })
+      ).rejects.toThrow(/Erro de validação/)
+    })
+  })
+
+  describe('delete', () => {
+    it('deleta protocolo sem erro', async () => {
+      supabase.__mocks.eqDelete2Mock.mockResolvedValue({ error: null })
+      await expect(protocolService.delete('p1')).resolves.toBeUndefined()
+      expect(supabase.__mocks.deleteMock).toHaveBeenCalled()
+    })
+
+    it('lança erro quando supabase falha', async () => {
+      supabase.__mocks.eqDelete2Mock.mockResolvedValue({ error: new Error('not allowed') })
+      await expect(protocolService.delete('p1')).rejects.toThrow('not allowed')
+    })
+  })
+
+  describe('getByMedicineId', () => {
+    it('retorna protocolos do medicamento', async () => {
+      const fixtures = [{ id: 'p1' }, { id: 'p2' }]
+      supabase.__mocks.eqByMedInnerMock.mockResolvedValue({ data: fixtures, error: null })
+      const result = await protocolService.getByMedicineId(MED_ID)
+      expect(result).toEqual(fixtures)
+    })
+
+    it('retorna [] quando data nulo', async () => {
+      supabase.__mocks.eqByMedInnerMock.mockResolvedValue({ data: null, error: null })
+      expect(await protocolService.getByMedicineId(MED_ID)).toEqual([])
+    })
+  })
+})

--- a/apps/mobile/src/features/treatments/services/protocolService.js
+++ b/apps/mobile/src/features/treatments/services/protocolService.js
@@ -1,0 +1,143 @@
+// protocolService.js — CRUD mobile de protocolos (Fase 2 G1: cópia web → mobile).
+//
+// G1 (cópia) por design: arquivo independente, sem factory, para validar
+// contrato + schemas no Hermes antes de extrair para @dosiq/core em G2 (Sprint T2.3).
+// Espelha apps/web/src/features/protocols/services/protocolService.js — qualquer
+// divergência intencional deve ser comentada inline.
+//
+// DI mobile:
+// - client: nativeSupabaseClient (Expo)
+// - getUserId via supabase.auth.getUser()
+// - schemas/utils via @dosiq/core (validateProtocolCreate/Update, getTodayLocal, getServerTimestamp)
+
+import {
+  validateProtocolCreate,
+  validateProtocolUpdate,
+  getTodayLocal,
+  getServerTimestamp,
+} from '@dosiq/core'
+import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
+
+async function getUserId() {
+  const { data: { user }, error } = await supabase.auth.getUser()
+  if (error || !user) throw new Error('Sessão expirada. Faça login novamente.')
+  return user.id
+}
+
+function formatValidationError(errors) {
+  const msg = errors.map((e) => `${e.field}: ${e.message}`).join('; ')
+  return new Error(`Erro de validação: ${msg}`)
+}
+
+// Selects compostos — espelhar web. Detail/list incluem medicine + treatment_plan.
+const LIST_SELECT = `
+  *,
+  medicine:medicines(*),
+  treatment_plan:treatment_plans(id, name, emoji, color)
+`
+
+const DETAIL_SELECT = `
+  *,
+  medicine:medicines(*),
+  treatment_plan:treatment_plans(*)
+`
+
+export const protocolService = {
+  async getAll() {
+    const { data, error } = await supabase
+      .from('protocols')
+      .select(LIST_SELECT)
+      .eq('user_id', await getUserId())
+      .order('created_at', { ascending: false })
+
+    if (error) throw error
+    return data ?? []
+  },
+
+  async getActive(date = getTodayLocal()) {
+    const { data, error } = await supabase
+      .from('protocols')
+      .select(LIST_SELECT)
+      .eq('user_id', await getUserId())
+      .eq('active', true)
+      .lte('start_date', date)
+      .or(`end_date.is.null,end_date.gte.${date}`)
+      .order('created_at', { ascending: false })
+
+    if (error) throw error
+    return data ?? []
+  },
+
+  async getById(id) {
+    const { data, error } = await supabase
+      .from('protocols')
+      .select(DETAIL_SELECT)
+      .eq('id', id)
+      .eq('user_id', await getUserId())
+      .single()
+
+    if (error) throw error
+    return data
+  },
+
+  async create(protocol) {
+    const validation = validateProtocolCreate(protocol)
+    if (!validation.success) throw formatValidationError(validation.errors)
+
+    const validated = validation.data
+    const { data, error } = await supabase
+      .from('protocols')
+      .insert([
+        {
+          ...validated,
+          user_id: await getUserId(),
+          titration_schedule: validated.titration_schedule || [],
+          current_stage_index: validated.current_stage_index || 0,
+          stage_started_at:
+            validated.titration_schedule?.length > 0 ? getServerTimestamp() : null,
+        },
+      ])
+      .select(DETAIL_SELECT)
+      .single()
+
+    if (error) throw error
+    return data
+  },
+
+  async update(id, updates) {
+    const validation = validateProtocolUpdate(updates)
+    if (!validation.success) throw formatValidationError(validation.errors)
+
+    const { data, error } = await supabase
+      .from('protocols')
+      .update(validation.data)
+      .eq('id', id)
+      .eq('user_id', await getUserId())
+      .select(DETAIL_SELECT)
+      .single()
+
+    if (error) throw error
+    return data
+  },
+
+  async delete(id) {
+    const { error } = await supabase
+      .from('protocols')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', await getUserId())
+
+    if (error) throw error
+  },
+
+  async getByMedicineId(medicineId) {
+    const { data, error } = await supabase
+      .from('protocols')
+      .select('*')
+      .eq('medicine_id', medicineId)
+      .eq('user_id', await getUserId())
+
+    if (error) throw error
+    return data ?? []
+  },
+}

--- a/packages/core/src/utils/__tests__/dateFormat.test.js
+++ b/packages/core/src/utils/__tests__/dateFormat.test.js
@@ -22,6 +22,12 @@ describe('formatDatePtBR', () => {
     const d = new Date(2026, 6, 15)
     expect(formatDatePtBR(d)).toBe('15 jul 2026')
   })
+
+  it('retorna vazio para tipo não-Date (number, object)', () => {
+    expect(formatDatePtBR(12345)).toBe('')
+    expect(formatDatePtBR({})).toBe('')
+    expect(formatDatePtBR(true)).toBe('')
+  })
 })
 
 describe('formatEndDate', () => {

--- a/packages/core/src/utils/__tests__/dateFormat.test.js
+++ b/packages/core/src/utils/__tests__/dateFormat.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { formatDatePtBR, formatEndDate } from '../dateFormat.js'
+
+describe('formatDatePtBR', () => {
+  it('formata string YYYY-MM-DD para DD MMM YYYY PT-BR lowercase', () => {
+    expect(formatDatePtBR('2026-03-12')).toBe('12 mar 2026')
+    expect(formatDatePtBR('2026-01-01')).toBe('01 jan 2026')
+    expect(formatDatePtBR('2026-12-31')).toBe('31 dez 2026')
+  })
+
+  it('zero-pad em dias single-digit', () => {
+    expect(formatDatePtBR('2026-05-03')).toBe('03 mai 2026')
+  })
+
+  it('retorna vazio para null/undefined/empty', () => {
+    expect(formatDatePtBR(null)).toBe('')
+    expect(formatDatePtBR(undefined)).toBe('')
+    expect(formatDatePtBR('')).toBe('')
+  })
+
+  it('aceita Date object', () => {
+    const d = new Date(2026, 6, 15)
+    expect(formatDatePtBR(d)).toBe('15 jul 2026')
+  })
+})
+
+describe('formatEndDate', () => {
+  it('retorna "Uso contínuo" quando null/undefined', () => {
+    expect(formatEndDate(null)).toBe('Uso contínuo')
+    expect(formatEndDate(undefined)).toBe('Uso contínuo')
+    expect(formatEndDate('')).toBe('Uso contínuo')
+  })
+
+  it('formata data quando presente', () => {
+    expect(formatEndDate('2026-12-31')).toBe('31 dez 2026')
+  })
+})

--- a/packages/core/src/utils/__tests__/doseUnit.test.js
+++ b/packages/core/src/utils/__tests__/doseUnit.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { pluralizeDoseUnit, formatDoseUnit } from '../doseUnit.js'
+
+describe('pluralizeDoseUnit', () => {
+  it('comprimido singular quando qty=1 e unidade mg/cp/g/mcg', () => {
+    expect(pluralizeDoseUnit(1, 'mg')).toBe('comprimido')
+    expect(pluralizeDoseUnit(1, 'cp')).toBe('comprimido')
+    expect(pluralizeDoseUnit(1, 'g')).toBe('comprimido')
+    expect(pluralizeDoseUnit(1, 'mcg')).toBe('comprimido')
+  })
+
+  it('comprimidos plural quando qty>1 ou !=1', () => {
+    expect(pluralizeDoseUnit(2, 'mg')).toBe('comprimidos')
+    expect(pluralizeDoseUnit(0.5, 'mg')).toBe('comprimidos')
+    expect(pluralizeDoseUnit(0, 'cp')).toBe('comprimidos')
+  })
+
+  it('ml mantém igual singular/plural', () => {
+    expect(pluralizeDoseUnit(1, 'ml')).toBe('ml')
+    expect(pluralizeDoseUnit(15, 'ml')).toBe('ml')
+  })
+
+  it('gotas singular/plural', () => {
+    expect(pluralizeDoseUnit(1, 'gotas')).toBe('gota')
+    expect(pluralizeDoseUnit(15, 'gotas')).toBe('gotas')
+  })
+
+  it('UI mantém igual', () => {
+    expect(pluralizeDoseUnit(1, 'ui')).toBe('UI')
+    expect(pluralizeDoseUnit(4, 'ui')).toBe('UI')
+  })
+
+  it('fallback unidades quando dosageUnit undefined ou desconhecida', () => {
+    expect(pluralizeDoseUnit(1, undefined)).toBe('unidade')
+    expect(pluralizeDoseUnit(2, undefined)).toBe('unidades')
+    expect(pluralizeDoseUnit(2, 'xyz')).toBe('unidades')
+  })
+
+  it('coerce string para number', () => {
+    expect(pluralizeDoseUnit('1', 'mg')).toBe('comprimido')
+    expect(pluralizeDoseUnit('2', 'mg')).toBe('comprimidos')
+  })
+})
+
+describe('formatDoseUnit', () => {
+  it('formata inteiro + unidade', () => {
+    expect(formatDoseUnit(2, 'mg')).toBe('2 comprimidos')
+    expect(formatDoseUnit(1, 'gotas')).toBe('1 gota')
+  })
+
+  it('formata decimal com vírgula PT-BR', () => {
+    expect(formatDoseUnit(15.5, 'ml')).toBe('15,5 ml')
+    expect(formatDoseUnit(0.5, 'mg')).toBe('0,5 comprimidos')
+  })
+
+  it('aceita string como qty', () => {
+    expect(formatDoseUnit('1', 'mg')).toBe('1 comprimido')
+    expect(formatDoseUnit('0.5', 'ml')).toBe('0,5 ml')
+  })
+
+  it('fallback unidades quando dosageUnit ausente', () => {
+    expect(formatDoseUnit(3, undefined)).toBe('3 unidades')
+    expect(formatDoseUnit(1, undefined)).toBe('1 unidade')
+  })
+})

--- a/packages/core/src/utils/dateFormat.js
+++ b/packages/core/src/utils/dateFormat.js
@@ -19,7 +19,7 @@ const MONTHS_PT_BR = [
 export function formatDatePtBR(isoDate) {
   if (!isoDate) return ''
   const d = typeof isoDate === 'string' ? parseLocalDate(isoDate) : isoDate
-  if (!d || Number.isNaN(d.getTime())) return ''
+  if (!(d instanceof Date) || Number.isNaN(d.getTime())) return ''
   const day = String(d.getDate()).padStart(2, '0')
   const month = MONTHS_PT_BR[d.getMonth()]
   const year = d.getFullYear()

--- a/packages/core/src/utils/dateFormat.js
+++ b/packages/core/src/utils/dateFormat.js
@@ -1,0 +1,38 @@
+// dateFormat.js — Apresentação de datas PT-BR (Fase 2).
+//
+// Helpers de display puros. Hermes (mobile) sem ICU completo: NÃO usar
+// toLocaleString('pt-BR'). Formatação manual via tabela de meses.
+
+import { parseLocalDate } from './dateUtils.js'
+
+const MONTHS_PT_BR = [
+  'jan', 'fev', 'mar', 'abr', 'mai', 'jun',
+  'jul', 'ago', 'set', 'out', 'nov', 'dez',
+]
+
+/**
+ * Formata uma data ISO/string YYYY-MM-DD para "DD MMM YYYY" PT-BR lowercase.
+ *
+ * @example formatDatePtBR('2026-03-12') → '12 mar 2026'
+ * @example formatDatePtBR(null)         → ''
+ */
+export function formatDatePtBR(isoDate) {
+  if (!isoDate) return ''
+  const d = typeof isoDate === 'string' ? parseLocalDate(isoDate) : isoDate
+  if (!d || Number.isNaN(d.getTime())) return ''
+  const day = String(d.getDate()).padStart(2, '0')
+  const month = MONTHS_PT_BR[d.getMonth()]
+  const year = d.getFullYear()
+  return `${day} ${month} ${year}`
+}
+
+/**
+ * Formata data de término de tratamento. null/undefined → "Uso contínuo".
+ *
+ * @example formatEndDate(null)         → 'Uso contínuo'
+ * @example formatEndDate('2026-12-31') → '31 dez 2026'
+ */
+export function formatEndDate(isoDate) {
+  if (!isoDate) return 'Uso contínuo'
+  return formatDatePtBR(isoDate)
+}

--- a/packages/core/src/utils/doseUnit.js
+++ b/packages/core/src/utils/doseUnit.js
@@ -1,0 +1,44 @@
+// doseUnit.js — Apresentação de quantidade + unidade de dose (Fase 2).
+//
+// Helper compartilhado web↔mobile. Sempre usar em vez de hardcoded "comprimidos".
+// Hermes (mobile) default NÃO inclui ICU completo — toLocaleString('pt-BR') cai em
+// fallback US. Por isso usamos replace('.', ',') manual (confiável em V8 e Hermes).
+
+const UNIT_DISPLAY = {
+  mg: { singular: 'comprimido', plural: 'comprimidos' },
+  mcg: { singular: 'comprimido', plural: 'comprimidos' },
+  g: { singular: 'comprimido', plural: 'comprimidos' },
+  cp: { singular: 'comprimido', plural: 'comprimidos' },
+  ml: { singular: 'ml', plural: 'ml' },
+  gotas: { singular: 'gota', plural: 'gotas' },
+  ui: { singular: 'UI', plural: 'UI' },
+}
+
+const FALLBACK = { singular: 'unidade', plural: 'unidades' }
+
+/**
+ * Retorna a palavra correta de unidade (singular/plural) para a quantidade.
+ * Coerce explícito via Number — valores podem chegar como string de TextInput.
+ *
+ * @example pluralizeDoseUnit(2, 'mg')    → 'comprimidos'
+ * @example pluralizeDoseUnit(1, 'gotas') → 'gota'
+ * @example pluralizeDoseUnit(15, 'ml')   → 'ml'
+ * @example pluralizeDoseUnit(2, undefined) → 'unidades'
+ */
+export function pluralizeDoseUnit(qty, dosageUnit) {
+  const u = UNIT_DISPLAY[dosageUnit] ?? FALLBACK
+  return Number(qty) === 1 ? u.singular : u.plural
+}
+
+/**
+ * Formata quantidade + unidade para exibição. Vírgula decimal PT-BR.
+ *
+ * @example formatDoseUnit(2, 'mg')      → '2 comprimidos'
+ * @example formatDoseUnit(1, 'gotas')   → '1 gota'
+ * @example formatDoseUnit(15.5, 'ml')   → '15,5 ml'
+ * @example formatDoseUnit('0.5', 'mg')  → '0,5 comprimidos'
+ */
+export function formatDoseUnit(qty, dosageUnit) {
+  const display = String(qty).replace('.', ',')
+  return `${display} ${pluralizeDoseUnit(qty, dosageUnit)}`
+}

--- a/packages/core/src/utils/index.js
+++ b/packages/core/src/utils/index.js
@@ -66,3 +66,15 @@ export {
   getNotificationIcon,
   formatRelativeTime,
 } from './notificationIconMapper.js'
+
+// Dose unit presentation (Fase 2)
+export {
+  pluralizeDoseUnit,
+  formatDoseUnit,
+} from './doseUnit.js'
+
+// Date presentation PT-BR (Fase 2)
+export {
+  formatDatePtBR,
+  formatEndDate,
+} from './dateFormat.js'


### PR DESCRIPTION
## Summary
- Início Fase 2 (CRUD Tratamentos) — Sprint T2.1 entregue em **2 PRs** por escolha (revisão antecipada do Opus crítico antes do fan-out Sonnet/Haiku).
- **Este PR**: helpers de apresentação compartilhados `@dosiq/core/utils` (`pluralizeDoseUnit`, `formatDoseUnit`, `formatDatePtBR`, `formatEndDate`) + **T1.1** `protocolService` mobile (cópia G1 standalone do web, com DI nativeSupabaseClient + `@dosiq/core` schemas/utils) + **T1.10** suite Jest do service.

## Decisões técnicas
- **Hermes-safe formatação numérica**: `String(qty).replace('.', ',')` em vez de `toLocaleString('pt-BR')`. Hermes default não inclui ICU completo → fallback US mantém ponto. Documentado inline + comentário no helper.
- **`pluralizeDoseUnit` coerce explícito**: `Number(qty) === 1` (qty pode vir como string de TextInput). Mapping fechado em UNIT_DISPLAY com fallback `'unidades'`.
- **`formatEndDate(null)` → `'Uso contínuo'`**: convenção spec §8 (mais claro que "Sem prazo").
- **G1 cópia standalone** (não usa factory ainda): consistente com hardening G1→G2→G3 da Fase 1 (ADR-043). Sprint T2.3 extrai para `@dosiq/core/repositories/createProtocolRepository` (ADR-045). `advanceTitrationStage` omitido aqui (spec §2 Exclusões v1).

## Testes
- ✅ **Helpers** (vitest, web workspace): 17/17 (`doseUnit.test.js` + `dateFormat.test.js`).
- ✅ **protocolService mobile** (jest): 17/17 (mocked Supabase fluente cobrindo getAll/getActive/getById/create/update/delete/getByMedicineId + sessão expirada + erro DB + validação Zod).
- ✅ **Web `validate:agent`**: 530/530 (zero regressão).
- ✅ Lint clean nos arquivos novos.

## Próximos PRs (mesma sprint T2.1, contra esta mãe `feat/crud-protocols`)
- T1.2 `treatmentPlanService` mobile (Sonnet)
- T1.3 `useProtocols` hook + cache (Sonnet)
- T1.4 `useProtocol(id)` (Haiku)
- T1.5 `TreatmentsScreen` update — empty + FAB (Opus)
- T1.6 `TreatmentEmptyState` (Haiku)
- T1.7 `ProtocolDetailScreen` (Opus)
- T1.8 `TreatmentsStack` rotas (Haiku)
- T1.9 `routes.js` (Haiku)
- T1.11 Polish: Ionicons → lucide 5 telas auth/landing (Haiku)

## Test plan
- [x] `cd apps/web && npx vitest run ../../packages/core/src/utils/__tests__/doseUnit.test.js ../../packages/core/src/utils/__tests__/dateFormat.test.js`
- [x] `cd apps/mobile && npx jest src/features/treatments/services/__tests__/protocolService.test.js`
- [x] `npm run validate:agent` (web)
- [ ] PO smoke quando T2.1 completo (próximos PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)