### PR TITLE
feat(mobile/treatments): Fase 2 T2.2 PR-B — Sheet + PlanField + ProtocolFormScreen CREATE

### DIFF
--- a/apps/mobile/src/features/_dev/screens/MedicineDemoScreen.jsx
+++ b/apps/mobile/src/features/_dev/screens/MedicineDemoScreen.jsx
@@ -36,6 +36,19 @@ export default function MedicineDemoScreen({ navigation }) {
           >
             <Text style={styles.buttonText}>🧪 WeekdaySelector + MedicineSelectorRow + TimeSchedulePicker</Text>
           </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => {
+              lightTap()
+              // ProtocolForm vive em TreatmentsStack → Tab Tratamentos
+              navigation?.navigate(ROUTES.TABS, {
+                screen: ROUTES.TREATMENTS,
+                params: { screen: ROUTES.PROTOCOL_FORM },
+              })
+            }}
+            style={styles.buttonCard}
+          >
+            <Text style={styles.buttonText}>📝 ProtocolFormScreen (CREATE) — composição completa T2.6</Text>
+          </TouchableOpacity>
         </View>
 
         {/* Seção 1 — Telas Sprint M1.1 */}

--- a/apps/mobile/src/features/treatments/components/MedicineSelectorSheet.jsx
+++ b/apps/mobile/src/features/treatments/components/MedicineSelectorSheet.jsx
@@ -5,7 +5,7 @@
 // Tap-and-close: tap no item → callback onSelect(medicine) + close.
 // Footer "+ Cadastrar novo medicamento" → callback onCreateNew (parent navega).
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   View,
   Text,
@@ -37,7 +37,7 @@ export default function MedicineSelectorSheet({
 }) {
   // States (R-010 — States → Memos → Effects → Handlers)
   const [query, setQuery] = useState('')
-  const { data, loading, error } = useMedicines()
+  const { data, loading, error, refresh } = useMedicines()
 
   // Memos
   const list = useMemo(() => Array.isArray(data) ? data : [], [data])
@@ -67,6 +67,11 @@ export default function MedicineSelectorSheet({
     if (trimmed) return `${filtered.length} de ${total} medicamentos`
     return `Biblioteca · ${total} ${total === 1 ? 'medicamento' : 'medicamentos'}`
   }, [loading, error, list.length, filtered.length, trimmed])
+
+  // Effects — refresh biblioteca toda vez que sheet abre (captura med recém-criado)
+  useEffect(() => {
+    if (open) refresh?.()
+  }, [open, refresh])
 
   // Handlers
   function handleClose() {

--- a/apps/mobile/src/features/treatments/components/MedicineSelectorSheet.jsx
+++ b/apps/mobile/src/features/treatments/components/MedicineSelectorSheet.jsx
@@ -1,0 +1,347 @@
+// MedicineSelectorSheet.jsx — bottom sheet busca medicamento na biblioteca do user.
+// Fase 2 T2.4. Spec §3.5. Análogo estrutural ao MedicineAnvisaSheet mas o dataset
+// vem de useMedicines() (biblioteca do user no Supabase, não ANVISA).
+//
+// Tap-and-close: tap no item → callback onSelect(medicine) + close.
+// Footer "+ Cadastrar novo medicamento" → callback onCreateNew (parent navega).
+
+import { useMemo, useState } from 'react'
+import {
+  View,
+  Text,
+  TextInput,
+  Modal,
+  Pressable,
+  FlatList,
+  StyleSheet,
+} from 'react-native'
+import { Search, X, Pill, PillBottle, Plus } from 'lucide-react-native'
+import { useMedicines } from '../../medications/hooks/useMedicines'
+import { selectionTap, lightTap } from '@shared/utils/haptics'
+import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
+
+// NFD normalize para busca case-/diacritics-insensitive (AP-157 — pré-computado).
+function normalize(s) {
+  return String(s || '')
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+}
+
+export default function MedicineSelectorSheet({
+  open,
+  onClose,
+  onSelect,
+  onCreateNew,
+  selectedId,
+}) {
+  // States (R-010 — States → Memos → Effects → Handlers)
+  const [query, setQuery] = useState('')
+  const { data, loading, error } = useMedicines()
+
+  // Memos
+  const list = useMemo(() => Array.isArray(data) ? data : [], [data])
+
+  // Pré-compute haystack normalizado para evitar normalize por keystroke (AP-157)
+  const indexed = useMemo(
+    () =>
+      list.map((m) => ({
+        item: m,
+        haystack: normalize(`${m.name || ''} ${m.active_ingredient || ''}`),
+      })),
+    [list]
+  )
+
+  const trimmed = query.trim()
+  const filtered = useMemo(() => {
+    if (!trimmed) return indexed.map((x) => x.item)
+    const q = normalize(trimmed)
+    return indexed.filter((x) => x.haystack.includes(q)).map((x) => x.item)
+  }, [indexed, trimmed])
+
+  const subtitle = useMemo(() => {
+    if (loading) return 'Carregando biblioteca…'
+    if (error) return error
+    const total = list.length
+    if (!total) return 'Biblioteca vazia'
+    if (trimmed) return `${filtered.length} de ${total} medicamentos`
+    return `Biblioteca · ${total} ${total === 1 ? 'medicamento' : 'medicamentos'}`
+  }, [loading, error, list.length, filtered.length, trimmed])
+
+  // Handlers
+  function handleClose() {
+    setQuery('')
+    onClose?.()
+  }
+
+  function handleSelect(item) {
+    selectionTap()
+    setQuery('')
+    onSelect?.(item)
+    onClose?.()
+  }
+
+  function handleCreateNew() {
+    lightTap()
+    setQuery('')
+    onClose?.()
+    onCreateNew?.()
+  }
+
+  function renderItem({ item }) {
+    const isSelected = item.id === selectedId
+    const isSupplement = item.type === 'suplemento'
+    const Icon = isSupplement ? PillBottle : Pill
+    const iconColor = isSupplement ? colors.supplement[500] : colors.primary[500]
+    const iconBg = isSupplement ? colors.supplement[50] : colors.primary[50]
+
+    return (
+      <Pressable
+        style={({ pressed }) => [
+          styles.item,
+          isSelected && styles.itemSelected,
+          pressed && styles.itemPressed,
+        ]}
+        onPress={() => handleSelect(item)}
+        accessibilityRole="button"
+        accessibilityLabel={`Selecionar ${item.name}`}
+        accessibilityState={{ selected: isSelected }}
+      >
+        <View style={[styles.itemIcon, { backgroundColor: iconBg }]}>
+          <Icon size={20} color={iconColor} strokeWidth={2} />
+        </View>
+        <View style={styles.itemText}>
+          <View style={styles.itemHeader}>
+            <Text style={styles.itemName} numberOfLines={1}>
+              {item.name}
+            </Text>
+            {item.dosage_per_pill ? (
+              <View style={styles.dosagePill}>
+                <Text style={styles.dosagePillText}>
+                  {item.dosage_per_pill}{item.dosage_unit || ''}
+                </Text>
+              </View>
+            ) : null}
+          </View>
+          {item.active_ingredient ? (
+            <Text style={styles.itemSub} numberOfLines={1}>
+              {item.active_ingredient}
+            </Text>
+          ) : null}
+        </View>
+        <View style={[styles.radio, isSelected && styles.radioSelected]} />
+      </Pressable>
+    )
+  }
+
+  return (
+    <Modal visible={!!open} transparent animationType="slide" onRequestClose={handleClose}>
+      <View style={styles.root}>
+        <Pressable style={styles.backdrop} onPress={handleClose} />
+        <View style={styles.sheet}>
+          <View style={styles.handle} />
+          <Text style={styles.title}>Escolher medicamento</Text>
+
+          <View style={styles.searchBox}>
+            <Search size={18} color={colors.text.muted} strokeWidth={2} />
+            <TextInput
+              style={styles.searchInput}
+              value={query}
+              onChangeText={setQuery}
+              placeholder="Buscar em medicamentos…"
+              placeholderTextColor={colors.text.muted}
+              autoCorrect={false}
+              autoCapitalize="none"
+              returnKeyType="search"
+              accessibilityLabel="Buscar medicamento na biblioteca"
+            />
+            {query ? (
+              <Pressable
+                onPress={() => setQuery('')}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel="Limpar busca"
+              >
+                <X size={18} color={colors.text.muted} strokeWidth={2} />
+              </Pressable>
+            ) : null}
+          </View>
+
+          <Text style={styles.subtitle}>{subtitle}</Text>
+
+          <FlatList
+            data={filtered}
+            keyExtractor={(item) => item.id}
+            renderItem={renderItem}
+            keyboardShouldPersistTaps="handled"
+            keyboardDismissMode="on-drag"
+            contentContainerStyle={styles.listContent}
+            ListEmptyComponent={
+              !loading && !error ? (
+                <Text style={styles.empty}>
+                  {trimmed ? 'Nenhum medicamento encontrado.' : 'Nenhum medicamento cadastrado ainda.'}
+                </Text>
+              ) : null
+            }
+          />
+
+          <Pressable
+            onPress={handleCreateNew}
+            style={({ pressed }) => [styles.footerBtn, pressed && styles.footerBtnPressed]}
+            accessibilityRole="button"
+            accessibilityLabel="Cadastrar novo medicamento"
+          >
+            <Plus size={18} color={colors.primary[700]} />
+            <Text style={styles.footerBtnText}>Cadastrar novo medicamento</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: colors.bg.overlay,
+  },
+  sheet: {
+    backgroundColor: colors.bg.card,
+    borderTopLeftRadius: borderRadius.xl,
+    borderTopRightRadius: borderRadius.xl,
+    padding: spacing[5],
+    maxHeight: '85%',
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 40,
+    height: 4,
+    borderRadius: borderRadius.full,
+    backgroundColor: colors.neutral[300],
+    marginBottom: spacing[3],
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.text.primary,
+    marginBottom: spacing[3],
+    fontFamily: typography.fontFamily.bold,
+  },
+  searchBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    height: 44,
+    paddingHorizontal: spacing[3],
+    backgroundColor: colors.neutral[100],
+    borderRadius: borderRadius.md,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 15,
+    color: colors.text.primary,
+    padding: 0,
+  },
+  subtitle: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: colors.text.muted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+    marginTop: spacing[3],
+    marginBottom: spacing[2],
+  },
+  listContent: {
+    paddingBottom: spacing[4],
+  },
+  empty: {
+    fontSize: 13,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    paddingVertical: spacing[6],
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    padding: spacing[3],
+    marginBottom: spacing[2],
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.bg.card,
+  },
+  itemSelected: {
+    backgroundColor: colors.primary[50],
+  },
+  itemPressed: {
+    opacity: 0.7,
+  },
+  itemIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: borderRadius.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  itemText: {
+    flex: 1,
+    gap: 2,
+  },
+  itemHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  itemName: {
+    flexShrink: 1,
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.text.primary,
+  },
+  itemSub: {
+    fontSize: 13,
+    color: colors.text.secondary,
+  },
+  dosagePill: {
+    backgroundColor: colors.neutral[100],
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    borderRadius: 4,
+  },
+  dosagePillText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.neutral[700],
+  },
+  radio: {
+    width: 20,
+    height: 20,
+    borderRadius: borderRadius.full,
+    backgroundColor: colors.neutral[100],
+  },
+  radioSelected: {
+    backgroundColor: colors.primary[500],
+  },
+  footerBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[2],
+    paddingVertical: spacing[3],
+    marginTop: spacing[2],
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.primary[50],
+  },
+  footerBtnPressed: {
+    opacity: 0.7,
+  },
+  footerBtnText: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.primary[700],
+    fontFamily: typography.fontFamily.bold,
+  },
+})

--- a/apps/mobile/src/features/treatments/components/MedicineSelectorSheet.jsx
+++ b/apps/mobile/src/features/treatments/components/MedicineSelectorSheet.jsx
@@ -159,6 +159,7 @@ export default function MedicineSelectorSheet({
               autoCapitalize="none"
               returnKeyType="search"
               accessibilityLabel="Buscar medicamento na biblioteca"
+              maxLength={100}
             />
             {query ? (
               <Pressable

--- a/apps/mobile/src/features/treatments/components/PlanSelectField.jsx
+++ b/apps/mobile/src/features/treatments/components/PlanSelectField.jsx
@@ -129,6 +129,7 @@ export default function PlanSelectField({
         placeholderTextColor={colors.text.muted}
         style={styles.inlineInput}
         autoCapitalize="words"
+        maxLength={50}
       />
 
       <Text style={styles.inlineLabel}>Cor</Text>

--- a/apps/mobile/src/features/treatments/components/PlanSelectField.jsx
+++ b/apps/mobile/src/features/treatments/components/PlanSelectField.jsx
@@ -92,7 +92,7 @@ export default function PlanSelectField({
     return (
       <FormSelect
         name="treatment_plan"
-        label="Plano terapêutico"
+        label="plano terapêutico"
         value={value.planId}
         options={options}
         onChange={handleSelectChange}

--- a/apps/mobile/src/features/treatments/components/PlanSelectField.jsx
+++ b/apps/mobile/src/features/treatments/components/PlanSelectField.jsx
@@ -1,0 +1,286 @@
+// PlanSelectField.jsx — seletor de plano terapêutico com 2 variações (Fase 2 T2.5).
+// Spec §3.4 seção "ORGANIZAÇÃO".
+//
+// Modo SELECT (default): FormSelect com planos existentes + opção especial
+// "+ Criar novo" no fim → muda para modo INLINE.
+//
+// Modo INLINE (PlanInlineCreate): card primaryBg com input "Nome" + paleta de
+// cores (5 swatches) + paleta de emojis (6). Header tem link "Usar existente ↗"
+// para voltar ao modo SELECT.
+//
+// Componente controlado:
+//   value: { mode: 'select' | 'inline', planId?: string, inline?: { name, color, emoji } }
+//   onChange: (newValue) => void
+//
+// Parent decide o que fazer no submit: se mode='inline' + inline.name preenchido,
+// chamar treatmentPlanService.create({ name, color, emoji }) ANTES do protocolService.create.
+
+import { useCallback } from 'react'
+import { View, Text, TextInput, Pressable, StyleSheet } from 'react-native'
+import { Check, ArrowUpRight } from 'lucide-react-native'
+import FormSelect from '@shared/components/form/FormSelect'
+import { selectionTap, lightTap } from '@shared/utils/haptics'
+import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
+
+const CREATE_NEW_VALUE = '__create_new__'
+
+// Paleta sugerida (5 cores) — preferir tokens, mas paleta inline é PT-spec
+// (não há "plan-color" no design tokens; cores escolhidas para boa diferenciação).
+const COLOR_SWATCHES = [
+  { id: 'teal', value: '#14b8a6' },
+  { id: 'blue', value: '#3b82f6' },
+  { id: 'purple', value: '#8b5cf6' },
+  { id: 'orange', value: '#f97316' },
+  { id: 'rose', value: '#f43f5e' },
+]
+
+const EMOJI_CHOICES = ['💊', '🌿', '❤️', '🧠', '🔬', '✨']
+
+export default function PlanSelectField({
+  plans = [],
+  value = { mode: 'select', planId: null, inline: null },
+  onChange,
+  error,
+}) {
+  // Handlers
+  const handleSelectChange = useCallback(
+    (_name, planId) => {
+      if (planId === CREATE_NEW_VALUE) {
+        // Alternar para modo inline com defaults
+        onChange?.({
+          mode: 'inline',
+          planId: null,
+          inline: {
+            name: '',
+            color: COLOR_SWATCHES[0].value,
+            emoji: EMOJI_CHOICES[0],
+          },
+        })
+      } else {
+        onChange?.({ mode: 'select', planId: planId || null, inline: null })
+      }
+    },
+    [onChange]
+  )
+
+  const handleBackToSelect = useCallback(() => {
+    lightTap()
+    onChange?.({ mode: 'select', planId: null, inline: null })
+  }, [onChange])
+
+  const handleInlineChange = useCallback(
+    (patch) => {
+      onChange?.({
+        mode: 'inline',
+        planId: null,
+        inline: { ...value.inline, ...patch },
+      })
+    },
+    [onChange, value.inline]
+  )
+
+  // Render — modo SELECT
+  if (value.mode !== 'inline') {
+    const options = [
+      ...plans.map((p) => ({
+        value: p.id,
+        label: `${p.emoji ? `${p.emoji} ` : ''}${p.name}`,
+      })),
+      { value: CREATE_NEW_VALUE, label: '+ Criar novo plano' },
+    ]
+
+    return (
+      <FormSelect
+        name="treatment_plan"
+        label="Plano terapêutico"
+        value={value.planId}
+        options={options}
+        onChange={handleSelectChange}
+        error={error}
+        placeholder={plans.length ? 'Selecione um plano' : 'Sem planos cadastrados'}
+      />
+    )
+  }
+
+  // Render — modo INLINE
+  const inline = value.inline ?? { name: '', color: COLOR_SWATCHES[0].value, emoji: EMOJI_CHOICES[0] }
+
+  return (
+    <View style={[styles.inlineCard, error && styles.inlineCardError]}>
+      <View style={styles.inlineHeader}>
+        <Text style={styles.inlineTitle}>Criar novo plano</Text>
+        <Pressable
+          onPress={handleBackToSelect}
+          style={({ pressed }) => [styles.switchBtn, pressed && styles.switchBtnPressed]}
+          accessibilityRole="button"
+          accessibilityLabel="Usar plano existente"
+          hitSlop={6}
+        >
+          <Text style={styles.switchBtnText}>Usar existente</Text>
+          <ArrowUpRight size={14} color={colors.primary[700]} />
+        </Pressable>
+      </View>
+
+      <Text style={styles.inlineLabel}>Nome</Text>
+      <TextInput
+        value={inline.name}
+        onChangeText={(name) => handleInlineChange({ name })}
+        placeholder="Ex: Ansiolíticos"
+        placeholderTextColor={colors.text.muted}
+        style={styles.inlineInput}
+        autoCapitalize="words"
+      />
+
+      <Text style={styles.inlineLabel}>Cor</Text>
+      <View style={styles.swatchRow}>
+        {COLOR_SWATCHES.map((c) => {
+          const isSelected = inline.color === c.value
+          return (
+            <Pressable
+              key={c.id}
+              onPress={() => {
+                selectionTap()
+                handleInlineChange({ color: c.value })
+              }}
+              style={({ pressed }) => [
+                styles.swatch,
+                { backgroundColor: c.value },
+                isSelected && styles.swatchSelected,
+                pressed && styles.swatchPressed,
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`Selecionar cor ${c.id}`}
+              accessibilityState={{ selected: isSelected }}
+            >
+              {isSelected ? <Check size={18} color={colors.text.inverse} strokeWidth={3} /> : null}
+            </Pressable>
+          )
+        })}
+      </View>
+
+      <Text style={styles.inlineLabel}>Emoji</Text>
+      <View style={styles.emojiRow}>
+        {EMOJI_CHOICES.map((e) => {
+          const isSelected = inline.emoji === e
+          return (
+            <Pressable
+              key={e}
+              onPress={() => {
+                selectionTap()
+                handleInlineChange({ emoji: e })
+              }}
+              style={({ pressed }) => [
+                styles.emojiBtn,
+                isSelected && styles.emojiBtnSelected,
+                pressed && styles.emojiBtnPressed,
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`Selecionar emoji ${e}`}
+              accessibilityState={{ selected: isSelected }}
+            >
+              <Text style={styles.emojiText}>{e}</Text>
+            </Pressable>
+          )
+        })}
+      </View>
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  inlineCard: {
+    backgroundColor: colors.primary[50],
+    borderRadius: borderRadius.lg,
+    padding: spacing[4],
+    gap: spacing[3],
+  },
+  inlineCardError: {
+    backgroundColor: colors.neutral[100],
+  },
+  inlineHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  inlineTitle: {
+    fontSize: 15,
+    fontWeight: '800',
+    color: colors.text.primary,
+    fontFamily: typography.fontFamily.bold,
+  },
+  switchBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  switchBtnPressed: {
+    opacity: 0.6,
+  },
+  switchBtnText: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: colors.primary[700],
+    fontFamily: typography.fontFamily.bold,
+  },
+  inlineLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: colors.text.secondary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+  inlineInput: {
+    backgroundColor: colors.bg.card,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[3],
+    fontSize: 15,
+    color: colors.text.primary,
+  },
+  swatchRow: {
+    flexDirection: 'row',
+    gap: spacing[3],
+  },
+  swatch: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  swatchSelected: {
+    borderWidth: 2.5,
+    borderColor: colors.bg.card,
+  },
+  swatchPressed: {
+    opacity: 0.85,
+  },
+  emojiRow: {
+    flexDirection: 'row',
+    gap: spacing[2],
+    flexWrap: 'wrap',
+  },
+  emojiBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bg.card,
+  },
+  emojiBtnSelected: {
+    backgroundColor: colors.primary[100],
+  },
+  emojiBtnPressed: {
+    opacity: 0.7,
+  },
+  emojiText: {
+    fontSize: 22,
+  },
+  error: {
+    fontSize: 12,
+    color: colors.status.error,
+  },
+})

--- a/apps/mobile/src/features/treatments/hooks/_treatmentsTransformer.js
+++ b/apps/mobile/src/features/treatments/hooks/_treatmentsTransformer.js
@@ -1,18 +1,13 @@
-import { getTodayLocal, isProtocolActiveOnDate } from '@dosiq/core'
+// isProtocolInPeriod (period-only) em vez de isProtocolActiveOnDate (strict
+// adherence-aware). Listagem agrupada inclui quando_necessário, semanal, etc.
+import { getTodayLocal, isProtocolInPeriod } from '@dosiq/core'
 
 export function groupTreatmentsByPlanOrClass(data) {
   if (!data) return null
   const today = getTodayLocal()
 
   const validProtocols = data
-    .filter(p => {
-      const active = isProtocolActiveOnDate(p, today)
-      if (__DEV__ && !active) {
-        // eslint-disable-next-line no-console
-        console.log(`[transformer] DROPPED ${p.name}: today=${today} start=${p.start_date} end=${p.end_date}`)
-      }
-      return active
-    })
+    .filter(p => isProtocolInPeriod(p, today))
     .sort((a, b) => {
       const timeA = (a.time_schedule && a.time_schedule[0]) || '99:99'
       const timeB = (b.time_schedule && b.time_schedule[0]) || '99:99'

--- a/apps/mobile/src/features/treatments/hooks/_treatmentsTransformer.js
+++ b/apps/mobile/src/features/treatments/hooks/_treatmentsTransformer.js
@@ -5,7 +5,14 @@ export function groupTreatmentsByPlanOrClass(data) {
   const today = getTodayLocal()
 
   const validProtocols = data
-    .filter(p => isProtocolActiveOnDate(p, today))
+    .filter(p => {
+      const active = isProtocolActiveOnDate(p, today)
+      if (__DEV__ && !active) {
+        // eslint-disable-next-line no-console
+        console.log(`[transformer] DROPPED ${p.name}: today=${today} start=${p.start_date} end=${p.end_date}`)
+      }
+      return active
+    })
     .sort((a, b) => {
       const timeA = (a.time_schedule && a.time_schedule[0]) || '99:99'
       const timeB = (b.time_schedule && b.time_schedule[0]) || '99:99'

--- a/apps/mobile/src/features/treatments/hooks/useTreatments.js
+++ b/apps/mobile/src/features/treatments/hooks/useTreatments.js
@@ -34,10 +34,19 @@ export function useTreatments() {
       if (authError || !user) throw new Error('Sessão expirada.')
 
       const result = await getActiveTreatments(user.id)
-      
+
       if (!result.success) throw new Error(result.error)
 
       const newData = result.data
+      if (__DEV__) {
+        debugLog('useTreatments', `RAW: ${newData?.length ?? 0} protocols from supabase`)
+        newData?.forEach((p) => {
+          debugLog(
+            'useTreatments',
+            `  - ${p.name} | active=${p.active} | start=${p.start_date} | end=${p.end_date} | plan_id=${p.treatment_plan?.id ?? 'null'} (${p.treatment_plan?.name ?? 'no-join'})`
+          )
+        })
+      }
       const today = getTodayLocal()
       const snapshot = {
         data: newData,

--- a/apps/mobile/src/features/treatments/hooks/useTreatments.js
+++ b/apps/mobile/src/features/treatments/hooks/useTreatments.js
@@ -38,15 +38,6 @@ export function useTreatments() {
       if (!result.success) throw new Error(result.error)
 
       const newData = result.data
-      if (__DEV__) {
-        debugLog('useTreatments', `RAW: ${newData?.length ?? 0} protocols from supabase`)
-        newData?.forEach((p) => {
-          debugLog(
-            'useTreatments',
-            `  - ${p.name} | active=${p.active} | start=${p.start_date} | end=${p.end_date} | plan_id=${p.treatment_plan?.id ?? 'null'} (${p.treatment_plan?.name ?? 'no-join'})`
-          )
-        })
-      }
       const today = getTodayLocal()
       const snapshot = {
         data: newData,

--- a/apps/mobile/src/features/treatments/screens/ProtocolDetailScreen.jsx
+++ b/apps/mobile/src/features/treatments/screens/ProtocolDetailScreen.jsx
@@ -223,7 +223,7 @@ export default function ProtocolDetailScreen() {
 
         {/* Dosagem & Frequência */}
         <SectionCard title="DOSAGEM & FREQUÊNCIA">
-          <DetailRow label="Dose por tomada" value={formatDoseUnit(protocol.dosage_per_intake, medicine?.dosage_unit)} />
+          <DetailRow label="Dose por tomada" value={formatDoseUnit(protocol.dosage_per_intake)} />
           <DetailRow label="Frequência" value={frequencyLabel} />
           {protocol.time_schedule?.length > 0 ? (
             <View style={styles.scheduleBlock}>
@@ -239,7 +239,7 @@ export default function ProtocolDetailScreen() {
             </View>
           ) : null}
           {dailyIntakeTotal !== null ? (
-            <DetailRow label="Consumo diário" value={formatDoseUnit(dailyIntakeTotal, medicine?.dosage_unit)} />
+            <DetailRow label="Consumo diário" value={formatDoseUnit(dailyIntakeTotal)} />
           ) : null}
         </SectionCard>
 

--- a/apps/mobile/src/features/treatments/screens/ProtocolFormScreen.jsx
+++ b/apps/mobile/src/features/treatments/screens/ProtocolFormScreen.jsx
@@ -13,7 +13,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { View, Text, ScrollView, Pressable, StyleSheet, KeyboardAvoidingView, Platform } from 'react-native'
-import { useNavigation, useRoute } from '@react-navigation/native'
+import { useNavigation, useRoute, useFocusEffect } from '@react-navigation/native'
 import { ArrowLeft } from 'lucide-react-native'
 import {
   protocolCreateSchema,
@@ -85,6 +85,9 @@ export default function ProtocolFormScreen() {
   // Sidecar state — UI-only (não vai pro schema)
   const [medicine, setMedicine] = useState(null) // objeto completo do medicamento selecionado
   const [sheetOpen, setSheetOpen] = useState(false)
+  // Flag para reabrir o sheet ao voltar de MedicineFormScreen (UX: foco continua
+  // no contexto de selecionar medicamento; sheet recarrega lista e mostra novo).
+  const [pendingReopenSheet, setPendingReopenSheet] = useState(false)
   const [plans, setPlans] = useState([])
   const [planField, setPlanField] = useState(() => ({
     mode: 'select',
@@ -109,6 +112,16 @@ export default function ProtocolFormScreen() {
   const endDateAsDate = useMemo(
     () => (form.values.end_date ? parseLocalDate(form.values.end_date) : null),
     [form.values.end_date]
+  )
+
+  // Effects — reabrir sheet ao retornar de MedicineFormScreen
+  useFocusEffect(
+    useCallback(() => {
+      if (pendingReopenSheet) {
+        setPendingReopenSheet(false)
+        setSheetOpen(true)
+      }
+    }, [pendingReopenSheet])
   )
 
   // Effects — carregar planos terapêuticos para o seletor
@@ -149,6 +162,7 @@ export default function ProtocolFormScreen() {
   const handleCloseSheet = useCallback(() => setSheetOpen(false), [])
 
   const handleCreateNewMedicine = useCallback(() => {
+    setPendingReopenSheet(true)
     navigation.navigate(ROUTES.MEDICINE_CREATE)
   }, [navigation])
 

--- a/apps/mobile/src/features/treatments/screens/ProtocolFormScreen.jsx
+++ b/apps/mobile/src/features/treatments/screens/ProtocolFormScreen.jsx
@@ -1,73 +1,449 @@
-// ProtocolFormScreen.jsx — stub Fase 2 Sprint T2.1 (Read screens only).
-// Implementação completa em Sprint T2.2 (T2.6 da spec).
-// Aqui apenas para registrar rota e evitar runtime crash.
+// ProtocolFormScreen.jsx — formulário CREATE de tratamento (Fase 2 T2.6).
+// Spec EXEC_SPEC_FASE2_PROTOCOLOS.md §3.4.
+//
+// v1 PR-B (Sprint T2.2): apenas CREATE mode. Edit (T2.7) e ProtocolFormErrors
+// UX banner (T2.8) entram em PR-C. ProtocolDeleteSheet (T2.11) substitui o
+// Alert stub do ProtocolDetailScreen no mesmo PR-C.
+//
+// Composição: MedicineSelectorRow + MedicineSelectorSheet + FormInput + FormSelect
+// + WeekdaySelector + TimeSchedulePicker + FormDatePicker + PlanSelectField +
+// FormActions. Validação via useFormState(protocolCreateSchema). Submit:
+// se PlanSelectField está em modo inline com nome preenchido, cria o plano
+// via treatmentPlanService.create ANTES de criar o tratamento.
 
-import { View, Text, StyleSheet, Pressable } from 'react-native'
-import { useNavigation } from '@react-navigation/native'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { View, Text, ScrollView, Pressable, StyleSheet, KeyboardAvoidingView, Platform } from 'react-native'
+import { useNavigation, useRoute } from '@react-navigation/native'
 import { ArrowLeft } from 'lucide-react-native'
+import {
+  protocolCreateSchema,
+  FREQUENCIES,
+  getTodayLocal,
+  parseLocalDate,
+  formatLocalDate,
+  pluralizeDoseUnit,
+} from '@dosiq/core'
 import ScreenContainer from '@shared/components/ui/ScreenContainer'
+import FormInput from '@shared/components/form/FormInput'
+import FormSelect from '@shared/components/form/FormSelect'
+import FormDatePicker from '@shared/components/form/FormDatePicker'
+import FormActions from '@shared/components/form/FormActions'
+import { useFormState } from '@shared/hooks/useFormState'
+import { useToast } from '@shared/components/feedback/Toast'
+import { lightTap } from '@shared/utils/haptics'
 import { colors, spacing, typography } from '@shared/styles/tokens'
+import MedicineSelectorRow from '@treatments/components/MedicineSelectorRow'
+import MedicineSelectorSheet from '@treatments/components/MedicineSelectorSheet'
+import WeekdaySelector from '@treatments/components/WeekdaySelector'
+import TimeSchedulePicker from '@treatments/components/TimeSchedulePicker'
+import PlanSelectField from '@treatments/components/PlanSelectField'
+import { treatmentPlanService } from '@treatments/services/treatmentPlanService'
+import { useProtocolMutation } from '@treatments/hooks/useProtocolMutation'
+import { ROUTES } from '@navigation/routes'
+
+const FREQUENCY_OPTIONS = [
+  { value: 'diário', label: 'Diário' },
+  { value: 'dias_alternados', label: 'Dias alternados' },
+  { value: 'semanal', label: 'Semanal' },
+  { value: 'personalizado', label: 'Personalizado' },
+  { value: 'quando_necessário', label: 'Quando necessário' },
+]
+
+const REQUIRES_WEEKDAYS = new Set(['semanal', 'personalizado'])
+
+function buildInitialValues({ todayIso, presetPlanId }) {
+  return {
+    medicine_id: '',
+    name: '',
+    dosage_per_intake: '',
+    frequency: 'diário',
+    weekdays: [],
+    time_schedule: [],
+    start_date: todayIso,
+    end_date: null,
+    notes: '',
+    active: true,
+    titration_status: 'estável',
+    titration_schedule: [],
+    current_stage_index: 0,
+    treatment_plan_id: presetPlanId || null,
+  }
+}
 
 export default function ProtocolFormScreen() {
+  // States (R-010 — States → Memos → Effects → Handlers)
   const navigation = useNavigation()
+  const route = useRoute()
+  const presetPlanId = route.params?.treatment_plan_id ?? null
+  const todayIso = useMemo(() => getTodayLocal(), [])
+  const { show } = useToast()
+
+  const form = useFormState(protocolCreateSchema, {
+    initialValues: buildInitialValues({ todayIso, presetPlanId }),
+  })
+
+  // Sidecar state — UI-only (não vai pro schema)
+  const [medicine, setMedicine] = useState(null) // objeto completo do medicamento selecionado
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const [plans, setPlans] = useState([])
+  const [planField, setPlanField] = useState(() => ({
+    mode: 'select',
+    planId: presetPlanId || null,
+    inline: null,
+  }))
+  const [submitting, setSubmitting] = useState(false)
+
+  const mutation = useProtocolMutation()
+
+  // Memos
+  const showWeekdays = REQUIRES_WEEKDAYS.has(form.values.frequency)
+  const doseSuffix = useMemo(
+    () => pluralizeDoseUnit(form.values.dosage_per_intake || 0, medicine?.dosage_unit),
+    [form.values.dosage_per_intake, medicine]
+  )
+
+  const startDateAsDate = useMemo(
+    () => (form.values.start_date ? parseLocalDate(form.values.start_date) : null),
+    [form.values.start_date]
+  )
+  const endDateAsDate = useMemo(
+    () => (form.values.end_date ? parseLocalDate(form.values.end_date) : null),
+    [form.values.end_date]
+  )
+
+  // Effects — carregar planos terapêuticos para o seletor
+  useEffect(() => {
+    let cancelled = false
+    treatmentPlanService
+      .getAll()
+      .then((list) => {
+        if (!cancelled) setPlans(Array.isArray(list) ? list : [])
+      })
+      .catch(() => {
+        if (!cancelled) setPlans([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Handlers
+  const goBack = useCallback(() => {
+    lightTap()
+    navigation.goBack()
+  }, [navigation])
+
+  const handleSelectMedicine = useCallback(
+    (med) => {
+      setMedicine(med)
+      form.handleChange('medicine_id', med.id)
+    },
+    [form]
+  )
+
+  const handleOpenSheet = useCallback(() => {
+    lightTap()
+    setSheetOpen(true)
+  }, [])
+
+  const handleCloseSheet = useCallback(() => setSheetOpen(false), [])
+
+  const handleCreateNewMedicine = useCallback(() => {
+    navigation.navigate(ROUTES.MEDICINE_CREATE)
+  }, [navigation])
+
+  const handleDoseChange = useCallback(
+    (name, raw) => {
+      // Normaliza vírgula → ponto para Number parsing (Hermes-safe)
+      const normalized = String(raw ?? '').replace(',', '.')
+      const num = normalized === '' ? '' : Number(normalized)
+      form.handleChange(name, Number.isFinite(num) ? num : '')
+    },
+    [form]
+  )
+
+  const handleStartDateChange = useCallback(
+    (_name, date) => {
+      form.handleChange('start_date', date ? formatLocalDate(date) : null)
+    },
+    [form]
+  )
+
+  const handleEndDateChange = useCallback(
+    (_name, date) => {
+      form.handleChange('end_date', date ? formatLocalDate(date) : null)
+    },
+    [form]
+  )
+
+  const handlePlanFieldChange = useCallback(
+    (next) => {
+      setPlanField(next)
+      form.handleChange('treatment_plan_id', next.mode === 'select' ? next.planId : null)
+    },
+    [form]
+  )
+
+  const handleSubmit = useCallback(async () => {
+    if (submitting) return
+    // Validação Zod com refinements cross-campo (AP-156)
+    const ok = form.validate()
+    if (!ok) {
+      show('Verifique os campos destacados', { variant: 'error' })
+      return
+    }
+    setSubmitting(true)
+    try {
+      // Se modo inline preenchido, criar plano antes
+      let planId = form.values.treatment_plan_id || null
+      if (planField.mode === 'inline' && planField.inline?.name?.trim()) {
+        const created = await treatmentPlanService.create({
+          name: planField.inline.name.trim(),
+          color: planField.inline.color,
+          emoji: planField.inline.emoji,
+        })
+        planId = created?.id ?? null
+      }
+
+      const payload = {
+        ...form.values,
+        treatment_plan_id: planId,
+      }
+
+      const result = await mutation.create(payload, { goBack: true })
+      if (!result) setSubmitting(false)
+    } catch (err) {
+      setSubmitting(false)
+      show(err?.message ?? 'Erro ao criar tratamento', { variant: 'error' })
+    }
+  }, [form, planField, mutation, submitting, show])
+
+  const handleCancel = useCallback(() => {
+    lightTap()
+    navigation.goBack()
+  }, [navigation])
+
   return (
     <ScreenContainer>
       <View style={styles.appbar}>
-        <Pressable
-          onPress={() => navigation.goBack()}
-          style={styles.back}
-          accessibilityRole="button"
-          accessibilityLabel="Voltar"
-          hitSlop={12}
-        >
+        <Pressable onPress={goBack} style={styles.iconBtn} accessibilityRole="button" accessibilityLabel="Voltar" hitSlop={12}>
           <ArrowLeft size={24} color={colors.text.primary} />
         </Pressable>
-        <Text style={styles.title}>Novo tratamento</Text>
+        <Text style={styles.appbarTitle}>Novo tratamento</Text>
+        <View style={styles.appbarSpacer} />
       </View>
 
-      <View style={styles.body}>
-        <Text style={styles.placeholder}>Em construção</Text>
-        <Text style={styles.placeholderHint}>
-          Formulário completo chega no próximo sprint (T2.2).
-        </Text>
-      </View>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 60 : 0}
+      >
+        <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
+          {/* MEDICAMENTO */}
+          <Section title="Medicamento">
+            <MedicineSelectorRow
+              medicine={medicine}
+              onPress={handleOpenSheet}
+              error={form.touched.medicine_id ? form.errors.medicine_id : null}
+            />
+          </Section>
+
+          {/* INFORMAÇÕES BÁSICAS */}
+          <Section title="Informações básicas">
+            <FormInput
+              name="name"
+              label="Nome do tratamento"
+              value={form.values.name}
+              error={form.touched.name ? form.errors.name : null}
+              onChange={form.handleChange}
+              onBlur={form.handleBlur}
+              placeholder="Ex: SeloZok manhã/noite"
+              required
+            />
+            <FormInput
+              name="dosage_per_intake"
+              label="Dose por tomada"
+              value={form.values.dosage_per_intake === '' ? '' : String(form.values.dosage_per_intake).replace('.', ',')}
+              error={form.touched.dosage_per_intake ? form.errors.dosage_per_intake : null}
+              onChange={handleDoseChange}
+              onBlur={form.handleBlur}
+              placeholder="0"
+              keyboardType="decimal-pad"
+              helperText={`Unidade: ${doseSuffix}`}
+              required
+            />
+          </Section>
+
+          {/* FREQUÊNCIA */}
+          <Section title="Frequência">
+            <FormSelect
+              name="frequency"
+              label="Periodicidade"
+              value={form.values.frequency}
+              options={FREQUENCY_OPTIONS}
+              onChange={form.handleChange}
+              onBlur={form.handleBlur}
+              error={form.touched.frequency ? form.errors.frequency : null}
+              required
+            />
+            {showWeekdays ? (
+              <View style={styles.fieldBlock}>
+                <Text style={styles.fieldLabel}>Dias da semana</Text>
+                <WeekdaySelector
+                  value={form.values.weekdays}
+                  onChange={(next) => form.handleChange('weekdays', next)}
+                  error={form.touched.weekdays ? form.errors.weekdays : null}
+                />
+              </View>
+            ) : null}
+            <View style={styles.fieldBlock}>
+              <Text style={styles.fieldLabel}>Horários</Text>
+              <TimeSchedulePicker
+                value={form.values.time_schedule}
+                onChange={(next) => form.handleChange('time_schedule', next)}
+                error={form.touched.time_schedule ? form.errors.time_schedule : null}
+              />
+            </View>
+          </Section>
+
+          {/* PERÍODO */}
+          <Section title="Período">
+            <View style={styles.dateRow}>
+              <View style={styles.flex}>
+                <FormDatePicker
+                  name="start_date"
+                  label="Início"
+                  value={startDateAsDate}
+                  onChange={handleStartDateChange}
+                  error={form.touched.start_date ? form.errors.start_date : null}
+                />
+              </View>
+              <View style={styles.flex}>
+                <FormDatePicker
+                  name="end_date"
+                  label="Término"
+                  value={endDateAsDate}
+                  onChange={handleEndDateChange}
+                  error={form.touched.end_date ? form.errors.end_date : null}
+                  helperText="Sem prazo = uso contínuo"
+                  minimumDate={startDateAsDate}
+                />
+              </View>
+            </View>
+          </Section>
+
+          {/* ORGANIZAÇÃO */}
+          <Section title="Organização">
+            <PlanSelectField
+              plans={plans}
+              value={planField}
+              onChange={handlePlanFieldChange}
+              error={form.touched.treatment_plan_id ? form.errors.treatment_plan_id : null}
+            />
+          </Section>
+
+          {/* OBSERVAÇÕES */}
+          <Section title="Observações">
+            <FormInput
+              name="notes"
+              label="Notas"
+              value={form.values.notes}
+              error={form.touched.notes ? form.errors.notes : null}
+              onChange={form.handleChange}
+              onBlur={form.handleBlur}
+              placeholder="Notas sobre este tratamento…"
+              multiline
+              numberOfLines={4}
+              helperText="Opcional"
+            />
+          </Section>
+
+          <View style={styles.bottomSpacer} />
+        </ScrollView>
+
+        <FormActions
+          primaryLabel="Criar tratamento"
+          onPrimary={handleSubmit}
+          primaryLoading={submitting || mutation.isLoading}
+          secondaryLabel="Cancelar"
+          onSecondary={handleCancel}
+        />
+      </KeyboardAvoidingView>
+
+      <MedicineSelectorSheet
+        open={sheetOpen}
+        onClose={handleCloseSheet}
+        onSelect={handleSelectMedicine}
+        onCreateNew={handleCreateNewMedicine}
+        selectedId={medicine?.id}
+      />
     </ScreenContainer>
   )
 }
 
+function Section({ title, children }) {
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      <View style={styles.sectionBody}>{children}</View>
+    </View>
+  )
+}
+
 const styles = StyleSheet.create({
+  flex: { flex: 1 },
   appbar: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: spacing[3],
-    paddingHorizontal: spacing[4],
-    paddingTop: spacing[2],
-    paddingBottom: spacing[4],
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    gap: spacing[2],
   },
-  back: {
+  iconBtn: {
     padding: spacing[1],
   },
-  title: {
-    fontSize: 20,
+  appbarTitle: {
+    flex: 1,
+    fontSize: 18,
     fontWeight: '700',
     color: colors.text.primary,
     fontFamily: typography.fontFamily.bold,
   },
-  body: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: spacing[6],
+  scroll: {
+    paddingHorizontal: spacing[5],
+    paddingTop: spacing[3],
+    paddingBottom: spacing[6],
+    gap: spacing[5],
   },
-  placeholder: {
-    fontSize: 18,
+  section: {
+    gap: spacing[2],
+  },
+  sectionTitle: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: colors.text.secondary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+  sectionBody: {
+    gap: spacing[3],
+  },
+  fieldBlock: {
+    gap: spacing[2],
+  },
+  fieldLabel: {
+    fontSize: 13,
     fontWeight: '700',
     color: colors.text.primary,
-    marginBottom: spacing[2],
   },
-  placeholderHint: {
-    fontSize: 14,
-    color: colors.text.secondary,
-    textAlign: 'center',
+  dateRow: {
+    flexDirection: 'row',
+    gap: spacing[3],
+  },
+  appbarSpacer: {
+    width: 32,
+  },
+  bottomSpacer: {
+    height: spacing[10],
   },
 })

--- a/apps/mobile/src/features/treatments/screens/ProtocolFormScreen.jsx
+++ b/apps/mobile/src/features/treatments/screens/ProtocolFormScreen.jsx
@@ -209,30 +209,43 @@ export default function ProtocolFormScreen() {
 
   const handleSubmit = useCallback(async () => {
     if (submitting) return
-    // Coerce dose string→number antes do validate. handleDoseChange mantém
-    // estados intermediários como string ("0,") pra preservar digitação;
-    // no submit garantimos number final que o Zod schema espera.
-    const rawDose = form.values.dosage_per_intake
-    if (typeof rawDose === 'string' && rawDose !== '') {
-      const normalized = rawDose.replace(',', '.')
+
+    // Coerce dose string→number. handleChange é assíncrono, mas validate()
+    // lê state atual no momento da call — fora de ciclo de re-render, ainda
+    // vê valor antigo. Usar `currentDose` local garante consistência tanto
+    // no validate quanto no payload final.
+    let currentDose = form.values.dosage_per_intake
+    if (typeof currentDose === 'string' && currentDose !== '') {
+      const normalized = currentDose.replace(',', '.')
       const num = Number(normalized)
       if (Number.isFinite(num)) {
+        currentDose = num
         form.handleChange('dosage_per_intake', num)
       }
     }
+
     // Validação Zod com refinements cross-campo (AP-156)
     const ok = form.validate()
     if (!ok) {
       show('Verifique os campos destacados', { variant: 'error' })
       return
     }
+
     setSubmitting(true)
     try {
-      // Se modo inline preenchido, criar plano antes
       let planId = form.values.treatment_plan_id || null
-      if (planField.mode === 'inline' && planField.inline?.name?.trim()) {
+      // Plano inline: guard explícito por nome — visualmente o user pode ter
+      // entrado em modo inline e deixado nome vazio; sem este check o protocol
+      // seria criado sem plano + um plano órfão poderia aparecer no DB.
+      if (planField.mode === 'inline') {
+        const planName = planField.inline?.name?.trim()
+        if (!planName) {
+          show('Informe o nome do novo plano', { variant: 'error' })
+          setSubmitting(false)
+          return
+        }
         const created = await treatmentPlanService.create({
-          name: planField.inline.name.trim(),
+          name: planName,
           color: planField.inline.color,
           emoji: planField.inline.emoji,
         })
@@ -241,6 +254,7 @@ export default function ProtocolFormScreen() {
 
       const payload = {
         ...form.values,
+        dosage_per_intake: currentDose,
         treatment_plan_id: planId,
       }
 

--- a/apps/mobile/src/features/treatments/screens/ProtocolFormScreen.jsx
+++ b/apps/mobile/src/features/treatments/screens/ProtocolFormScreen.jsx
@@ -21,7 +21,6 @@ import {
   getTodayLocal,
   parseLocalDate,
   formatLocalDate,
-  pluralizeDoseUnit,
 } from '@dosiq/core'
 import ScreenContainer from '@shared/components/ui/ScreenContainer'
 import FormInput from '@shared/components/form/FormInput'
@@ -100,10 +99,6 @@ export default function ProtocolFormScreen() {
 
   // Memos
   const showWeekdays = REQUIRES_WEEKDAYS.has(form.values.frequency)
-  const doseSuffix = useMemo(
-    () => pluralizeDoseUnit(form.values.dosage_per_intake || 0, medicine?.dosage_unit),
-    [form.values.dosage_per_intake, medicine]
-  )
 
   const startDateAsDate = useMemo(
     () => (form.values.start_date ? parseLocalDate(form.values.start_date) : null),
@@ -168,10 +163,24 @@ export default function ProtocolFormScreen() {
 
   const handleDoseChange = useCallback(
     (name, raw) => {
-      // Normaliza vírgula → ponto para Number parsing (Hermes-safe)
-      const normalized = String(raw ?? '').replace(',', '.')
-      const num = normalized === '' ? '' : Number(normalized)
-      form.handleChange(name, Number.isFinite(num) ? num : '')
+      // Aceita decimais "0,5" / "0.5" / vazio / intermediários "0," "0.".
+      // Estados intermediários (trailing ponto/vírgula OU só ponto/vírgula)
+      // mantidos como STRING para preservar a digitação do usuário — converter
+      // para Number agora apagaria a vírgula e bloquearia decimais.
+      // Schema Zod faz coerce no submit (z.number()).
+      const str = String(raw ?? '')
+      if (str === '') {
+        form.handleChange(name, '')
+        return
+      }
+      const normalized = str.replace(',', '.')
+      const isIntermediate = normalized === '.' || normalized.endsWith('.')
+      if (isIntermediate) {
+        form.handleChange(name, str)
+        return
+      }
+      const num = Number(normalized)
+      form.handleChange(name, Number.isFinite(num) ? num : str)
     },
     [form]
   )
@@ -200,6 +209,17 @@ export default function ProtocolFormScreen() {
 
   const handleSubmit = useCallback(async () => {
     if (submitting) return
+    // Coerce dose string→number antes do validate. handleDoseChange mantém
+    // estados intermediários como string ("0,") pra preservar digitação;
+    // no submit garantimos number final que o Zod schema espera.
+    const rawDose = form.values.dosage_per_intake
+    if (typeof rawDose === 'string' && rawDose !== '') {
+      const normalized = rawDose.replace(',', '.')
+      const num = Number(normalized)
+      if (Number.isFinite(num)) {
+        form.handleChange('dosage_per_intake', num)
+      }
+    }
     // Validação Zod com refinements cross-campo (AP-156)
     const ok = form.validate()
     if (!ok) {
@@ -283,7 +303,7 @@ export default function ProtocolFormScreen() {
               onBlur={form.handleBlur}
               placeholder="0"
               keyboardType="decimal-pad"
-              helperText={`Unidade: ${doseSuffix}`}
+              helperText="Quantas unidades do medicamento por tomada (aceita decimais, ex: 0,5)"
               required
             />
           </Section>

--- a/apps/mobile/src/features/treatments/screens/TreatmentsScreen.jsx
+++ b/apps/mobile/src/features/treatments/screens/TreatmentsScreen.jsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo } from 'react'
 import { ScrollView, View, Text, Pressable, StyleSheet, RefreshControl, LayoutAnimation, Platform, UIManager } from 'react-native'
-import { useNavigation } from '@react-navigation/native'
+import { useNavigation, useFocusEffect } from '@react-navigation/native'
 import { Pill, ChevronRight, Plus } from 'lucide-react-native'
 import ScreenContainer from '@shared/components/ui/ScreenContainer'
 import LoadingState from '@shared/components/states/LoadingState'
@@ -53,6 +53,14 @@ export default function TreatmentsScreen() {
     const flat = groups.flatMap(g => g.protocols)
     return { isComplex: total > 3, flatData: flat }
   }, [groups])
+
+  // Refresh ao ganhar foco: captura tratamentos/planos criados em ProtocolFormScreen
+  // (useTreatments cache key difere de @dosiq/protocols-snapshot invalidado pela mutation).
+  useFocusEffect(
+    useCallback(() => {
+      refresh()
+    }, [refresh])
+  )
 
   const toggleGroup = useCallback((groupId) => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)

--- a/apps/mobile/src/features/treatments/screens/__tests__/TreatmentsScreen.test.jsx
+++ b/apps/mobile/src/features/treatments/screens/__tests__/TreatmentsScreen.test.jsx
@@ -8,6 +8,7 @@ jest.mock('@shared/components/ui/ScreenContainer', () => ({ children }) => <>{ch
 jest.mock('@dashboard/components/AdherenceRing', () => 'AdherenceRing');
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: jest.fn() }),
+  useFocusEffect: () => {},
 }));
 jest.mock('lucide-react-native', () => new Proxy({}, { get: () => () => null }));
 

--- a/apps/mobile/src/features/treatments/services/treatmentsService.js
+++ b/apps/mobile/src/features/treatments/services/treatmentsService.js
@@ -3,7 +3,11 @@
 // ADR-029: chama Supabase directamente usando nativeSupabaseClient
 
 import { z } from 'zod'
-import { getTodayLocal, isProtocolActiveOnDate } from '@dosiq/core'
+// isProtocolInPeriod (period-only) em vez de isProtocolActiveOnDate (adherence
+// strict que filtra por frequency/weekdays — exclui quando_necessário,
+// personalizado, semanal sem weekdays). Listagem mostra qualquer tratamento
+// dentro do período de validade independente da frequência.
+import { getTodayLocal, isProtocolInPeriod } from '@dosiq/core'
 import { supabase as nativeSupabaseClient } from '../../../platform/supabase/nativeSupabaseClient'
 import { debugLog, errorLog } from '@shared/utils/debugLog'
 
@@ -19,7 +23,7 @@ export async function getActiveTreatments(userId) {
 
     debugLog('treatmentsService', `Buscando tratamentos ativos para: ${userId}`)
 
-    const { data: rawData, error, status, count } = await nativeSupabaseClient
+    const { data: rawData, error } = await nativeSupabaseClient
       .from('protocols')
       .select(`
         id,
@@ -45,27 +49,21 @@ export async function getActiveTreatments(userId) {
           dosage_unit,
           therapeutic_class
         )
-      `, { count: 'exact' })
+      `)
       .eq('user_id', userId)
       .eq('active', true)
       .order('name')
-
-    if (__DEV__) {
-      debugLog('treatmentsService', `RESP status=${status} count=${count} data.length=${(rawData || []).length}`)
-      if (Array.isArray(rawData)) {
-        debugLog('treatmentsService', `IDs: ${rawData.map((r) => `${r.name}#${r.id?.slice(0, 8)}`).join(' | ')}`)
-      }
-    }
 
     if (error) {
       errorLog('treatmentsService', 'Erro Supabase', error)
       return { success: false, error: error.message }
     }
 
-    // Filtro de validade temporal (Wave v0.1.5)
-    // Garantimos que o usuário só veja o que está tomando HOJE na fase Read-Only
+    // Filtro de validade temporal — período only (start_date/end_date).
+    // Listagem mostra TODOS os tratamentos em período de validade, ignorando
+    // frequency (quando_necessário, semanal etc. devem aparecer).
     const today = getTodayLocal()
-    const validData = (rawData || []).filter(p => isProtocolActiveOnDate(p, today))
+    const validData = (rawData || []).filter(p => isProtocolInPeriod(p, today))
 
     return { success: true, data: validData }
   } catch (err) {

--- a/apps/mobile/src/features/treatments/services/treatmentsService.js
+++ b/apps/mobile/src/features/treatments/services/treatmentsService.js
@@ -19,7 +19,7 @@ export async function getActiveTreatments(userId) {
 
     debugLog('treatmentsService', `Buscando tratamentos ativos para: ${userId}`)
 
-    const { data: rawData, error } = await nativeSupabaseClient
+    const { data: rawData, error, status, count } = await nativeSupabaseClient
       .from('protocols')
       .select(`
         id,
@@ -45,10 +45,17 @@ export async function getActiveTreatments(userId) {
           dosage_unit,
           therapeutic_class
         )
-      `)
+      `, { count: 'exact' })
       .eq('user_id', userId)
       .eq('active', true)
       .order('name')
+
+    if (__DEV__) {
+      debugLog('treatmentsService', `RESP status=${status} count=${count} data.length=${(rawData || []).length}`)
+      if (Array.isArray(rawData)) {
+        debugLog('treatmentsService', `IDs: ${rawData.map((r) => `${r.name}#${r.id?.slice(0, 8)}`).join(' | ')}`)
+      }
+    }
 
     if (error) {
       errorLog('treatmentsService', 'Erro Supabase', error)

--- a/packages/core/src/utils/__tests__/doseUnit.test.js
+++ b/packages/core/src/utils/__tests__/doseUnit.test.js
@@ -1,65 +1,45 @@
 import { describe, it, expect } from 'vitest'
 import { pluralizeDoseUnit, formatDoseUnit } from '../doseUnit.js'
 
-describe('pluralizeDoseUnit', () => {
-  it('comprimido singular quando qty=1 e unidade mg/cp/g/mcg', () => {
-    expect(pluralizeDoseUnit(1, 'mg')).toBe('comprimido')
-    expect(pluralizeDoseUnit(1, 'cp')).toBe('comprimido')
-    expect(pluralizeDoseUnit(1, 'g')).toBe('comprimido')
-    expect(pluralizeDoseUnit(1, 'mcg')).toBe('comprimido')
+describe('pluralizeDoseUnit (padronizado para unidade(s))', () => {
+  it('singular quando qty === 1', () => {
+    expect(pluralizeDoseUnit(1)).toBe('unidade')
+    expect(pluralizeDoseUnit('1')).toBe('unidade')
   })
 
-  it('comprimidos plural quando qty>1 ou !=1', () => {
-    expect(pluralizeDoseUnit(2, 'mg')).toBe('comprimidos')
-    expect(pluralizeDoseUnit(0.5, 'mg')).toBe('comprimidos')
-    expect(pluralizeDoseUnit(0, 'cp')).toBe('comprimidos')
-  })
-
-  it('ml mantém igual singular/plural', () => {
-    expect(pluralizeDoseUnit(1, 'ml')).toBe('ml')
-    expect(pluralizeDoseUnit(15, 'ml')).toBe('ml')
-  })
-
-  it('gotas singular/plural', () => {
-    expect(pluralizeDoseUnit(1, 'gotas')).toBe('gota')
-    expect(pluralizeDoseUnit(15, 'gotas')).toBe('gotas')
-  })
-
-  it('UI mantém igual', () => {
-    expect(pluralizeDoseUnit(1, 'ui')).toBe('UI')
-    expect(pluralizeDoseUnit(4, 'ui')).toBe('UI')
-  })
-
-  it('fallback unidades quando dosageUnit undefined ou desconhecida', () => {
-    expect(pluralizeDoseUnit(1, undefined)).toBe('unidade')
-    expect(pluralizeDoseUnit(2, undefined)).toBe('unidades')
-    expect(pluralizeDoseUnit(2, 'xyz')).toBe('unidades')
+  it('plural quando qty !== 1', () => {
+    expect(pluralizeDoseUnit(0)).toBe('unidades')
+    expect(pluralizeDoseUnit(2)).toBe('unidades')
+    expect(pluralizeDoseUnit(0.5)).toBe('unidades')
+    expect(pluralizeDoseUnit(15)).toBe('unidades')
   })
 
   it('coerce string para number', () => {
-    expect(pluralizeDoseUnit('1', 'mg')).toBe('comprimido')
-    expect(pluralizeDoseUnit('2', 'mg')).toBe('comprimidos')
+    expect(pluralizeDoseUnit('1')).toBe('unidade')
+    expect(pluralizeDoseUnit('2')).toBe('unidades')
+    expect(pluralizeDoseUnit('0.5')).toBe('unidades')
+  })
+
+  it('fallback sem unidade-aware (decorrente da padronização)', () => {
+    // Mesmo passando 2º argumento (legacy), ignora e retorna unidade(s)
+    expect(pluralizeDoseUnit(1, 'mg')).toBe('unidade')
+    expect(pluralizeDoseUnit(2, 'ml')).toBe('unidades')
   })
 })
 
 describe('formatDoseUnit', () => {
-  it('formata inteiro + unidade', () => {
-    expect(formatDoseUnit(2, 'mg')).toBe('2 comprimidos')
-    expect(formatDoseUnit(1, 'gotas')).toBe('1 gota')
+  it('formata inteiros', () => {
+    expect(formatDoseUnit(1)).toBe('1 unidade')
+    expect(formatDoseUnit(2)).toBe('2 unidades')
   })
 
-  it('formata decimal com vírgula PT-BR', () => {
-    expect(formatDoseUnit(15.5, 'ml')).toBe('15,5 ml')
-    expect(formatDoseUnit(0.5, 'mg')).toBe('0,5 comprimidos')
+  it('formata decimais com vírgula PT-BR', () => {
+    expect(formatDoseUnit(0.5)).toBe('0,5 unidades')
+    expect(formatDoseUnit(15.5)).toBe('15,5 unidades')
   })
 
   it('aceita string como qty', () => {
-    expect(formatDoseUnit('1', 'mg')).toBe('1 comprimido')
-    expect(formatDoseUnit('0.5', 'ml')).toBe('0,5 ml')
-  })
-
-  it('fallback unidades quando dosageUnit ausente', () => {
-    expect(formatDoseUnit(3, undefined)).toBe('3 unidades')
-    expect(formatDoseUnit(1, undefined)).toBe('1 unidade')
+    expect(formatDoseUnit('1')).toBe('1 unidade')
+    expect(formatDoseUnit('0.5')).toBe('0,5 unidades')
   })
 })

--- a/packages/core/src/utils/doseUnit.js
+++ b/packages/core/src/utils/doseUnit.js
@@ -1,44 +1,39 @@
-// doseUnit.js — Apresentação de quantidade + unidade de dose (Fase 2).
+// doseUnit.js — Apresentação de quantidade de DOSE (Fase 2).
 //
-// Helper compartilhado web↔mobile. Sempre usar em vez de hardcoded "comprimidos".
-// Hermes (mobile) default NÃO inclui ICU completo — toLocaleString('pt-BR') cai em
-// fallback US. Por isso usamos replace('.', ',') manual (confiável em V8 e Hermes).
-
-const UNIT_DISPLAY = {
-  mg: { singular: 'comprimido', plural: 'comprimidos' },
-  mcg: { singular: 'comprimido', plural: 'comprimidos' },
-  g: { singular: 'comprimido', plural: 'comprimidos' },
-  cp: { singular: 'comprimido', plural: 'comprimidos' },
-  ml: { singular: 'ml', plural: 'ml' },
-  gotas: { singular: 'gota', plural: 'gotas' },
-  ui: { singular: 'UI', plural: 'UI' },
-}
-
-const FALLBACK = { singular: 'unidade', plural: 'unidades' }
+// `dosage_per_intake` representa NÚMERO DE UNIDADES farmacêuticas do
+// medicamento por tomada (1 comprimido, 1 ampola, 1 gota, etc), NÃO a
+// quantidade em mg/ml/etc. A apresentação (`dosage_per_pill` + `dosage_unit`
+// no medicamento) é a carga POR UNIDADE — exibida separadamente no hero card.
+//
+// Padronização (2026-05-17): sempre "unidade(s)", independente da apresentação.
+// Tentar mapear (mg→comprimido, ml→ml, gotas→gota) gerava bugs semânticos
+// como "Apidra 2ml — dose por tomada: 1 ml" (deveria ser "1 unidade [de 2ml]").
+//
+// Hermes (mobile) sem ICU completo: toLocaleString('pt-BR') cai em fallback
+// US. Por isso usamos replace('.', ',') manual (confiável em V8 e Hermes).
 
 /**
- * Retorna a palavra correta de unidade (singular/plural) para a quantidade.
+ * Retorna "unidade" (singular) ou "unidades" (plural) baseado na quantidade.
  * Coerce explícito via Number — valores podem chegar como string de TextInput.
  *
- * @example pluralizeDoseUnit(2, 'mg')    → 'comprimidos'
- * @example pluralizeDoseUnit(1, 'gotas') → 'gota'
- * @example pluralizeDoseUnit(15, 'ml')   → 'ml'
- * @example pluralizeDoseUnit(2, undefined) → 'unidades'
+ * @example pluralizeDoseUnit(1)   → 'unidade'
+ * @example pluralizeDoseUnit(2)   → 'unidades'
+ * @example pluralizeDoseUnit(0.5) → 'unidades'
+ * @example pluralizeDoseUnit('1') → 'unidade'
  */
-export function pluralizeDoseUnit(qty, dosageUnit) {
-  const u = UNIT_DISPLAY[dosageUnit] ?? FALLBACK
-  return Number(qty) === 1 ? u.singular : u.plural
+export function pluralizeDoseUnit(qty) {
+  return Number(qty) === 1 ? 'unidade' : 'unidades'
 }
 
 /**
- * Formata quantidade + unidade para exibição. Vírgula decimal PT-BR.
+ * Formata quantidade + "unidade(s)" para exibição. Vírgula decimal PT-BR.
  *
- * @example formatDoseUnit(2, 'mg')      → '2 comprimidos'
- * @example formatDoseUnit(1, 'gotas')   → '1 gota'
- * @example formatDoseUnit(15.5, 'ml')   → '15,5 ml'
- * @example formatDoseUnit('0.5', 'mg')  → '0,5 comprimidos'
+ * @example formatDoseUnit(1)    → '1 unidade'
+ * @example formatDoseUnit(2)    → '2 unidades'
+ * @example formatDoseUnit(0.5)  → '0,5 unidades'
+ * @example formatDoseUnit(15.5) → '15,5 unidades'
  */
-export function formatDoseUnit(qty, dosageUnit) {
+export function formatDoseUnit(qty) {
   const display = String(qty).replace('.', ',')
-  return `${display} ${pluralizeDoseUnit(qty, dosageUnit)}`
+  return `${display} ${pluralizeDoseUnit(qty)}`
 }

--- a/packages/core/src/utils/index.js
+++ b/packages/core/src/utils/index.js
@@ -27,6 +27,11 @@ export {
   getLastDayOfMonth,
   parseLocalDatetime,
   parseTimestamp,
+  // Verifica APENAS validade de período (start_date/end_date). NÃO checa
+  // frequency/weekdays — use isProtocolActiveOnDate (adherenceLogic) para
+  // contexto de schedule/adesão. Exportado com nome explícito para
+  // diferenciar do strict adherence-aware.
+  isProtocolActiveOnDate as isProtocolInPeriod,
 } from './dateUtils.js'
 
 // Adherence logic and calculations

--- a/plans/backlog-native_app/EXEC_SPEC_FASE2_PROTOCOLOS.md
+++ b/plans/backlog-native_app/EXEC_SPEC_FASE2_PROTOCOLOS.md
@@ -70,10 +70,27 @@ A Fase 2 herda diretamente:
 | AP-157 | NFD normalization pré-computada via useMemo (não a cada keystroke) |
 | AP-159 | Delete pre-check FK — **NÃO aplicável a tratamento** (ver §3.7) |
 | AP-160 | Opus em fixes incrementais viola R-010 — usar template comment + ler bloco antes de editar |
+| AP-163 | `borderStyle: 'dashed'/'dotted'` em RN dispara warning (RN só aceita `'solid'`) — usar background shift (No-Line Rule do DESIGN-SYSTEM §2) para separação visual |
 | ADR-036 | JS stack (`createStackNavigator`) já está aplicado em `TreatmentsStack`; não migrar |
 | ADR-043 | Hardening G1→G2→G3 — parity test obrigatório em G2 |
 | ADR-044 | Distribuição cavecrew Opus/Sonnet/Haiku + gate de confiança |
 | ADR-045 | Factory location = `@dosiq/core/repositories/` |
+
+### Cuidados aprendidos em T2.1 / T2.2 (smoke PO 2026-05-17)
+
+| Pattern | Aplicação obrigatória |
+|---------|----------------------|
+| **Listagem usa `isProtocolInPeriod`** (period-only, dateUtils) — NÃO `isProtocolActiveOnDate` (strict, adherenceLogic) | `treatmentsService.getActiveTreatments` + `_treatmentsTransformer`. A versão strict filtra por frequency/weekdays e exclui `quando_necessário`, `personalizado`, `semanal` sem weekdays. Listagem deve mostrar TODOS no período. Adherence/dashboard/stock continuam usando a strict (intent correto). |
+| **`isProtocolActiveOnDate` ambíguo** (2 funções com mesmo nome) | Barrel `@dosiq/core` re-exporta a strict como `isProtocolActiveOnDate` e a period-only como `isProtocolInPeriod`. Verificar import correto antes de spawn. |
+| **`useFocusEffect(refresh)` em tela de listagem** | TreatmentsScreen + qualquer screen que dependa de dados mutados em outras telas. Cache key invalidation NÃO é suficiente — hook montado não escuta invalidation. |
+| **Refresh on open em bottom sheets com lista** | MedicineSelectorSheet `useEffect([open, refresh])`. Captura entidades criadas em fluxos paralelos (ex: "Cadastrar novo medicamento" dentro do sheet). |
+| **Reabrir sheet pós retorno de tela de create** | Flag `pendingReopenSheet` + `useFocusEffect`. Mantém foco no contexto de seleção; user vê nova entidade na lista. |
+| **Defensive auth destructuring** | `const { data, error } = await supabase.auth.getUser(); const user = data?.user` — NUNCA `const { data: { user }, error }` (crasha se `data` null em falha crítica de rede). Aplicar em todos services mobile. |
+| **Padronização "unidade(s)" para dose** | `pluralizeDoseUnit(qty)` e `formatDoseUnit(qty)` SEMPRE retornam "unidade(s)". Mapping por `dosage_unit` (mg→comprimido, ml→ml, gotas→gota, UI→UI) era confuso semanticamente (ex: Apidra 2ml dose=1 mostrava "1 ml" em vez de "1 unidade de 2ml"). Apresentação fica visível separadamente no DosagePill do hero. |
+| **Decimais em input numérico** | `handleDoseChange` deve preservar estados intermediários como string (`"0,"`, `"."`, vazio). Conversão para number só no submit antes do `form.validate()`. Eager parse a cada keystroke perde a vírgula e bloqueia decimais. |
+| **borderStyle dashed proibido (AP-163)** | Tanto pelo RN (warning ruidoso em LayoutAnimation) quanto pelo DESIGN-SYSTEM §2 No-Line Rule. Usar background shift (primary[50] chip rounded) em vez de borda. |
+| **Barrel `packages/core/src/schemas/index.js`** | DEVE re-exportar `WEEKDAYS`, `WEEKDAY_LABELS`, `FREQUENCIES`, `FREQUENCY_LABELS` (faltavam até 2026-05-16 — primary[500] crash em WeekdaySelector). Sempre verificar barrel após adicionar export. |
+| **Padding lateral em primitivos atômicos** | Componentes (WeekdaySelector, MedicineSelectorRow, TimeSchedulePicker) NÃO devem ter `paddingHorizontal` próprio — delegar ao container pai (FormSection / Section da tela). Caso contrário, padding cumulativo estoura largura em iPhone (sábado vazando). |
 
 ---
 
@@ -122,11 +139,13 @@ Implementar CRUD completo de **Tratamentos** (entidade DB: `protocols`) no mobil
 **Estado**: usuário com tratamentos. JÁ implementado em Fase 1 com Heurística de Complexidade Adaptativa (SIMPLE até 3 protocolos; COMPLEX agrupado por plano com accordions). **Manter implementação atual** com ajustes:
 
 **Adições neste sprint**:
-- FAB `"+"` (vamos reaproveitar o FAB Plus, só alterando o destino do click) — bottom-right, sticky
-- Em cada grupo expandido (modo COMPLEX): footer link `"+ Adicionar tratamento ao grupo"` (color primary, dashed border-top opcional)
+- FAB `"+"` bottom-right sticky — **paridade exata com FAB de `MedicinesListScreen` Fase 1**: `backgroundColor: colors.primary[500]` (verde teal — brand), `width/height: 56`, `borderRadius: borderRadius.full`, `shadows.md` do tokens. NÃO usar primary[600] (azul) — bug detectado e corrigido em smoke 2026-05-17.
+- Em cada grupo expandido (modo COMPLEX): footer link `"+ Adicionar tratamento ao grupo"` — **chip soft `colors.primary[50]` com `borderRadius: borderRadius.md` e padding interno**. SEM borderStyle dashed (AP-163 RN + DESIGN-SYSTEM §2 No-Line Rule). Separação visual do próximo grupo via `groupContainer.marginBottom: spacing[4]`.
 - Tap em qualquer card → `navigation.navigate(ROUTES.PROTOCOL_DETAIL, { id })`
 - Tap FAB → `navigation.navigate(ROUTES.PROTOCOL_FORM)` (create mode)
+- Tap "+ Adicionar tratamento ao grupo" → `navigation.navigate(ROUTES.PROTOCOL_FORM, { treatment_plan_id: groupId })` (pré-seleciona plano via `route.params`)
 - Link "Medicamentos" no rodapé quando há tratamentos (JÁ implementado em Fase 1)
+- **`useFocusEffect(refresh)` obrigatório** — captura tratamentos/planos criados em ProtocolFormScreen (`useTreatments` cache key difere de `@dosiq/protocols-snapshot` invalidado pela mutation).
 
 **Card de tratamento** (mock):
 - Ícone pill colorido (primary[500]) + ícone bg pill (primary[50])
@@ -141,11 +160,11 @@ Implementar CRUD completo de **Tratamentos** (entidade DB: `protocols`) no mobil
 ### 3.3 — ProtocolDetailScreen — `mock-tratamentos-detalhes.png`
 
 **Layout (top → bottom)**:
-1. **AppBar**: `← SeloZok 50mg` (título = nome do medicamento + dosagem) | trailing icons: Edit + More (kebab menu para opções como pausar, futuro)
+1. **AppBar**: `← SeloZok manhã/noite` (título = nome do tratamento) | trailing icons: Edit + More (kebab menu para opções como pausar, futuro)
 2. **Hero card — Medicamento associado (clicável)**:
    - Background: `primaryBg` (verde claro)
    - Layout: ícone dinâmico **Pill** ou **PillBottle** 52px branco baseado em `medicine.type` (`medicamento` → Pill, `suplemento` → PillBottle) — mesmo pattern aplicado em `MedicineCard` da Fase 1
-   - Eyebrow: `"Medicamento"` (caption color primary)
+   - Eyebrow: `"Medicamento" ou "Suplemento"` (caption color primary)
    - Title: `medicine.name` + `DosagePill medicine.dosage_per_pill medicine.dosage_unit` inline (ex: `SeloZok` + `50mg`)
    - Subtitle: `medicine.active_ingredient` (caption inkMuted)
    - Trailing: chevron primary → `navigation.navigate(ROUTES.MEDICINE_DETAIL, { id: medicine_id })`
@@ -153,10 +172,10 @@ Implementar CRUD completo de **Tratamentos** (entidade DB: `protocols`) no mobil
    - **Requisito de dado**: `protocolService.getById` detailSelect DEVE incluir `medicine:medicines(*)` (não apenas `medicine_id`) — confirmar em §6
 3. **Card "Dosagem & Frequência"** (DosiqCard):
    - SectionLabel: `"DOSAGEM & FREQUÊNCIA"` (eyebrow inkSubtle)
-   - DetailRow `Dose por tomada`: `formatDoseUnit(dosage_per_intake, medicine.dosage_unit)` — ex: `"2 comprimidos"`, `"15 gotas"`, `"10 ml"`, `"4 UI"`
+   - DetailRow `Dose por tomada`: `formatDoseUnit(dosage_per_intake)` — sempre **"N unidade(s)"** independente de `medicine.dosage_unit`. Apresentação (`2ml`, `50mg`) já está no DosagePill do hero card acima. Mapping por dosage_unit foi descontinuado em 2026-05-17 (bug Apidra 2ml mostrava "1 ml" em vez de "1 unidade de 2ml").
    - DetailRow `Frequência`: `2x ao dia` (derivado de `time_schedule.length`)
    - Bloco `Horários`: label `"Horários"` + TimeChips lado a lado: `🕐 08:00` `🕐 20:00` (badge primarySoft)
-   - DetailRow `Consumo diário`: `formatDoseUnit(dosage_per_intake × time_schedule.length, medicine.dosage_unit)` — ex: `"4 comprimidos"`
+   - DetailRow `Consumo diário`: `formatDoseUnit(dosage_per_intake × time_schedule.length)` — ex: `"4 unidades"`
 4. **Card "Período"**:
    - DetailRow `Início`: `formatDatePtBR(start_date)` → `"12 mar 2026"` (DD MMM YYYY)
    - DetailRow `Término`: `formatEndDate(end_date)` → `"Uso contínuo"` se null/undefined, senão `formatDatePtBR(end_date)` (color inkMuted quando `"Uso contínuo"`)
@@ -188,7 +207,8 @@ Implementar CRUD completo de **Tratamentos** (entidade DB: `protocols`) no mobil
    - Tap → abre bottom sheet `MedicineSelectorSheet` (§3.5)
 2. **`INFORMAÇÕES BÁSICAS`**:
    - `FormInput name="name"` label `"Nome do tratamento"` required, placeholder `"Ex: SeloZok manhã/noite"`
-   - `FormInput name="dosage_per_intake"` label `"Dose por tomada"` required, placeholder `"0"`, **suffix dinâmico via `pluralizeDoseUnit(qty, medicine.dosage_unit)`** — ex: `"comprimidos"` / `"ml"` / `"gotas"` / `"UI"` baseado no medicamento selecionado. Antes de selecionar medicamento, suffix mostra `"unidades"` (genérico). `keyboardType="decimal-pad"` (vírgula→ponto normalize via R-232 ou handler local)
+   - `FormInput name="dosage_per_intake"` label `"Dose por tomada"` required, placeholder `"0"`, `keyboardType="decimal-pad"`. **helperText fixo**: `"Quantas unidades do medicamento por tomada (aceita decimais, ex: 0,5)"`. Sem suffix dinâmico baseado em medicine.dosage_unit (padronização em "unidade(s)" — ver §3.3).
+     - **Decimais (`0,5`)**: `handleDoseChange` DEVE preservar estados intermediários como STRING no form state (`"0,"`, `"."`, vazio). Conversão para number só acontece no `handleSubmit` antes do `form.validate()`. Eager parse a cada keystroke apaga a vírgula e bloqueia decimais (bug detectado em smoke 2026-05-17).
 3. **`FREQUÊNCIA`**:
    - `FormSelect name="frequency"` label `"Periodicidade"` required, options `[Diário, Dias alternados, Semanal, Personalizado, Quando necessário]` (de `FREQUENCIES` enum)
    - **Condicional**: se `frequency ∈ {semanal, personalizado}` → mostrar `WeekdaySelector` abaixo
@@ -233,10 +253,15 @@ Bottom sheet 85% altura sobre `ProtocolFormScreen`. Análogo a `MedicineAnvisaSh
 
 **Comportamento**:
 - Filter de busca: NFD normalize pré-computado via useMemo (AP-157)
-- Confirmar seleção: dois patterns possíveis (decidir no spawn):
-  - **Tap-and-close** (preferido): tap no item já fecha sheet e seta `medicine_id` no form
-  - **Confirm button** (alternativa): seleciona e usa "Confirmar" no footer
-- Se usuário toca "+ Cadastrar novo": fechar sheet → navegar para `MEDICINE_CREATE` → após criar (via useFocusEffect), abrir sheet de novo com novo medicamento pré-selecionado (pattern complexo — pode ficar para v2)
+- **Tap-and-close** (adotado): tap no item já fecha sheet e seta `medicine_id` no form via `onSelect(medicine)` + `onClose()`
+- **Refresh on open obrigatório**: `useEffect([open, refresh])` no sheet força reload de `useMedicines()` toda vez que `open` transitionar para `true`. Captura medicamento recém-criado em fluxo paralelo.
+- Fluxo "Cadastrar novo medicamento":
+  1. Tap no footer dispara callback `onCreateNew()` no parent (ProtocolFormScreen)
+  2. Parent seta `pendingReopenSheet=true` ANTES de `navigation.navigate(MEDICINE_CREATE)`
+  3. User cria medicamento; MedicineFormScreen faz `goBack` ao concluir
+  4. Parent ganha foco — `useFocusEffect` detecta `pendingReopenSheet=true` → reabre sheet automaticamente + limpa flag
+  5. Sheet reabre, `useMedicines.refresh()` dispara (useEffect open transition) → novo medicamento aparece na lista
+  6. User seleciona manualmente (sem pre-select complexo — foco visual já está no contexto correto)
 
 ---
 
@@ -425,51 +450,39 @@ Mesma estrutura do create, com:
 - Customizar mensagens só quando regra dá info útil (R-232); deixar locale global cobrir genéricos
 - Refinements cross-campo: **NÃO** usar `schema.pick({field:true}).safeParse` (AP-156). Usar `validateField` do `useFormState` que parsea objeto completo e filtra issues por campo
 
-### Helpers de Apresentação (a criar em `@dosiq/core/utils/`)
+### Helpers de Apresentação (`@dosiq/core/utils/`)
 
-Centralizar formatação em `@dosiq/core` para reuso web↔mobile. Criar **antes** do spawn de telas que usam (sprint T2.1 task adicional, ou parte de T2.6):
+Centralizados em `@dosiq/core` para reuso web↔mobile. Já criados em PR-A T2.1 (mergeado).
 
 ```javascript
-// packages/core/src/utils/doseUnit.js — Fase 2
+// packages/core/src/utils/doseUnit.js — Fase 2 (padronizado 2026-05-17)
+//
+// dosage_per_intake = NÚMERO DE UNIDADES farmacêuticas do medicamento por
+// tomada (1 comprimido, 1 ampola, 1 gota). A apresentação (dosage_per_pill +
+// dosage_unit no medicamento) é a carga POR UNIDADE — exibida separadamente
+// no DosagePill do hero card.
+//
+// Padronização: SEMPRE "unidade(s)", independente de dosage_unit. Mapping
+// (mg→comprimido, ml→ml, gotas→gota) foi descontinuado por gerar bug
+// semântico (Apidra 2ml dose=1 → "1 ml" em vez de "1 unidade [de 2ml]").
 
-const UNIT_DISPLAY = {
-  mg: { singular: 'comprimido', plural: 'comprimidos' },
-  mcg: { singular: 'comprimido', plural: 'comprimidos' },
-  g: { singular: 'comprimido', plural: 'comprimidos' },
-  cp: { singular: 'comprimido', plural: 'comprimidos' },
-  ml: { singular: 'ml', plural: 'ml' },
-  gotas: { singular: 'gota', plural: 'gotas' },
-  ui: { singular: 'UI', plural: 'UI' },
-}
-const FALLBACK = { singular: 'unidade', plural: 'unidades' }
-
-// pluralizeDoseUnit(2, 'mg') → 'comprimidos'
-// pluralizeDoseUnit(1, 'gotas') → 'gota'
-// pluralizeDoseUnit(15, 'ml') → 'ml'
-// pluralizeDoseUnit(qty, undefined) → 'unidades' (fallback antes de selecionar medicamento)
-// Coerce explícito Number(qty) — valores podem vir como string de TextInput
-export function pluralizeDoseUnit(qty, dosageUnit) {
-  const u = UNIT_DISPLAY[dosageUnit] ?? FALLBACK
-  return Number(qty) === 1 ? u.singular : u.plural
+export function pluralizeDoseUnit(qty) {
+  return Number(qty) === 1 ? 'unidade' : 'unidades'
 }
 
-// formatDoseUnit(2, 'mg') → '2 comprimidos'
-// formatDoseUnit(1, 'gotas') → '1 gota'
-// formatDoseUnit(15.5, 'ml') → '15,5 ml'
-// NOTA: Hermes (mobile) default NÃO inclui ICU completo — toLocaleString('pt-BR')
-// cai em fallback US e mantém ponto. Helper manual replace('.', ',') é confiável
-// em ambos web (V8) e mobile (Hermes).
-export function formatDoseUnit(qty, dosageUnit) {
+// Hermes (mobile) sem ICU completo → replace('.', ',') manual em vez de
+// toLocaleString('pt-BR') (cairia em fallback US).
+export function formatDoseUnit(qty) {
   const display = String(qty).replace('.', ',')
-  return `${display} ${pluralizeDoseUnit(qty, dosageUnit)}`
+  return `${display} ${pluralizeDoseUnit(qty)}`
 }
 ```
 
 ```javascript
-// packages/core/src/utils/dateFormat.js — Fase 2 (extender se já existir)
+// packages/core/src/utils/dateFormat.js — Fase 2
 
 // formatDatePtBR('2026-03-12') → '12 mar 2026'
-export function formatDatePtBR(isoDate) { /* ... */ }
+export function formatDatePtBR(isoDate) { /* tabela manual de meses PT */ }
 
 // formatEndDate(null) → 'Uso contínuo'
 // formatEndDate('2026-12-31') → '31 dez 2026'
@@ -479,7 +492,30 @@ export function formatEndDate(isoDate) {
 }
 ```
 
-**Reuso obrigatório**: tanto detail (§3.3) quanto form (§3.4) usam `pluralizeDoseUnit` para suffix dinâmico baseado em `medicine.dosage_unit`. Web pode adotar os mesmos helpers no G3 (consistência cross-plataforma).
+**Reuso obrigatório**: tanto detail (§3.3) quanto form (§3.4 helperText) usam apenas o número (sem dosage_unit). Web pode adotar os mesmos helpers no G3.
+
+### Barrel exports críticos (`packages/core/src/schemas/index.js`)
+
+A partir de 2026-05-16, o barrel DEVE re-exportar (faltavam — bug crashou WeekdaySelector):
+
+```javascript
+export {
+  protocolSchema, protocolCreateSchema, ...,
+  FREQUENCIES, FREQUENCY_LABELS,
+  WEEKDAYS, WEEKDAY_LABELS,  // ← obrigatórios para WeekdaySelector + FormSelect frequency
+} from './protocolSchema.js'
+```
+
+### Função `isProtocolActiveOnDate` — DUAS variantes (cuidado)
+
+`@dosiq/core` exporta DUAS funções com semântica diferente — escolher a correta por contexto:
+
+| Função | De onde | Comportamento | Quando usar |
+|--------|---------|---------------|-------------|
+| `isProtocolActiveOnDate` | `adherenceLogic.js` (strict) | Checa period + frequency + weekdays. Retorna false para `quando_necessário`/`personalizado` SEMPRE. Para `semanal` exige `weekdays`. | Adherence: cálculo de doses esperadas hoje. Dashboard/calendar/stock. |
+| `isProtocolInPeriod` | `dateUtils.js` (period-only) | Checa apenas start_date/end_date | **Listagem** de tratamentos visíveis ao paciente. treatmentsService + _treatmentsTransformer. |
+
+Usar o nome errado oculta tratamentos não-diários da listagem (bug detectado e corrigido em 2026-05-17).
 
 ---
 
@@ -579,6 +615,15 @@ Cobertura mínima:
 
 ## 12. Histórico
 
+- **2026-05-17 (Sprint T2.2 PR-A + PR-B smoke PO)**: Spec atualizada com lições de implementação real (3 PRs mergeados: #561 PR-A T2.1, #563 PR-A T2.2, #562 T2.1 fan-out; #564 PR-B T2.2 aguardando review). Mudanças principais:
+  - §1 — adicionado AP-163 (borderStyle dashed/dotted RN proibido) + bloco "Cuidados aprendidos em T2.1/T2.2" com 11 patterns obrigatórios (focus refresh, sheet reopen, defensive auth destructure, padronização unidade(s), decimais intermediate string, padding lateral atomic components, etc.).
+  - §3.2 — FAB primary[500] verde teal (paridade Fase 1 — não primary[600] azul). Link "+ Adicionar tratamento ao grupo" usa chip primary[50] soft em vez de dashed border (No-Line Rule + AP-163). `useFocusEffect(refresh)` obrigatório.
+  - §3.3 — Dose por tomada/Consumo diário usam `formatDoseUnit(qty)` sem dosage_unit (padronizado em "unidade(s)").
+  - §3.4 — Dose input com `decimal-pad` aceita decimais via estado intermediate string (coerce no submit). helperText explica intent.
+  - §3.5 — MedicineSelectorSheet com refresh on open + flow completo "Cadastrar novo medicamento" (pendingReopenSheet flag + reabertura automática).
+  - §6 — Helpers reescritos (padronização "unidade(s)"). Barrel exports schemas/index.js explicitados. Documentação das DUAS `isProtocolActiveOnDate` (strict adherence vs period-only) com tabela de uso.
+  - PRs entregues: #561 helpers+protocolService, #562 hooks+screens+navigation+icons, #563 primitivos+useProtocolMutation/Delete/Stats+dev demo, #564 MedicineSelectorSheet+PlanSelectField+ProtocolFormScreen CREATE.
+  - Bugs corrigidos no smoke (8 ciclos cobertos pela spec atualizada): WEEKDAYS not exported, Android picker race condition, sábado vazando, dashed warning, focus refresh, sheet reopen, isProtocolActiveOnDate strict filtrando não-diários, Apidra 2ml semantic, decimais bloqueados.
 - **2026-05-16 (Spike Pre-Fase-2)**: Spec reescrita aplicando RETRO_FASE1 (18 gaps) + mocks Fase 2 aprovados pelo PO (8 PNG + 1173 LOC JSX referência) + ADR-045 (factory location). Mudanças principais:
   - G1: factory location consolidado em `@dosiq/core/repositories/` (descarta `shared-data/services/`)
   - G4: delete tratamento NÃO usa hard block — warning soft com histórico (mock confirma)


### PR DESCRIPTION
## Summary

Sprint **T2.2 PR-B** (composição da Fase 2 — Form Complexo). Substitui o stub do ProtocolFormScreen pelo formulário CREATE completo. Refinamentos (T2.7 edit · T2.8 errors UX · T2.11 ProtocolDeleteSheet) ficam em PR-C.

Todos os primitivos do PR-A integrados. Smoke PO validado iOS + Android após 6 ciclos de fix de bugs reais.

## NOVOS componentes (`apps/mobile/src/features/treatments/components/`)
- **MedicineSelectorSheet (T2.4)** — bottom sheet 85% com busca na biblioteca user via `useMedicines()`. NFD normalize pré-computado por useMemo (AP-157). Tap-and-close pattern. Footer "Cadastrar novo medicamento" via callback `onCreateNew` (parent navega). Refresh on open captura medicamento recém-criado.
- **PlanSelectField (T2.5)** — 2 modos controlados:
  - **SELECT**: FormSelect com planos existentes + opção `+ Criar novo plano` no fim.
  - **INLINE**: card primaryBg com nome + 5 swatches de cor + 6 emojis + link "Usar existente ↗" pra voltar.
  - Parent decide submit: se `mode=inline`, cria plano via `treatmentPlanService.create` ANTES do `protocolService.create`.

## ProtocolFormScreen real (T2.6) — substitui stub
- AppBar (← Novo tratamento) + KeyboardAvoidingView + ScrollView + sticky FormActions.
- 6 seções: Medicamento → Informações básicas → Frequência → Período → Organização → Observações.
- Aceita `route.params.treatment_plan_id` pra pré-selecionar plano (vem do "+ Adicionar ao grupo" do TreatmentsScreen modo COMPLEX).
- Validação `useFormState(protocolCreateSchema)` + refinements cross-campo (AP-156).
- Submit: cria plano inline (se aplicável) → mutation.create com goBack.
- Reabertura automática do sheet ao retornar de MedicineFormScreen (UX: foco continua no contexto).

## Dev demo
- Entry "📝 ProtocolFormScreen (CREATE)" no MedicineDemoScreen hub.

## Bugs pegos + corrigidos no smoke (6 ciclos)

| # | Bug | Causa-raiz | Fix |
|---|---|---|---|
| 1 | Novo medicamento criado não aparece no sheet | useMedicines cached, sem refresh on open | Sheet `useEffect([open, refresh])` |
| 2 | Foco volta pro form ao invés do sheet pós-criar med | navigate pra MEDICINE_CREATE sem flag | `pendingReopenSheet` state + useFocusEffect reabre sheet |
| 3 | Tratamento/plano criado não aparece na TreatmentsScreen | `useTreatments` cache key difere de `@dosiq/protocols-snapshot` | `useFocusEffect(refresh)` em TreatmentsScreen |
| 4 | Tratamentos não-`diário` (semanal/quando_necessário/personalizado) sumiam da listagem | `@dosiq/core` exportava `isProtocolActiveOnDate` strict (adherence-aware) — filtrava por frequency/weekdays | Barrel expõe `isProtocolInPeriod` (period-only dateUtils); treatments switch |
| 5 | "Apidra 2ml" detail mostrava "Dose por tomada: 1 ml" (semanticamente errado) | helper `formatDoseUnit(qty, dosage_unit)` mapeava ml→'ml' herdado da apresentação | Padronizado SEMPRE em "unidade(s)"; apresentação fica no DosagePill do hero |
| 6 | Form não aceitava decimais (0,5 virava 0) | `handleDoseChange` parseava eager string→number a cada keystroke, perdia trailing vírgula | Estados intermediários ("0,", ".") mantidos como string; coerce no submit |

## Diagnóstico do bug #4 (mais técnico)
DB tinha 5 protocols active; mobile retornava 3. MCP Supabase + 3 ciclos de debug log confirmaram:
- `RESP status=200 count=5 data.length=5` (server OK)
- `RAW: 3 protocols` (filtro client-side reduzia)

Root: `@dosiq/core` re-exporta `isProtocolActiveOnDate` de `adherenceLogic.js` (strict — `FREQUENCY_MATCHERS` com `quando_necessário => false`, `personalizado => false`, `semanal` exige `weekdays`). Versão simples em `dateUtils.js` (só period dates) NÃO era exportada. Listagem usava a strict por engano.

Fix: barrel exporta ambas com nomes distintos. Listagem (treatmentsService + transformer) usa `isProtocolInPeriod`. Adherence/dashboard/stock continuam com `isProtocolActiveOnDate` (intent correto deles).

## Testes
- ✅ Mobile jest: 148/148 (3 skipped pré-existentes).
- ✅ Web `validate:agent`: 530/530.
- ✅ doseUnit tests (vitest): 7/7.
- ✅ Lint: 0 errors. Warnings pré-existentes (max-lines/complexity) — R-221 SQP.

## Próximo PR-C (refinamento Sprint T2.2)
T2.7 ProtocolFormScreen edit mode · T2.8 errors UX banner topo + scroll to first error · T2.11 ProtocolDeleteSheet (substitui Alert stub do ProtocolDetailScreen com warning soft + stats via useProtocolStats).

## Test plan
- [x] `npm run validate:agent` (web) → 530/530
- [x] `cd apps/mobile && npx jest` → 148/148
- [x] `rtk lint` → 0 errors
- [x] Smoke iOS: criar tratamento com med existente, criar med novo dentro do sheet, criar plano inline, todas frequências (diário, semanal, quando_necessário, personalizado), decimais 0,5
- [x] Smoke Android: idem (incluindo refresh on focus pós-criar)
- [x] Cross-verify Supabase via MCP confirma 5 active rows visíveis na listagem
- [ ] PO smoke Android API 24 (rn-screens stable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
