### PR TITLE
feat(mobile/treatments): Fase 2 T2.2 PR-A — primitivos + hooks + dev demo

### DIFF
--- a/apps/mobile/src/features/_dev/screens/MedicineDemoScreen.jsx
+++ b/apps/mobile/src/features/_dev/screens/MedicineDemoScreen.jsx
@@ -24,6 +24,20 @@ export default function MedicineDemoScreen({ navigation }) {
       </View>
 
       <ScrollView contentContainerStyle={styles.scroll}>
+        {/* Seção Fase 2 — Primitivos */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Fase 2 — Primitivos T2.2</Text>
+          <TouchableOpacity
+            onPress={() => {
+              lightTap()
+              navigation?.navigate(ROUTES.TREATMENT_PRIMITIVES_DEMO)
+            }}
+            style={styles.buttonCard}
+          >
+            <Text style={styles.buttonText}>🧪 WeekdaySelector + MedicineSelectorRow + TimeSchedulePicker</Text>
+          </TouchableOpacity>
+        </View>
+
         {/* Seção 1 — Telas Sprint M1.1 */}
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Telas Sprint M1.1</Text>

--- a/apps/mobile/src/features/_dev/screens/TreatmentPrimitivesDemoScreen.jsx
+++ b/apps/mobile/src/features/_dev/screens/TreatmentPrimitivesDemoScreen.jsx
@@ -1,0 +1,219 @@
+// TreatmentPrimitivesDemoScreen — playground primitivos Fase 2 (Sprint T2.2).
+// DEV-only. Cada bloco isolado para validar interação visual antes da integração no form.
+
+import { useState } from 'react'
+import { ScrollView, View, Text, StyleSheet, TouchableOpacity, SafeAreaView } from 'react-native'
+import { ChevronLeft } from 'lucide-react-native'
+import { colors, spacing, typography } from '@shared/styles/tokens'
+import WeekdaySelector from '../../treatments/components/WeekdaySelector'
+import MedicineSelectorRow from '../../treatments/components/MedicineSelectorRow'
+import TimeSchedulePicker from '../../treatments/components/TimeSchedulePicker'
+
+const FAKE_MEDICINE = {
+  id: 'demo-med-1',
+  name: 'SeloZok',
+  dosage_per_pill: 50,
+  dosage_unit: 'mg',
+  type: 'medicamento',
+  laboratory: 'AstraZeneca',
+  active_ingredient: 'Metoprolol',
+}
+
+const FAKE_SUPPLEMENT = {
+  id: 'demo-supp-1',
+  name: 'Vitamina D3',
+  dosage_per_pill: 2000,
+  dosage_unit: 'ui',
+  type: 'suplemento',
+  laboratory: 'Now Foods',
+}
+
+export default function TreatmentPrimitivesDemoScreen({ navigation }) {
+  // States
+  const [weekdays, setWeekdays] = useState(['segunda', 'quarta', 'sexta'])
+  const [weekdaysError, setWeekdaysError] = useState(false)
+  const [medicine, setMedicine] = useState(null)
+  const [times, setTimes] = useState(['08:00', '20:00'])
+  const [timesError, setTimesError] = useState(false)
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top']}>
+      <View style={styles.header}>
+        <TouchableOpacity
+          onPress={() => navigation?.goBack()}
+          style={styles.backBtn}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <ChevronLeft size={24} color={colors.text.primary} />
+        </TouchableOpacity>
+        <Text style={styles.title}>Primitivos T2.2</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scroll}>
+        {/* ── WeekdaySelector ───────────────────────────────────────────── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>WeekdaySelector</Text>
+          <Text style={styles.caption}>Toque dias; toggle on/off. Toggle erro pra ver hint.</Text>
+          <WeekdaySelector
+            value={weekdays}
+            onChange={setWeekdays}
+            error={weekdaysError ? 'Selecione ao menos um dia' : null}
+          />
+          <View style={styles.controls}>
+            <TouchableOpacity
+              style={styles.controlBtn}
+              onPress={() => setWeekdaysError((v) => !v)}
+            >
+              <Text style={styles.controlBtnText}>
+                Toggle erro ({weekdaysError ? 'ON' : 'OFF'})
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.controlBtn} onPress={() => setWeekdays([])}>
+              <Text style={styles.controlBtnText}>Limpar</Text>
+            </TouchableOpacity>
+          </View>
+          <Text style={styles.stateLabel}>State: {JSON.stringify(weekdays)}</Text>
+        </View>
+
+        {/* ── MedicineSelectorRow ───────────────────────────────────────── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>MedicineSelectorRow</Text>
+          <Text style={styles.caption}>
+            Estado vazio + selecionado (medicamento) + selecionado (suplemento).
+          </Text>
+
+          <Text style={styles.subLabel}>Vazio:</Text>
+          <MedicineSelectorRow
+            medicine={null}
+            onPress={() => setMedicine(FAKE_MEDICINE)}
+          />
+
+          <Text style={styles.subLabel}>Selecionado (medicamento):</Text>
+          <MedicineSelectorRow
+            medicine={FAKE_MEDICINE}
+            onPress={() => setMedicine(FAKE_SUPPLEMENT)}
+          />
+
+          <Text style={styles.subLabel}>Selecionado (suplemento — cor laranja):</Text>
+          <MedicineSelectorRow
+            medicine={FAKE_SUPPLEMENT}
+            onPress={() => setMedicine(null)}
+          />
+
+          <Text style={styles.subLabel}>Controlado (toca pra alternar fake/null):</Text>
+          <MedicineSelectorRow
+            medicine={medicine}
+            onPress={() => setMedicine(medicine ? null : FAKE_MEDICINE)}
+            error={medicine ? null : 'Selecione o medicamento'}
+          />
+        </View>
+
+        {/* ── TimeSchedulePicker ────────────────────────────────────────── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>TimeSchedulePicker</Text>
+          <Text style={styles.caption}>
+            Adicionar/editar/remover horários (iOS modal spinner; Android picker nativo).
+          </Text>
+          <TimeSchedulePicker
+            value={times}
+            onChange={setTimes}
+            error={timesError ? 'Adicione ao menos um horário' : null}
+            maxItems={10}
+          />
+          <View style={styles.controls}>
+            <TouchableOpacity
+              style={styles.controlBtn}
+              onPress={() => setTimesError((v) => !v)}
+            >
+              <Text style={styles.controlBtnText}>
+                Toggle erro ({timesError ? 'ON' : 'OFF'})
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.controlBtn} onPress={() => setTimes([])}>
+              <Text style={styles.controlBtnText}>Limpar</Text>
+            </TouchableOpacity>
+          </View>
+          <Text style={styles.stateLabel}>State: {JSON.stringify(times)}</Text>
+        </View>
+
+        <View style={{ height: spacing[10] }} />
+      </ScrollView>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: colors.bg.screen || colors.neutral[50],
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    gap: spacing[2],
+  },
+  backBtn: {
+    padding: spacing[1],
+  },
+  title: {
+    flex: 1,
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.text.primary,
+    fontFamily: typography.fontFamily.bold,
+  },
+  headerSpacer: {
+    width: 32,
+  },
+  scroll: {
+    padding: spacing[4],
+    gap: spacing[6],
+  },
+  section: {
+    gap: spacing[3],
+    padding: spacing[4],
+    backgroundColor: colors.neutral[50],
+    borderRadius: 16,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '800',
+    color: colors.text.primary,
+    fontFamily: typography.fontFamily.bold,
+  },
+  subLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: colors.text.secondary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+    marginTop: spacing[2],
+  },
+  caption: {
+    fontSize: 13,
+    color: colors.text.secondary,
+  },
+  controls: {
+    flexDirection: 'row',
+    gap: spacing[2],
+  },
+  controlBtn: {
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    backgroundColor: colors.neutral[100],
+    borderRadius: 8,
+  },
+  controlBtnText: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: colors.text.primary,
+  },
+  stateLabel: {
+    fontSize: 11,
+    color: colors.text.secondary,
+    fontFamily: 'Courier',
+  },
+})

--- a/apps/mobile/src/features/treatments/components/MedicineSelectorRow.jsx
+++ b/apps/mobile/src/features/treatments/components/MedicineSelectorRow.jsx
@@ -1,0 +1,156 @@
+// MedicineSelectorRow — row de seleção de medicamento (Fase 2 T2.3)
+// (componente puro controlado)
+import { View, Text, Pressable, StyleSheet } from 'react-native'
+import { Plus, ChevronRight, Pill, PillBottle } from 'lucide-react-native'
+import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
+
+export default function MedicineSelectorRow({ medicine, onPress, error }) {
+  const isEmpty = medicine == null
+  const isSupplement = !isEmpty && medicine.type === 'suplemento'
+  const LeadingIcon = isEmpty ? Plus : isSupplement ? PillBottle : Pill
+
+  const leadingBg = isEmpty
+    ? colors.neutral[100]
+    : isSupplement
+      ? colors.supplement[50]
+      : colors.primary[50]
+
+  const leadingColor = isEmpty
+    ? colors.primary[600]
+    : isSupplement
+      ? colors.supplement[500]
+      : colors.primary[500]
+
+  const subtitleText = isEmpty
+    ? 'Escolha da biblioteca ou cadastre um novo'
+    : medicine.laboratory || medicine.active_ingredient || ''
+
+  const dosageLabel =
+    !isEmpty && medicine.dosage_per_pill
+      ? `${medicine.dosage_per_pill}${medicine.dosage_unit || ''}`
+      : null
+
+  const accessibilityLabel = isEmpty
+    ? 'Selecionar medicamento'
+    : `Trocar medicamento ${medicine.name}`
+
+  return (
+    <View>
+      <Pressable
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+        style={[styles.card, isEmpty ? styles.cardEmpty : styles.cardSelected]}
+      >
+        <View style={[styles.leading, { backgroundColor: leadingBg }]}>
+          <LeadingIcon size={isEmpty ? 20 : 22} color={leadingColor} />
+        </View>
+
+        <View style={styles.middle}>
+          {isEmpty ? (
+            <>
+              <Text style={styles.title}>Selecionar medicamento</Text>
+              <Text style={styles.subtitle}>{subtitleText}</Text>
+            </>
+          ) : (
+            <>
+              <View style={styles.titleRow}>
+                <Text style={styles.title} numberOfLines={1}>
+                  {medicine.name}
+                </Text>
+                {dosageLabel ? (
+                  <View style={styles.dosagePill}>
+                    <Text style={styles.dosagePillText}>{dosageLabel}</Text>
+                  </View>
+                ) : null}
+              </View>
+              {subtitleText ? (
+                <Text style={styles.subtitle} numberOfLines={1}>
+                  {subtitleText}
+                </Text>
+              ) : null}
+            </>
+          )}
+        </View>
+
+        {isEmpty ? (
+          <ChevronRight size={22} color={colors.text.secondary} />
+        ) : (
+          <Text style={styles.trailingAction}>Trocar</Text>
+        )}
+      </Pressable>
+
+      {error ? <Text style={styles.errorText}>{error}</Text> : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    padding: spacing[4],
+    borderRadius: borderRadius.md,
+  },
+  cardEmpty: {
+    backgroundColor: colors.primary[50],
+  },
+  cardSelected: {
+    backgroundColor: colors.bg.screen,
+  },
+  leading: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  middle: {
+    flex: 1,
+    gap: 4,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  title: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.text.primary,
+    fontFamily: typography.fontFamily.bold,
+    flexShrink: 1,
+  },
+  subtitle: {
+    fontSize: 13,
+    color: colors.text.secondary,
+    fontFamily: typography.fontFamily.regular,
+  },
+  dosagePill: {
+    backgroundColor: colors.neutral[100],
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    borderRadius: 4,
+    borderWidth: 0.5,
+    borderColor: colors.neutral[300],
+  },
+  dosagePillText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.neutral[700],
+    fontFamily: typography.fontFamily.medium,
+  },
+  trailingAction: {
+    color: colors.primary[700],
+    fontWeight: '700',
+    fontSize: 14,
+    fontFamily: typography.fontFamily.bold,
+  },
+  errorText: {
+    color: colors.status.error,
+    fontSize: 12,
+    marginTop: spacing[2],
+    fontFamily: typography.fontFamily.regular,
+  },
+})

--- a/apps/mobile/src/features/treatments/components/TimeSchedulePicker.jsx
+++ b/apps/mobile/src/features/treatments/components/TimeSchedulePicker.jsx
@@ -53,22 +53,23 @@ export default function TimeSchedulePicker({
     setEditIndex(null)
   }, [])
 
-  const commitTime = useCallback(
-    (date) => {
+  // commitTimeAt recebe idx explicito — evita capturar editIndex via closure
+  // (no Android o picker imperativo dispara onChange ANTES do setState assíncrono
+  // re-renderizar; usar idx do closure direto é confiável em ambos os OS).
+  const commitTimeAt = useCallback(
+    (idx, date) => {
       const newTime = dateToString(date)
       const next = [...value]
-      if (editIndex === -1) {
-        // Add novo (evita duplicata)
+      if (idx === -1) {
         if (!next.includes(newTime)) next.push(newTime)
-      } else if (editIndex >= 0) {
-        next[editIndex] = newTime
+      } else if (idx >= 0) {
+        next[idx] = newTime
       }
-      // Ordena horários cronologicamente para UX previsível
       next.sort()
       onChange(next)
       selectionTap()
     },
-    [editIndex, value, onChange]
+    [value, onChange]
   )
 
   const openEditor = useCallback(
@@ -76,23 +77,24 @@ export default function TimeSchedulePicker({
       if (idx === -1 && !canAddMore) return
       lightTap()
       const seed = idx >= 0 ? stringToDate(value[idx]) : stringToDate('08:00')
-      setTempDate(seed)
-      setEditIndex(idx)
 
       if (Platform.OS === 'android') {
-        // Android usa picker imperativo nativo
+        // Android: picker imperativo nativo — commit inline via idx do closure
         DateTimePickerAndroid.open({
           value: seed,
           mode: 'time',
           is24Hour: true,
           onChange: (event, selectedDate) => {
-            if (event.type === 'set' && selectedDate) commitTime(selectedDate)
-            closePicker()
+            if (event.type === 'set' && selectedDate) commitTimeAt(idx, selectedDate)
           },
         })
+      } else {
+        // iOS: modal controlado por state (re-render acontece antes do OK)
+        setTempDate(seed)
+        setEditIndex(idx)
       }
     },
-    [value, canAddMore, commitTime, closePicker]
+    [value, canAddMore, commitTimeAt]
   )
 
   const removeAt = useCallback(
@@ -108,9 +110,9 @@ export default function TimeSchedulePicker({
   }, [])
 
   const onIosConfirm = useCallback(() => {
-    commitTime(tempDate)
+    if (editIndex !== null) commitTimeAt(editIndex, tempDate)
     closePicker()
-  }, [commitTime, closePicker, tempDate])
+  }, [commitTimeAt, closePicker, editIndex, tempDate])
 
   return (
     <View>

--- a/apps/mobile/src/features/treatments/components/TimeSchedulePicker.jsx
+++ b/apps/mobile/src/features/treatments/components/TimeSchedulePicker.jsx
@@ -1,0 +1,293 @@
+// TimeSchedulePicker.jsx — seletor de horários múltiplos para Protocol (Fase 2 T2.1).
+// Spec §3.4 — variação "Chips" (lista vertical de cards).
+//
+// API:
+//   value: string[] — array de "HH:MM" (24h)
+//   onChange: (string[]) => void
+//   error?: string
+//   maxItems?: number — default 10 (R-022 limite Zod)
+
+import { useCallback, useMemo, useState } from 'react'
+import { View, Text, Pressable, StyleSheet, Platform, Modal } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import DateTimePicker, { DateTimePickerAndroid } from '@react-native-community/datetimepicker'
+import { Clock, X, Plus } from 'lucide-react-native'
+import { getNow } from '@dosiq/core'
+import { selectionTap, lightTap } from '@shared/utils/haptics'
+import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
+
+const MAX_ITEMS_DEFAULT = 10
+const BACKDROP_COLOR = 'rgba(0,0,0,0.4)'
+
+// "HH:MM" → Date (hoje + esses horários) — usa getNow() para R-020 compliance
+function stringToDate(timeStr) {
+  const [hh, mm] = (timeStr || '08:00').split(':').map((n) => parseInt(n, 10) || 0)
+  const d = getNow()
+  d.setHours(hh, mm, 0, 0)
+  return d
+}
+
+// Date → "HH:MM" zero-padded
+function dateToString(d) {
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  return `${hh}:${mm}`
+}
+
+export default function TimeSchedulePicker({
+  value = [],
+  onChange,
+  error,
+  maxItems = MAX_ITEMS_DEFAULT,
+}) {
+  // States
+  const [editIndex, setEditIndex] = useState(null) // null = picker fechado; -1 = add novo; >=0 = editar slot
+  const [tempDate, setTempDate] = useState(() => stringToDate('08:00'))
+
+  // Memos
+  const canAddMore = useMemo(() => value.length < maxItems, [value.length, maxItems])
+  const isOpen = editIndex !== null
+
+  // Handlers
+  const closePicker = useCallback(() => {
+    setEditIndex(null)
+  }, [])
+
+  const commitTime = useCallback(
+    (date) => {
+      const newTime = dateToString(date)
+      const next = [...value]
+      if (editIndex === -1) {
+        // Add novo (evita duplicata)
+        if (!next.includes(newTime)) next.push(newTime)
+      } else if (editIndex >= 0) {
+        next[editIndex] = newTime
+      }
+      // Ordena horários cronologicamente para UX previsível
+      next.sort()
+      onChange(next)
+      selectionTap()
+    },
+    [editIndex, value, onChange]
+  )
+
+  const openEditor = useCallback(
+    (idx) => {
+      if (idx === -1 && !canAddMore) return
+      lightTap()
+      const seed = idx >= 0 ? stringToDate(value[idx]) : stringToDate('08:00')
+      setTempDate(seed)
+      setEditIndex(idx)
+
+      if (Platform.OS === 'android') {
+        // Android usa picker imperativo nativo
+        DateTimePickerAndroid.open({
+          value: seed,
+          mode: 'time',
+          is24Hour: true,
+          onChange: (event, selectedDate) => {
+            if (event.type === 'set' && selectedDate) commitTime(selectedDate)
+            closePicker()
+          },
+        })
+      }
+    },
+    [value, canAddMore, commitTime, closePicker]
+  )
+
+  const removeAt = useCallback(
+    (idx) => {
+      lightTap()
+      onChange(value.filter((_, i) => i !== idx))
+    },
+    [value, onChange]
+  )
+
+  const onIosChange = useCallback((_, selectedDate) => {
+    if (selectedDate) setTempDate(selectedDate)
+  }, [])
+
+  const onIosConfirm = useCallback(() => {
+    commitTime(tempDate)
+    closePicker()
+  }, [commitTime, closePicker, tempDate])
+
+  return (
+    <View>
+      <View style={styles.list}>
+        {value.map((t, idx) => (
+          <View key={`${t}-${idx}`} style={styles.row}>
+            <Pressable
+              onPress={() => openEditor(idx)}
+              style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
+              accessibilityRole="button"
+              accessibilityLabel={`Editar horário ${t}`}
+            >
+              <Clock size={20} color={colors.primary[600]} />
+              <Text style={styles.time}>{t}</Text>
+            </Pressable>
+            <Pressable
+              onPress={() => removeAt(idx)}
+              style={({ pressed }) => [styles.removeBtn, pressed && styles.removeBtnPressed]}
+              accessibilityRole="button"
+              accessibilityLabel={`Remover horário ${t}`}
+              hitSlop={8}
+            >
+              <X size={18} color={colors.text.secondary} />
+            </Pressable>
+          </View>
+        ))}
+
+        <Pressable
+          onPress={() => openEditor(-1)}
+          disabled={!canAddMore}
+          style={({ pressed }) => [
+            styles.addBtn,
+            error && styles.addBtnError,
+            (pressed || !canAddMore) && styles.addBtnPressed,
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel="Adicionar horário"
+          accessibilityState={{ disabled: !canAddMore }}
+        >
+          <Plus size={16} color={error ? colors.status.error : colors.primary[700]} />
+          <Text style={[styles.addBtnText, error && styles.addBtnTextError]}>
+            {canAddMore ? 'Adicionar horário' : `Máximo de ${maxItems} horários`}
+          </Text>
+        </Pressable>
+      </View>
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+
+      {/* iOS modal (Android usa picker imperativo) */}
+      {Platform.OS === 'ios' && isOpen ? (
+        <Modal transparent animationType="slide" visible onRequestClose={closePicker}>
+          <Pressable style={styles.backdrop} onPress={closePicker} />
+          <SafeAreaView edges={['bottom']} style={styles.sheet}>
+            <View style={styles.sheetHeader}>
+              <Pressable onPress={closePicker} hitSlop={8}>
+                <Text style={styles.sheetCancel}>Cancelar</Text>
+              </Pressable>
+              <Text style={styles.sheetTitle}>
+                {editIndex === -1 ? 'Adicionar horário' : 'Editar horário'}
+              </Text>
+              <Pressable onPress={onIosConfirm} hitSlop={8}>
+                <Text style={styles.sheetConfirm}>OK</Text>
+              </Pressable>
+            </View>
+            <DateTimePicker
+              value={tempDate}
+              mode="time"
+              is24Hour
+              display="spinner"
+              onChange={onIosChange}
+              themeVariant="light"
+            />
+          </SafeAreaView>
+        </Modal>
+      ) : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  list: {
+    gap: spacing[2],
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  card: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    backgroundColor: colors.primary[50],
+    borderRadius: borderRadius.md,
+  },
+  cardPressed: {
+    opacity: 0.7,
+  },
+  time: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.primary[700],
+    fontFamily: typography.fontFamily.bold,
+  },
+  removeBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: borderRadius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.neutral[100],
+  },
+  removeBtnPressed: {
+    opacity: 0.6,
+  },
+  addBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[1],
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[4],
+    backgroundColor: colors.primary[50],
+    borderRadius: borderRadius.md,
+  },
+  addBtnError: {
+    backgroundColor: colors.neutral[100],
+  },
+  addBtnPressed: {
+    opacity: 0.6,
+  },
+  addBtnText: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.primary[700],
+    fontFamily: typography.fontFamily.bold,
+  },
+  addBtnTextError: {
+    color: colors.status.error,
+  },
+  error: {
+    color: colors.status.error,
+    fontSize: 12,
+    marginTop: spacing[2],
+  },
+  backdrop: {
+    flex: 1,
+    backgroundColor: BACKDROP_COLOR,
+  },
+  sheet: {
+    backgroundColor: colors.bg.screen || colors.neutral[50],
+    borderTopLeftRadius: borderRadius.xl,
+    borderTopRightRadius: borderRadius.xl,
+    paddingBottom: spacing[2],
+  },
+  sheetHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing[5],
+    paddingVertical: spacing[3],
+  },
+  sheetTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.text.primary,
+  },
+  sheetCancel: {
+    fontSize: 16,
+    color: colors.text.secondary,
+  },
+  sheetConfirm: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.primary[700],
+  },
+})

--- a/apps/mobile/src/features/treatments/components/TimeSchedulePicker.jsx
+++ b/apps/mobile/src/features/treatments/components/TimeSchedulePicker.jsx
@@ -63,6 +63,9 @@ export default function TimeSchedulePicker({
       if (idx === -1) {
         if (!next.includes(newTime)) next.push(newTime)
       } else if (idx >= 0) {
+        // Editar para um horário que já existe em outro slot = no-op (evita
+        // duplicata silenciosa pós-sort). Trocar para o mesmo valor é OK.
+        if (next.includes(newTime) && next[idx] !== newTime) return
         next[idx] = newTime
       }
       next.sort()

--- a/apps/mobile/src/features/treatments/components/WeekdaySelector.jsx
+++ b/apps/mobile/src/features/treatments/components/WeekdaySelector.jsx
@@ -1,0 +1,104 @@
+import { View, Text, Pressable, StyleSheet } from 'react-native'
+import { WEEKDAYS } from '@dosiq/core'
+import { selectionTap } from '@shared/utils/haptics'
+import { colors, spacing } from '@shared/styles/tokens'
+
+// Ordem visual brasileira (Dom-Sáb) → canônico WEEKDAYS
+const VISUAL_ORDER = [
+  { key: 'domingo', label: 'D' },
+  { key: 'segunda', label: 'S' },
+  { key: 'terça', label: 'T' },
+  { key: 'quarta', label: 'Q' },
+  { key: 'quinta', label: 'Q' },
+  { key: 'sexta', label: 'S' },
+  { key: 'sábado', label: 'S' },
+]
+
+export default function WeekdaySelector({ value = [], onChange, error }) {
+  // (componente controlado — value/onChange via props; sem state interno)
+  // Handlers (R-010 — States → Memos → Effects → Handlers)
+  const handleToggle = (day) => {
+    if (!WEEKDAYS.includes(day)) return
+    const isSelected = value.includes(day)
+    const next = isSelected ? value.filter((d) => d !== day) : [...value, day]
+    onChange(next)
+    selectionTap()
+  }
+
+  return (
+    <View>
+      <View style={styles.row}>
+        {VISUAL_ORDER.map(({ key, label }) => {
+          const isSelected = value.includes(key)
+          return (
+            <Pressable
+              key={key}
+              onPress={() => handleToggle(key)}
+              accessibilityRole="checkbox"
+              accessibilityLabel={`Selecionar ${key}`}
+              accessibilityState={{ checked: isSelected }}
+              style={({ pressed }) => [
+                styles.button,
+                isSelected ? styles.buttonSelected : styles.buttonUnselected,
+                pressed && styles.buttonPressed,
+              ]}
+            >
+              <Text
+                style={[
+                  styles.label,
+                  isSelected ? styles.labelSelected : styles.labelUnselected,
+                ]}
+              >
+                {label}
+              </Text>
+            </Pressable>
+          )
+        })}
+      </View>
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing[5],
+    gap: spacing[2],
+  },
+  button: {
+    width: 40,
+    height: 40,
+    borderRadius: 9999,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  buttonSelected: {
+    backgroundColor: colors.primary[500],
+  },
+  buttonUnselected: {
+    backgroundColor: colors.neutral[100],
+  },
+  buttonPressed: {
+    opacity: 0.7,
+  },
+  label: {
+    fontSize: 14,
+  },
+  labelSelected: {
+    color: colors.text.inverse,
+    fontWeight: '700',
+  },
+  labelUnselected: {
+    color: colors.text.primary,
+    fontWeight: '600',
+  },
+  error: {
+    color: colors.status.error,
+    fontSize: 12,
+    marginTop: spacing[2],
+    paddingHorizontal: spacing[5],
+  },
+})

--- a/apps/mobile/src/features/treatments/components/WeekdaySelector.jsx
+++ b/apps/mobile/src/features/treatments/components/WeekdaySelector.jsx
@@ -62,11 +62,12 @@ export default function WeekdaySelector({ value = [], onChange, error }) {
 
 const styles = StyleSheet.create({
   row: {
+    // Sem paddingHorizontal próprio — primitivo atômico delega ao container pai
+    // (FormSection / ProtocolFormScreen). space-between distribui os 7 botões
+    // dentro da largura disponível.
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    paddingHorizontal: spacing[5],
-    gap: spacing[2],
   },
   button: {
     width: 40,
@@ -99,6 +100,5 @@ const styles = StyleSheet.create({
     color: colors.status.error,
     fontSize: 12,
     marginTop: spacing[2],
-    paddingHorizontal: spacing[5],
   },
 })

--- a/apps/mobile/src/features/treatments/hooks/useProtocolDelete.js
+++ b/apps/mobile/src/features/treatments/hooks/useProtocolDelete.js
@@ -1,0 +1,45 @@
+// useProtocolDelete.js — delete de Protocol (Fase 2 T2.10).
+// Sem hard block (spec §3.7 — warning soft via ProtocolDeleteSheet com stats
+// informativos do useProtocolStats). Aqui só o delete + cache invalidation
+// + toast + haptic + navegação.
+
+import { useState, useCallback } from 'react'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { useNavigation } from '@react-navigation/native'
+import { useToast } from '@shared/components/feedback/Toast'
+import { successHaptic, errorHaptic } from '@shared/utils/haptics'
+import { protocolService } from '../services/protocolService'
+
+const PROTOCOLS_CACHE_KEY = '@dosiq/protocols-snapshot'
+
+export function useProtocolDelete(protocol) {
+  // States (R-010 — States → Memos → Effects → Handlers)
+  const navigation = useNavigation()
+  const { show } = useToast()
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Handlers
+  const confirmDelete = useCallback(async () => {
+    if (!protocol?.id) return false
+    setIsLoading(true)
+    try {
+      await protocolService.delete(protocol.id)
+      await AsyncStorage.removeItem(PROTOCOLS_CACHE_KEY).catch(() => {})
+      successHaptic()
+      show('Tratamento excluído', { variant: 'success' })
+      navigation.goBack()
+      return true
+    } catch (err) {
+      errorHaptic()
+      show(err?.message ?? 'Erro ao excluir tratamento', { variant: 'error' })
+      return false
+    } finally {
+      setIsLoading(false)
+    }
+  }, [protocol, navigation, show])
+
+  return {
+    confirmDelete,
+    isLoading,
+  }
+}

--- a/apps/mobile/src/features/treatments/hooks/useProtocolMutation.js
+++ b/apps/mobile/src/features/treatments/hooks/useProtocolMutation.js
@@ -1,0 +1,61 @@
+// useProtocolMutation.js — wrappers create/update sobre useMutation
+//
+// Encapsula:
+// - Toast feedback (success/error)
+// - Cache invalidation (@dosiq/protocols-snapshot)
+// - Navegação opcional pós-sucesso
+//
+// Uso:
+//   const { create, update, isLoading } = useProtocolMutation()
+//   create(values, { goBack: true })
+
+import { useCallback } from 'react'
+import { useNavigation } from '@react-navigation/native'
+import { useMutation } from '@shared/hooks/useMutation'
+import { useToast } from '@shared/components/feedback/Toast'
+import { protocolService } from '../services/protocolService'
+
+const PROTOCOLS_CACHE_KEY = '@dosiq/protocols-snapshot'
+
+export function useProtocolMutation() {
+  // States (R-010 — States → Memos → Effects → Handlers)
+  const navigation = useNavigation()
+  const { show } = useToast()
+
+  const mutationCreate = useMutation({
+    invalidateKeys: [PROTOCOLS_CACHE_KEY],
+    onSuccess: () => show('Tratamento criado', { variant: 'success' }),
+    onError: (err) => show(err?.message ?? 'Erro ao criar tratamento', { variant: 'error' }),
+  })
+
+  const mutationUpdate = useMutation({
+    invalidateKeys: [PROTOCOLS_CACHE_KEY],
+    onSuccess: () => show('Tratamento atualizado', { variant: 'success' }),
+    onError: (err) => show(err?.message ?? 'Erro ao atualizar tratamento', { variant: 'error' }),
+  })
+
+  const create = useCallback(
+    async (payload, { goBack = false } = {}) => {
+      const result = await mutationCreate.mutate(() => protocolService.create(payload))
+      if (result && goBack) navigation.goBack()
+      return result
+    },
+    [mutationCreate, navigation]
+  )
+
+  const update = useCallback(
+    async (id, payload, { goBack = false } = {}) => {
+      const result = await mutationUpdate.mutate(() => protocolService.update(id, payload))
+      if (result && goBack) navigation.goBack()
+      return result
+    },
+    [mutationUpdate, navigation]
+  )
+
+  return {
+    create,
+    update,
+    isLoading: mutationCreate.isLoading || mutationUpdate.isLoading,
+    error: mutationCreate.error ?? mutationUpdate.error ?? null,
+  }
+}

--- a/apps/mobile/src/features/treatments/hooks/useProtocolStats.js
+++ b/apps/mobile/src/features/treatments/hooks/useProtocolStats.js
@@ -1,0 +1,77 @@
+// useProtocolStats.js — estatísticas de doses para warning de delete (Fase 2 §3.7).
+// Padrão: { data, loading, error }
+//
+// v1 (Sprint T2.2): confirmedLast7d via query real; pendingNow e scheduledNext7d
+// são estimativas ingênuas baseadas em time_schedule.length. Refinar quando util
+// de adherenceLogic for adaptado para mobile.
+
+import { useState, useEffect, useCallback, useMemo, startTransition } from 'react'
+import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
+import { protocolService } from '../services/protocolService'
+import { getNow, addDays } from '@dosiq/core'
+import { debugLog } from '@shared/utils/debugLog'
+
+export function useProtocolStats(protocolId) {
+  // States
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  // Handlers
+  const load = useCallback(async () => {
+    if (!protocolId) {
+      setLoading(false)
+      setData(null)
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      const today = getNow()
+      // addDays aceita Date direto; getNow já retorna Date (R-020 compliant)
+      const sevenDaysAgo = addDays(today, -7)
+
+      const [protocol, logsResult] = await Promise.all([
+        protocolService.getById(protocolId),
+        supabase
+          .from('logs')
+          .select('*', { count: 'exact', head: true })
+          .eq('protocol_id', protocolId)
+          .gte('taken_at', sevenDaysAgo.toISOString())
+          .lte('taken_at', today.toISOString()),
+      ])
+
+      if (logsResult.error) throw logsResult.error
+
+      const dailyDoses = Array.isArray(protocol?.time_schedule)
+        ? protocol.time_schedule.length
+        : 0
+
+      // pendingNow: placeholder v1 — cálculo real requer adherenceLogic.
+      // scheduledNext7d: estimativa ingênua (dailyDoses * 7).
+      setData({
+        confirmedLast7d: logsResult.count ?? 0,
+        pendingNow: 0,
+        scheduledNext7d: dailyDoses * 7,
+      })
+    } catch (err) {
+      if (__DEV__) debugLog('useProtocolStats', 'fetch failed:', err.message)
+      setError(err.message ?? 'Erro ao carregar estatísticas.')
+    } finally {
+      setLoading(false)
+    }
+  }, [protocolId])
+
+  // Effects
+  useEffect(() => {
+    startTransition(() => {
+      load()
+    })
+  }, [load])
+
+  // Memos
+  return useMemo(
+    () => ({ data, loading, error }),
+    [data, loading, error]
+  )
+}

--- a/apps/mobile/src/navigation/Navigation.jsx
+++ b/apps/mobile/src/navigation/Navigation.jsx
@@ -22,6 +22,7 @@ import ForgotPasswordScreen from '../screens/ForgotPasswordScreen'
 import ResetPasswordScreen from '../screens/ResetPasswordScreen'
 import RootTabs from './RootTabs'
 import MedicineDemoScreen from '../features/_dev/screens/MedicineDemoScreen'
+import TreatmentPrimitivesDemoScreen from '../features/_dev/screens/TreatmentPrimitivesDemoScreen'
 import { supabase } from '../platform/supabase/nativeSupabaseClient'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { usePushNotifications } from '../platform/notifications/usePushNotifications'
@@ -154,10 +155,16 @@ export default function Navigation() {
           <>
             <Stack.Screen name={ROUTES.TABS} component={RootTabs} />
             {__DEV__ && (
-              <Stack.Screen
-                name={ROUTES.MEDICINE_DEMO}
-                component={MedicineDemoScreen}
-              />
+              <>
+                <Stack.Screen
+                  name={ROUTES.MEDICINE_DEMO}
+                  component={MedicineDemoScreen}
+                />
+                <Stack.Screen
+                  name={ROUTES.TREATMENT_PRIMITIVES_DEMO}
+                  component={TreatmentPrimitivesDemoScreen}
+                />
+              </>
             )}
           </>
         ) : (

--- a/apps/mobile/src/navigation/routes.js
+++ b/apps/mobile/src/navigation/routes.js
@@ -42,4 +42,5 @@ export const ROUTES = {
 
   // Dev-only (apenas __DEV__)
   MEDICINE_DEMO: 'MedicineDemo',
+  TREATMENT_PRIMITIVES_DEMO: 'TreatmentPrimitivesDemo',
 }

--- a/packages/core/src/schemas/index.js
+++ b/packages/core/src/schemas/index.js
@@ -35,6 +35,10 @@ export {
   validateTitrationStage,
   mapProtocolErrorsToForm,
   getProtocolErrorMessage,
+  FREQUENCIES,
+  FREQUENCY_LABELS,
+  WEEKDAYS,
+  WEEKDAY_LABELS,
 } from './protocolSchema.js'
 
 export {


### PR DESCRIPTION
## Summary

Sprint **T2.2 PR-A** (building blocks da Fase 2 — Form Complexo). Não introduz tela final ainda — apenas os ingredientes que `ProtocolFormScreen` vai compor em PR-B.

Cavecrew distribution (spec §4):
| Owner | Tasks |
|-------|-------|
| Sonnet spawns paralelos | T2.2 WeekdaySelector · T2.3 MedicineSelectorRow · T2.9 useProtocolMutation · T2.12 useProtocolStats |
| Opus (eu) | T2.1 TimeSchedulePicker · T2.10 useProtocolDelete |

## NOVOS componentes (`apps/mobile/src/features/treatments/components/`)
- **WeekdaySelector** — 7 botões circulares D S T Q Q S S (ordem brasileira Dom-Sáb), controlado, accessibility checkbox/checked, error inline opcional. Sem padding interno (delega ao pai).
- **MedicineSelectorRow** — estado vazio (placeholder + Plus icon) + selecionado (ícone Pill/PillBottle por type, DosagePill inline, "Trocar" link), cor dinâmica medicamento/suplemento, error inline.
- **TimeSchedulePicker** — lista vertical de cards (Clock + "HH:MM" + X remove) + "Adicionar horário". iOS modal spinner; Android picker imperativo nativo. Ordena cronologicamente. Max default 10 (R-022).

## NOVOS hooks (`apps/mobile/src/features/treatments/hooks/`)
- **useProtocolMutation** — wrapper `useMutation` create/update + toast PT-BR + invalida `@dosiq/protocols-snapshot` + goBack opcional. Espelha `useMedicineMutation` Fase 1.
- **useProtocolDelete** — delete simples (sem hard block — spec §3.7 warning soft fica para T2.11 sheet), cache invalidation, haptic, navigation.goBack.
- **useProtocolStats** — `confirmedLast7d` via query real `logs`; `pendingNow`/`scheduledNext7d` v1 estimativa ingênua (refinar quando adherenceLogic for adaptado para mobile).

## MODIFICADO `packages/core/src/schemas/index.js`
- Re-export `WEEKDAYS`, `WEEKDAY_LABELS`, `FREQUENCIES`, `FREQUENCY_LABELS` (faltavam no barrel — bug pego em smoke iOS/Android).

## NOVOS dev (não-produção)
- **TreatmentPrimitivesDemoScreen** (`features/_dev/screens/`) — playground com cada primitivo isolado, state local, toggle erro, fake medicine/supplement.
- **routes.js** — `TREATMENT_PRIMITIVES_DEMO`.
- **Navigation.jsx** — registra rota em `__DEV__`.
- **MedicineDemoScreen** — entry "🧪 Primitivos T2.2" no topo do hub dev.

## Bugs pegos + corrigidos em smoke (3 ciclos)
| Bug | Plataforma | Causa | Fix |
|---|---|---|---|
| `WEEKDAYS.includes` undefined | iOS+Android | Constante não re-exportada em `schemas/index.js` | Adicionado ao barrel |
| Picker Android não commita horário | Android | `commitTime` capturava `editIndex` (state) via closure ANTES do re-render assíncrono | Refactor `commitTimeAt(idx, date)` recebe idx explícito do closure de `openEditor` |
| Sábado vazando tela | iOS | `paddingHorizontal: spacing[5]` interno + padding cumulativo do container = 52px cada lado, não cabe 7×40 | Removido padding interno; pai (FormSection) cuida |

## R-020 / R-022 / R-010 compliance
- `TimeSchedulePicker.stringToDate` + `useProtocolStats.load` usam `getNow()` de `@dosiq/core` (zero `new Date()` direto).
- `time_schedule.max(10)` respeitado pelo `maxItems` default do picker.
- Todos os hooks têm ordem States → Memos → Effects → Handlers (com exceção load/effect TDZ documentada inline).

## Testes
- ✅ Mobile jest: 148/148 (3 skipped pré-existentes).
- ✅ Web `validate:agent`: 530/530.
- ✅ Lint: 0 errors. Warnings pré-existentes color-literals/max-lines/complexity (R-221 SQP).
- ✅ Smoke PO iOS + Android via `TREATMENT_PRIMITIVES_DEMO` (Tab Hoje → DEV → "🧪 Primitivos T2.2") — todos os 3 primitivos OK após fixes.

## Próximos PRs Sprint T2.2
- **PR-B** (composição): T2.4 MedicineSelectorSheet · T2.5 PlanSelectField+PlanInlineCreate · T2.6 ProtocolFormScreen create.
- **PR-C** (refinamento): T2.7 edit · T2.8 errors UX · T2.11 ProtocolDeleteSheet (substitui Alert stub).

## Test plan
- [x] `cd apps/mobile && npx jest` → 148/148
- [x] `npm run validate:agent` (web) → 530/530
- [x] `rtk lint` arquivos novos → 0 errors
- [x] Smoke iOS WeekdaySelector + MedicineSelectorRow + TimeSchedulePicker
- [x] Smoke Android (incluindo picker imperativo)
- [ ] PO smoke Android API 24 (rn-screens stable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
