### PR TITLE
feat(mobile/treatments): Sprint T2.2 PR-C — edit mode + errors UX + delete sheet

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -5,7 +5,7 @@
 
 const BUILD_PROFILE = process.env.EAS_BUILD_PROFILE || 'production'
 
-const APP_VERSION = '0.3.8' // R-182: versão semântica (sem prefixo 'v')
+const APP_VERSION = '0.3.9' // R-182: versão semântica (sem prefixo 'v')
 const [major, minor, patch] = APP_VERSION.split('.').map(Number)
 // buildNumber/versionCode derivado da versão semântica: major*10000 + minor*100 + patch
 // 0.2.4 → 204 | 0.3.0 → 300 | 1.0.0 → 10000

--- a/apps/mobile/src/features/treatments/components/ProtocolDeleteSheet.jsx
+++ b/apps/mobile/src/features/treatments/components/ProtocolDeleteSheet.jsx
@@ -62,11 +62,11 @@ export default function ProtocolDeleteSheet({
           </View>
 
           <Text style={styles.title}>Excluir este tratamento?</Text>
-          <Text style={styles.body}>
+{/*           <Text style={styles.body}>
             As doses registradas continuam no histórico — apenas o agendamento futuro
             será removido.
           </Text>
-
+ */}
           {/* Seção HISTÓRICO RECENTE */}
           <Text style={styles.eyebrow}>HISTÓRICO RECENTE</Text>
           <View style={styles.statsCard}>

--- a/apps/mobile/src/features/treatments/components/ProtocolDeleteSheet.jsx
+++ b/apps/mobile/src/features/treatments/components/ProtocolDeleteSheet.jsx
@@ -63,7 +63,7 @@ export default function ProtocolDeleteSheet({
 
           <Text style={styles.title}>Excluir este tratamento?</Text>
            <Text style={styles.body}>
-            Essa operação não pode ser desfeita. Reflita antes de confirmar.
+            Essa operação não pode ser desfeita.
           </Text>
 
           {/* Seção HISTÓRICO RECENTE */}

--- a/apps/mobile/src/features/treatments/components/ProtocolDeleteSheet.jsx
+++ b/apps/mobile/src/features/treatments/components/ProtocolDeleteSheet.jsx
@@ -62,11 +62,10 @@ export default function ProtocolDeleteSheet({
           </View>
 
           <Text style={styles.title}>Excluir este tratamento?</Text>
-{/*           <Text style={styles.body}>
-            As doses registradas continuam no histórico — apenas o agendamento futuro
-            será removido.
+           <Text style={styles.body}>
+            Essa operação não pode ser desfeita. Reflita antes de confirmar.
           </Text>
- */}
+
           {/* Seção HISTÓRICO RECENTE */}
           <Text style={styles.eyebrow}>HISTÓRICO RECENTE</Text>
           <View style={styles.statsCard}>

--- a/apps/mobile/src/features/treatments/components/ProtocolDeleteSheet.jsx
+++ b/apps/mobile/src/features/treatments/components/ProtocolDeleteSheet.jsx
@@ -5,11 +5,11 @@
 // no histórico — apenas o agendamento futuro é cancelado. Mostra stats reais via
 // useProtocolStats para dar contexto antes do confirm.
 
-import { View, Text, Modal, Pressable, StyleSheet } from 'react-native'
+import { View, Text, Modal, Pressable, StyleSheet, Platform, StatusBar } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import {
   AlertTriangle,
   CheckCircle2,
-  Clock,
   CalendarDays,
   Info,
   Trash2,
@@ -46,14 +46,22 @@ export default function ProtocolDeleteSheet({
       transparent
       animationType="slide"
       onRequestClose={handleCancel}
+      // Android: statusBarTranslucent faz o Modal cobrir status bar + ignorar
+      // bottom tabs do parent navigator (sem isso o modal só ocupa a área do
+      // screen atual, deixando topo sem overlay e botões cortados pela tab bar).
+      statusBarTranslucent
     >
       <View style={styles.root}>
+        {/* Spacer Android: empurra o sheet abaixo da status bar translúcida */}
+        {Platform.OS === 'android' ? (
+          <View style={{ height: StatusBar.currentHeight ?? 0 }} />
+        ) : null}
         <Pressable
           style={styles.backdrop}
           onPress={handleCancel}
           accessibilityLabel="Fechar"
         />
-        <View style={styles.sheet}>
+        <SafeAreaView edges={['bottom']} style={styles.sheet}>
           <View style={styles.handle} />
 
           {/* Ícone alert soft */}
@@ -78,17 +86,6 @@ export default function ProtocolDeleteSheet({
                   : `${stats.confirmedLast7d} ${stats.confirmedLast7d === 1 ? 'dose tomada' : 'doses tomadas'}`
               }
               sub="Últimos 7 dias"
-              muted={loading || !stats}
-            />
-            <StatRow
-              icon={Clock}
-              iconColor={colors.status.warning}
-              label={
-                loading || !stats
-                  ? 'Carregando…'
-                  : `${stats.pendingNow} ${stats.pendingNow === 1 ? 'dose pendente' : 'doses pendentes'}`
-              }
-              sub="Agora"
               muted={loading || !stats}
             />
             <StatRow
@@ -150,7 +147,7 @@ export default function ProtocolDeleteSheet({
               </Text>
             </Pressable>
           </View>
-        </View>
+        </SafeAreaView>
       </View>
     </Modal>
   )

--- a/apps/mobile/src/features/treatments/components/ProtocolDeleteSheet.jsx
+++ b/apps/mobile/src/features/treatments/components/ProtocolDeleteSheet.jsx
@@ -1,0 +1,312 @@
+// ProtocolDeleteSheet.jsx — bottom sheet de confirmação de exclusão de tratamento.
+// Fase 2 T2.11 (Sprint T2.2 PR-C). Spec §3.7.
+//
+// Warning soft (não hard block como em medicamento): doses registradas continuam
+// no histórico — apenas o agendamento futuro é cancelado. Mostra stats reais via
+// useProtocolStats para dar contexto antes do confirm.
+
+import { View, Text, Modal, Pressable, StyleSheet } from 'react-native'
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  CalendarDays,
+  Info,
+  Trash2,
+} from 'lucide-react-native'
+import { useProtocolStats } from '@treatments/hooks/useProtocolStats'
+import { selectionTap } from '@shared/utils/haptics'
+import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
+
+export default function ProtocolDeleteSheet({
+  open,
+  onClose,
+  onConfirm,
+  protocolId,
+  isDeleting = false,
+}) {
+  // States (R-010 — States → Memos → Effects → Handlers)
+  const { data: stats, loading } = useProtocolStats(protocolId)
+
+  // Handlers
+  function handleCancel() {
+    if (isDeleting) return
+    selectionTap()
+    onClose?.()
+  }
+
+  function handleConfirm() {
+    if (isDeleting) return
+    onConfirm?.()
+  }
+
+  return (
+    <Modal
+      visible={!!open}
+      transparent
+      animationType="slide"
+      onRequestClose={handleCancel}
+    >
+      <View style={styles.root}>
+        <Pressable
+          style={styles.backdrop}
+          onPress={handleCancel}
+          accessibilityLabel="Fechar"
+        />
+        <View style={styles.sheet}>
+          <View style={styles.handle} />
+
+          {/* Ícone alert soft */}
+          <View style={styles.iconWrap}>
+            <AlertTriangle size={28} color={colors.status.warning} strokeWidth={2} />
+          </View>
+
+          <Text style={styles.title}>Excluir este tratamento?</Text>
+          <Text style={styles.body}>
+            As doses registradas continuam no histórico — apenas o agendamento futuro
+            será removido.
+          </Text>
+
+          {/* Seção HISTÓRICO RECENTE */}
+          <Text style={styles.eyebrow}>HISTÓRICO RECENTE</Text>
+          <View style={styles.statsCard}>
+            <StatRow
+              icon={CheckCircle2}
+              iconColor={colors.status.success}
+              label={
+                loading || !stats
+                  ? 'Carregando…'
+                  : `${stats.confirmedLast7d} ${stats.confirmedLast7d === 1 ? 'dose confirmada' : 'doses confirmadas'}`
+              }
+              sub="Últimos 7 dias"
+              muted={loading || !stats}
+            />
+            <StatRow
+              icon={Clock}
+              iconColor={colors.status.warning}
+              label={
+                loading || !stats
+                  ? 'Carregando…'
+                  : `${stats.pendingNow} ${stats.pendingNow === 1 ? 'dose pendente' : 'doses pendentes'}`
+              }
+              sub="Agora"
+              muted={loading || !stats}
+            />
+            <StatRow
+              icon={CalendarDays}
+              iconColor={colors.primary[600]}
+              label={
+                loading || !stats
+                  ? 'Carregando…'
+                  : `${stats.scheduledNext7d} ${stats.scheduledNext7d === 1 ? 'dose agendada' : 'doses agendadas'}`
+              }
+              sub="Próximos 7 dias · serão canceladas"
+              muted={loading || !stats}
+            />
+          </View>
+
+          {/* Banner warning */}
+          <View style={styles.banner}>
+            <Info size={16} color={colors.status.warning} strokeWidth={2} />
+            <Text style={styles.bannerText}>
+              Excluir o tratamento NÃO apaga o histórico de doses já registradas, nem
+              o cadastro do medicamento.
+            </Text>
+          </View>
+
+          {/* Botões */}
+          <View style={styles.actions}>
+            <Pressable
+              onPress={handleCancel}
+              disabled={isDeleting}
+              style={({ pressed }) => [
+                styles.btn,
+                styles.btnCancel,
+                pressed && !isDeleting && styles.btnPressed,
+                isDeleting && styles.btnDisabled,
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel="Cancelar"
+              accessibilityState={{ disabled: isDeleting }}
+            >
+              <Text style={styles.btnCancelText}>Cancelar</Text>
+            </Pressable>
+
+            <Pressable
+              onPress={handleConfirm}
+              disabled={isDeleting}
+              style={({ pressed }) => [
+                styles.btn,
+                styles.btnConfirm,
+                pressed && !isDeleting && styles.btnPressed,
+                isDeleting && styles.btnDisabled,
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel="Excluir tratamento"
+              accessibilityState={{ disabled: isDeleting, busy: isDeleting }}
+            >
+              <Trash2 size={18} color={colors.text.inverse} strokeWidth={2} />
+              <Text style={styles.btnConfirmText}>
+                {isDeleting ? 'Excluindo…' : 'Excluir'}
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  )
+}
+
+function StatRow(props) {
+  const { icon: IconComponent, iconColor, label, sub, muted } = props
+  return (
+    <View style={styles.statRow}>
+      {IconComponent ? <IconComponent size={18} color={iconColor} strokeWidth={2} /> : null}
+      <View style={styles.statTextWrap}>
+        <Text style={[styles.statLabel, muted && styles.statMuted]}>{label}</Text>
+        <Text style={styles.statSub}>{sub}</Text>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: colors.bg.overlay,
+  },
+  sheet: {
+    backgroundColor: colors.bg.card,
+    borderTopLeftRadius: borderRadius.xl,
+    borderTopRightRadius: borderRadius.xl,
+    padding: spacing[5],
+    paddingBottom: spacing[6],
+    maxHeight: '90%',
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 40,
+    height: 4,
+    borderRadius: borderRadius.full,
+    backgroundColor: colors.neutral[300],
+    marginBottom: spacing[4],
+  },
+  iconWrap: {
+    alignSelf: 'center',
+    width: 56,
+    height: 56,
+    borderRadius: borderRadius.full,
+    backgroundColor: colors.supplement[50],
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: spacing[3],
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.text.primary,
+    textAlign: 'center',
+    fontFamily: typography.fontFamily.bold,
+    marginBottom: spacing[2],
+  },
+  body: {
+    fontSize: 14,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    lineHeight: 20,
+    marginBottom: spacing[4],
+  },
+  eyebrow: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: colors.text.muted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+    marginBottom: spacing[2],
+  },
+  statsCard: {
+    backgroundColor: colors.neutral[100],
+    borderRadius: borderRadius.md,
+    padding: spacing[3],
+    gap: spacing[2],
+    marginBottom: spacing[3],
+  },
+  statRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing[3],
+    paddingVertical: spacing[1],
+  },
+  statTextWrap: {
+    flex: 1,
+    gap: 2,
+  },
+  statLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.text.primary,
+  },
+  statMuted: {
+    color: colors.text.muted,
+    fontWeight: '500',
+  },
+  statSub: {
+    fontSize: 12,
+    color: colors.text.secondary,
+  },
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing[2],
+    backgroundColor: colors.supplement[50],
+    borderRadius: borderRadius.md,
+    padding: spacing[3],
+    marginBottom: spacing[4],
+  },
+  bannerText: {
+    flex: 1,
+    fontSize: 12,
+    color: colors.text.primary,
+    lineHeight: 18,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: spacing[3],
+    paddingTop: spacing[1],
+  },
+  btn: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[2],
+    paddingVertical: spacing[4],
+    borderRadius: borderRadius.md,
+  },
+  btnCancel: {
+    backgroundColor: colors.neutral[100],
+  },
+  btnConfirm: {
+    backgroundColor: colors.status.error,
+  },
+  btnPressed: {
+    opacity: 0.85,
+  },
+  btnDisabled: {
+    opacity: 0.6,
+  },
+  btnCancelText: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.text.primary,
+  },
+  btnConfirmText: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.text.inverse,
+  },
+})

--- a/apps/mobile/src/features/treatments/components/ProtocolDeleteSheet.jsx
+++ b/apps/mobile/src/features/treatments/components/ProtocolDeleteSheet.jsx
@@ -63,7 +63,7 @@ export default function ProtocolDeleteSheet({
 
           <Text style={styles.title}>Excluir este tratamento?</Text>
            <Text style={styles.body}>
-            Essa operação não pode ser desfeita.
+            Confira os detalhes abaixo.
           </Text>
 
           {/* Seção HISTÓRICO RECENTE */}
@@ -75,7 +75,7 @@ export default function ProtocolDeleteSheet({
               label={
                 loading || !stats
                   ? 'Carregando…'
-                  : `${stats.confirmedLast7d} ${stats.confirmedLast7d === 1 ? 'dose confirmada' : 'doses confirmadas'}`
+                  : `${stats.confirmedLast7d} ${stats.confirmedLast7d === 1 ? 'dose tomada' : 'doses tomadas'}`
               }
               sub="Últimos 7 dias"
               muted={loading || !stats}

--- a/apps/mobile/src/features/treatments/components/ProtocolFormBody.jsx
+++ b/apps/mobile/src/features/treatments/components/ProtocolFormBody.jsx
@@ -70,6 +70,7 @@ export default function ProtocolFormBody({
           onChange={form.handleChange}
           onBlur={form.handleBlur}
           placeholder="Ex: SeloZok manhã/noite"
+          maxLength={200}
           required
         />
         <FormInput
@@ -81,6 +82,7 @@ export default function ProtocolFormBody({
           onBlur={form.handleBlur}
           placeholder="0"
           keyboardType="decimal-pad"
+          maxLength={10}
           helperText="Quantas unidades do medicamento por tomada (aceita decimais, ex: 0,5)"
           required
         />
@@ -162,6 +164,7 @@ export default function ProtocolFormBody({
           placeholder="Notas sobre este tratamento…"
           multiline
           numberOfLines={4}
+          maxLength={1000}
           helperText="Opcional"
         />
       </Section>

--- a/apps/mobile/src/features/treatments/components/ProtocolFormBody.jsx
+++ b/apps/mobile/src/features/treatments/components/ProtocolFormBody.jsx
@@ -1,0 +1,208 @@
+// ProtocolFormBody.jsx — sub-componente de render do ProtocolFormScreen.
+// Isola as 6 seções (Medicamento, Info, Frequência, Período, Organização,
+// Observações) pra manter o screen principal enxuto.
+
+import { useMemo } from 'react'
+import { View, Text, StyleSheet } from 'react-native'
+import { parseLocalDate } from '@dosiq/core'
+import FormInput from '@shared/components/form/FormInput'
+import FormSelect from '@shared/components/form/FormSelect'
+import FormDatePicker from '@shared/components/form/FormDatePicker'
+import MedicineSelectorRow from '@treatments/components/MedicineSelectorRow'
+import WeekdaySelector from '@treatments/components/WeekdaySelector'
+import TimeSchedulePicker from '@treatments/components/TimeSchedulePicker'
+import PlanSelectField from '@treatments/components/PlanSelectField'
+import { colors, spacing } from '@shared/styles/tokens'
+
+const FREQUENCY_OPTIONS = [
+  { value: 'diário', label: 'Diário' },
+  { value: 'dias_alternados', label: 'Dias alternados' },
+  { value: 'semanal', label: 'Semanal' },
+  { value: 'personalizado', label: 'Personalizado' },
+  { value: 'quando_necessário', label: 'Quando necessário' },
+]
+
+const REQUIRES_WEEKDAYS = new Set(['semanal', 'personalizado'])
+
+export default function ProtocolFormBody({
+  form,
+  medicine,
+  onOpenMedicineSheet,
+  plans,
+  planField,
+  onPlanFieldChange,
+  onDoseChange,
+  onStartDateChange,
+  onEndDateChange,
+}) {
+  const showWeekdays = REQUIRES_WEEKDAYS.has(form.values.frequency)
+
+  const startDateAsDate = useMemo(
+    () => (form.values.start_date ? parseLocalDate(form.values.start_date) : null),
+    [form.values.start_date]
+  )
+  const endDateAsDate = useMemo(
+    () => (form.values.end_date ? parseLocalDate(form.values.end_date) : null),
+    [form.values.end_date]
+  )
+
+  const doseDisplay =
+    form.values.dosage_per_intake === ''
+      ? ''
+      : String(form.values.dosage_per_intake).replace('.', ',')
+
+  return (
+    <>
+      <Section title="Medicamento">
+        <MedicineSelectorRow
+          medicine={medicine}
+          onPress={onOpenMedicineSheet}
+          error={form.touched.medicine_id ? form.errors.medicine_id : null}
+        />
+      </Section>
+
+      <Section title="Informações básicas">
+        <FormInput
+          name="name"
+          label="Nome do tratamento"
+          value={form.values.name}
+          error={form.touched.name ? form.errors.name : null}
+          onChange={form.handleChange}
+          onBlur={form.handleBlur}
+          placeholder="Ex: SeloZok manhã/noite"
+          required
+        />
+        <FormInput
+          name="dosage_per_intake"
+          label="Dose por tomada"
+          value={doseDisplay}
+          error={form.touched.dosage_per_intake ? form.errors.dosage_per_intake : null}
+          onChange={onDoseChange}
+          onBlur={form.handleBlur}
+          placeholder="0"
+          keyboardType="decimal-pad"
+          helperText="Quantas unidades do medicamento por tomada (aceita decimais, ex: 0,5)"
+          required
+        />
+      </Section>
+
+      <Section title="Frequência">
+        <FormSelect
+          name="frequency"
+          label="Periodicidade"
+          value={form.values.frequency}
+          options={FREQUENCY_OPTIONS}
+          onChange={form.handleChange}
+          onBlur={form.handleBlur}
+          error={form.touched.frequency ? form.errors.frequency : null}
+          required
+        />
+        {showWeekdays ? (
+          <View style={styles.fieldBlock}>
+            <Text style={styles.fieldLabel}>Dias da semana</Text>
+            <WeekdaySelector
+              value={form.values.weekdays}
+              onChange={(next) => form.handleChange('weekdays', next)}
+              error={form.touched.weekdays ? form.errors.weekdays : null}
+            />
+          </View>
+        ) : null}
+        <View style={styles.fieldBlock}>
+          <Text style={styles.fieldLabel}>Horários</Text>
+          <TimeSchedulePicker
+            value={form.values.time_schedule}
+            onChange={(next) => form.handleChange('time_schedule', next)}
+            error={form.touched.time_schedule ? form.errors.time_schedule : null}
+          />
+        </View>
+      </Section>
+
+      <Section title="Período">
+        <View style={styles.dateRow}>
+          <View style={styles.flex}>
+            <FormDatePicker
+              name="start_date"
+              label="Início"
+              value={startDateAsDate}
+              onChange={onStartDateChange}
+              error={form.touched.start_date ? form.errors.start_date : null}
+            />
+          </View>
+          <View style={styles.flex}>
+            <FormDatePicker
+              name="end_date"
+              label="Término"
+              value={endDateAsDate}
+              onChange={onEndDateChange}
+              error={form.touched.end_date ? form.errors.end_date : null}
+              helperText="Sem prazo = uso contínuo"
+              minimumDate={startDateAsDate}
+            />
+          </View>
+        </View>
+      </Section>
+
+      <Section title="Organização">
+        <PlanSelectField
+          plans={plans}
+          value={planField}
+          onChange={onPlanFieldChange}
+          error={form.touched.treatment_plan_id ? form.errors.treatment_plan_id : null}
+        />
+      </Section>
+
+      <Section title="Observações">
+        <FormInput
+          name="notes"
+          label="Notas"
+          value={form.values.notes}
+          error={form.touched.notes ? form.errors.notes : null}
+          onChange={form.handleChange}
+          onBlur={form.handleBlur}
+          placeholder="Notas sobre este tratamento…"
+          multiline
+          numberOfLines={4}
+          helperText="Opcional"
+        />
+      </Section>
+    </>
+  )
+}
+
+function Section({ title, children }) {
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      <View style={styles.sectionBody}>{children}</View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  section: {
+    gap: spacing[2],
+  },
+  sectionTitle: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: colors.text.secondary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+  sectionBody: {
+    gap: spacing[3],
+  },
+  fieldBlock: {
+    gap: spacing[2],
+  },
+  fieldLabel: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: colors.text.primary,
+  },
+  dateRow: {
+    flexDirection: 'row',
+    gap: spacing[3],
+  },
+})

--- a/apps/mobile/src/features/treatments/hooks/useProtocolFormState.js
+++ b/apps/mobile/src/features/treatments/hooks/useProtocolFormState.js
@@ -1,0 +1,138 @@
+// useProtocolFormState.js — encapsula state do ProtocolFormScreen (Fase 2 T2.7).
+//
+// Centraliza:
+// - form (useFormState com protocolCreateSchema)
+// - sidecar UI: medicine, sheetOpen, pendingReopenSheet, plans, planField
+// - load assíncrono de planos terapêuticos
+// - prefill em modo EDIT (one-shot via guard `prefilled`)
+//
+// Retorna API plana consumida pelo screen; tudo memoizado/estável.
+
+import { useCallback, useEffect, useState, startTransition } from 'react'
+import { useFormState } from '@shared/hooks/useFormState'
+import { protocolCreateSchema } from '@dosiq/core'
+import { useProtocol } from './useProtocols'
+import { treatmentPlanService } from '../services/treatmentPlanService'
+
+export function buildInitialValues({ todayIso, presetPlanId }) {
+  return {
+    medicine_id: '',
+    name: '',
+    dosage_per_intake: '',
+    frequency: 'diário',
+    weekdays: [],
+    time_schedule: [],
+    start_date: todayIso,
+    end_date: null,
+    notes: '',
+    active: true,
+    titration_status: 'estável',
+    titration_schedule: [],
+    current_stage_index: 0,
+    treatment_plan_id: presetPlanId || null,
+  }
+}
+
+function buildPrefill(existing, todayIso) {
+  return {
+    medicine_id: existing.medicine_id ?? '',
+    name: existing.name ?? '',
+    dosage_per_intake: existing.dosage_per_intake ?? '',
+    frequency: existing.frequency ?? 'diário',
+    weekdays: Array.isArray(existing.weekdays) ? existing.weekdays : [],
+    time_schedule: Array.isArray(existing.time_schedule) ? existing.time_schedule : [],
+    start_date: existing.start_date ?? todayIso,
+    end_date: existing.end_date ?? null,
+    notes: existing.notes ?? '',
+    active: existing.active ?? true,
+    titration_status: existing.titration_status ?? 'estável',
+    titration_schedule: existing.titration_schedule ?? [],
+    current_stage_index: existing.current_stage_index ?? 0,
+    treatment_plan_id: existing.treatment_plan_id ?? null,
+  }
+}
+
+export function useProtocolFormState({ editId, todayIso, presetPlanId }) {
+  // States (R-010 — States → Memos → Effects → Handlers)
+  const form = useFormState(protocolCreateSchema, {
+    initialValues: buildInitialValues({ todayIso, presetPlanId }),
+  })
+
+  const [medicine, setMedicine] = useState(null)
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const [pendingReopenSheet, setPendingReopenSheet] = useState(false)
+  const [plans, setPlans] = useState([])
+  const [planField, setPlanField] = useState(() => ({
+    mode: 'select',
+    planId: presetPlanId || null,
+    inline: null,
+  }))
+  const [prefilled, setPrefilled] = useState(false)
+
+  const { data: existing, loading: existingLoading, error: existingError } = useProtocol(editId)
+
+  // Effects — load planos
+  useEffect(() => {
+    let cancelled = false
+    treatmentPlanService
+      .getAll()
+      .then((list) => {
+        if (!cancelled) startTransition(() => setPlans(Array.isArray(list) ? list : []))
+      })
+      .catch(() => {
+        if (!cancelled) startTransition(() => setPlans([]))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Effects — prefill EDIT (one-shot via guard, startTransition para evitar
+  // cascading renders flag do react-hooks/set-state-in-effect).
+  useEffect(() => {
+    if (!editId || prefilled || !existing) return
+    const prefill = buildPrefill(existing, todayIso)
+    startTransition(() => {
+      form.reset(prefill)
+      if (existing.medicine) setMedicine(existing.medicine)
+      setPlanField({
+        mode: 'select',
+        planId: existing.treatment_plan_id ?? null,
+        inline: null,
+      })
+      setPrefilled(true)
+    })
+  }, [editId, prefilled, existing, todayIso, form])
+
+  // Handlers — wrappers para o screen
+  const selectMedicine = useCallback(
+    (med) => {
+      setMedicine(med)
+      form.handleChange('medicine_id', med.id)
+    },
+    [form]
+  )
+
+  const changePlanField = useCallback(
+    (next) => {
+      setPlanField(next)
+      form.handleChange('treatment_plan_id', next.mode === 'select' ? next.planId : null)
+    },
+    [form]
+  )
+
+  return {
+    form,
+    medicine,
+    selectMedicine,
+    sheetOpen,
+    setSheetOpen,
+    pendingReopenSheet,
+    setPendingReopenSheet,
+    plans,
+    planField,
+    changePlanField,
+    existingLoading: !!editId && existingLoading && !prefilled,
+    existingError: !!editId && !!existingError ? existingError : null,
+  }
+}

--- a/apps/mobile/src/features/treatments/hooks/useProtocolFormSubmit.js
+++ b/apps/mobile/src/features/treatments/hooks/useProtocolFormSubmit.js
@@ -43,7 +43,10 @@ export function useProtocolFormSubmit({ editId, form, planField, mutation, show,
     if (submitting) return
     const currentDose = coerceDose(form)
 
-    const ok = form.validate()
+    // Override em validate evita race com handleChange assíncrono que coerceDose
+    // dispara — validate lê state da frame anterior; passamos o valor já coercido
+    // explicitamente pra schema parse.
+    const ok = form.validate({ dosage_per_intake: currentDose })
     if (!ok) {
       show('Verifique os campos destacados', { variant: 'error' })
       onValidateFail?.()

--- a/apps/mobile/src/features/treatments/hooks/useProtocolFormSubmit.js
+++ b/apps/mobile/src/features/treatments/hooks/useProtocolFormSubmit.js
@@ -1,0 +1,83 @@
+// useProtocolFormSubmit.js — handler de submit do ProtocolFormScreen.
+//
+// Encapsula:
+// - Coerce de dose (string "0,5" / "0.5" / intermediário) → number
+// - Validate Zod com refinements cross-campo (AP-156)
+// - Plano inline: cria via treatmentPlanService.create ANTES do tratamento
+// - Roteamento create vs update por presença de editId
+
+import { useCallback, useState } from 'react'
+import { treatmentPlanService } from '../services/treatmentPlanService'
+
+function coerceDose(form) {
+  const raw = form.values.dosage_per_intake
+  if (typeof raw !== 'string' || raw === '') return raw
+  const normalized = raw.replace(',', '.')
+  const num = Number(normalized)
+  if (!Number.isFinite(num)) return raw
+  form.handleChange('dosage_per_intake', num)
+  return num
+}
+
+async function resolveInlinePlan(planField, show) {
+  if (planField.mode !== 'inline') return { ok: true, planId: null, useInline: false }
+  const planName = planField.inline?.name?.trim()
+  if (!planName) {
+    show('Informe o nome do novo plano', { variant: 'error' })
+    return { ok: false, planId: null, useInline: true }
+  }
+  const created = await treatmentPlanService.create({
+    name: planName,
+    color: planField.inline.color,
+    emoji: planField.inline.emoji,
+  })
+  return { ok: true, planId: created?.id ?? null, useInline: true }
+}
+
+export function useProtocolFormSubmit({ editId, form, planField, mutation, show, onValidateFail }) {
+  // States
+  const [submitting, setSubmitting] = useState(false)
+
+  // Handlers
+  const submit = useCallback(async () => {
+    if (submitting) return
+    const currentDose = coerceDose(form)
+
+    const ok = form.validate()
+    if (!ok) {
+      show('Verifique os campos destacados', { variant: 'error' })
+      onValidateFail?.()
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const resolved = await resolveInlinePlan(planField, show)
+      if (!resolved.ok) {
+        setSubmitting(false)
+        return
+      }
+      const planId = resolved.useInline
+        ? resolved.planId
+        : (form.values.treatment_plan_id || null)
+
+      const payload = {
+        ...form.values,
+        dosage_per_intake: currentDose,
+        treatment_plan_id: planId,
+      }
+
+      const result = editId
+        ? await mutation.update(editId, payload, { goBack: true })
+        : await mutation.create(payload, { goBack: true })
+
+      if (!result) setSubmitting(false)
+    } catch (err) {
+      setSubmitting(false)
+      const verb = editId ? 'atualizar' : 'criar'
+      show(err?.message ?? `Erro ao ${verb} tratamento`, { variant: 'error' })
+    }
+  }, [editId, form, planField, mutation, show, submitting, onValidateFail])
+
+  return { submit, submitting }
+}

--- a/apps/mobile/src/features/treatments/hooks/useProtocolStats.js
+++ b/apps/mobile/src/features/treatments/hooks/useProtocolStats.js
@@ -34,7 +34,7 @@ export function useProtocolStats(protocolId) {
       const [protocol, logsResult] = await Promise.all([
         protocolService.getById(protocolId),
         supabase
-          .from('logs')
+          .from('medicine_logs')
           .select('*', { count: 'exact', head: true })
           .eq('protocol_id', protocolId)
           .gte('taken_at', sevenDaysAgo.toISOString())

--- a/apps/mobile/src/features/treatments/screens/ProtocolDetailScreen.jsx
+++ b/apps/mobile/src/features/treatments/screens/ProtocolDetailScreen.jsx
@@ -5,7 +5,7 @@
 // Delete sheet com warning soft + stats chega em Sprint T2.2 (T2.11/T2.12).
 
 import { useCallback, useMemo, useState } from 'react'
-import { ScrollView, View, Text, Pressable, StyleSheet, Alert } from 'react-native'
+import { ScrollView, View, Text, Pressable, StyleSheet } from 'react-native'
 import { useNavigation, useRoute, useFocusEffect } from '@react-navigation/native'
 import {
   ArrowLeft,
@@ -30,6 +30,7 @@ import LoadingState from '@shared/components/states/LoadingState'
 import ErrorState from '@shared/components/states/ErrorState'
 import { useProtocol } from '@treatments/hooks/useProtocols'
 import { protocolService } from '@treatments/services/protocolService'
+import ProtocolDeleteSheet from '@treatments/components/ProtocolDeleteSheet'
 import { useToast } from '@shared/components/feedback/Toast'
 import { lightTap, selectionTap, successHaptic } from '@shared/utils/haptics'
 import { colors, spacing, typography } from '@shared/styles/tokens'
@@ -59,6 +60,7 @@ export default function ProtocolDetailScreen() {
   const { data: protocol, loading, error, refresh } = useProtocol(id)
   const toast = useToast?.()
   const [isDeleting, setIsDeleting] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
 
   // Memos
   const frequencyLabel = useMemo(
@@ -100,33 +102,31 @@ export default function ProtocolDetailScreen() {
   }, [navigation, protocol])
 
   const onDelete = useCallback(() => {
-    // Stub Sprint T2.1 — ProtocolDeleteSheet (T2.11) implementa warning soft + stats.
     if (isDeleting) return
-    Alert.alert(
-      'Excluir tratamento?',
-      'As doses registradas continuam no histórico — apenas o agendamento futuro será removido.',
-      [
-        { text: 'Cancelar', style: 'cancel' },
-        {
-          text: 'Excluir',
-          style: 'destructive',
-          onPress: async () => {
-            setIsDeleting(true)
-            try {
-              await protocolService.delete(id)
-              successHaptic()
-              toast?.show?.('Tratamento excluído', { type: 'success' })
-              navigation.goBack()
-            } catch (err) {
-              if (__DEV__) console.error('[ProtocolDetail.delete]', err)
-              toast?.show?.(err?.message ?? 'Erro ao excluir', { type: 'error' })
-              setIsDeleting(false)
-            }
-          },
-        },
-      ]
-    )
+    lightTap()
+    setDeleteOpen(true)
+  }, [isDeleting])
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (isDeleting) return
+    setIsDeleting(true)
+    try {
+      await protocolService.delete(id)
+      successHaptic()
+      toast?.show?.('Tratamento excluído', { type: 'success' })
+      setDeleteOpen(false)
+      navigation.goBack()
+    } catch (err) {
+      if (__DEV__) console.error('[ProtocolDetail.delete]', err)
+      toast?.show?.(err?.message ?? 'Erro ao excluir', { type: 'error' })
+      setIsDeleting(false)
+    }
   }, [id, isDeleting, navigation, toast])
+
+  const handleCloseDelete = useCallback(() => {
+    if (isDeleting) return
+    setDeleteOpen(false)
+  }, [isDeleting])
 
   if (loading && !protocol) {
     return (
@@ -290,6 +290,14 @@ export default function ProtocolDetailScreen() {
           </Text>
         </Pressable>
       </ScrollView>
+
+      <ProtocolDeleteSheet
+        open={deleteOpen}
+        onClose={handleCloseDelete}
+        onConfirm={handleConfirmDelete}
+        protocolId={id}
+        isDeleting={isDeleting}
+      />
     </ScreenContainer>
   )
 }

--- a/apps/mobile/src/features/treatments/screens/ProtocolFormScreen.jsx
+++ b/apps/mobile/src/features/treatments/screens/ProtocolFormScreen.jsx
@@ -1,113 +1,88 @@
-// ProtocolFormScreen.jsx — formulário CREATE de tratamento (Fase 2 T2.6).
-// Spec EXEC_SPEC_FASE2_PROTOCOLOS.md §3.4.
+// ProtocolFormScreen.jsx — formulário CREATE + EDIT de tratamento (Fase 2 T2.6/T2.7).
+// Spec EXEC_SPEC_FASE2_PROTOCOLOS.md §3.4 / §3.6 / §3.8.
 //
-// v1 PR-B (Sprint T2.2): apenas CREATE mode. Edit (T2.7) e ProtocolFormErrors
-// UX banner (T2.8) entram em PR-C. ProtocolDeleteSheet (T2.11) substitui o
-// Alert stub do ProtocolDetailScreen no mesmo PR-C.
+// Modo: route.params.id presente → EDIT; ausente → CREATE.
+// route.params.treatment_plan_id (create only) → pré-seleciona plano.
 //
-// Composição: MedicineSelectorRow + MedicineSelectorSheet + FormInput + FormSelect
-// + WeekdaySelector + TimeSchedulePicker + FormDatePicker + PlanSelectField +
-// FormActions. Validação via useFormState(protocolCreateSchema). Submit:
-// se PlanSelectField está em modo inline com nome preenchido, cria o plano
-// via treatmentPlanService.create ANTES de criar o tratamento.
+// State/lógica delegados a useProtocolFormState + useProtocolFormSubmit.
+// Render das 6 seções delegado a ProtocolFormBody.
+//
+// Errors UX (T2.8): banner topo + scroll-to-top on validate fail.
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { View, Text, ScrollView, Pressable, StyleSheet, KeyboardAvoidingView, Platform } from 'react-native'
-import { useNavigation, useRoute, useFocusEffect } from '@react-navigation/native'
-import { ArrowLeft } from 'lucide-react-native'
+import { useCallback, useMemo, useRef } from 'react'
 import {
-  protocolCreateSchema,
-  FREQUENCIES,
-  getTodayLocal,
-  parseLocalDate,
-  formatLocalDate,
-} from '@dosiq/core'
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native'
+import { useNavigation, useRoute, useFocusEffect } from '@react-navigation/native'
+import { ArrowLeft, AlertCircle } from 'lucide-react-native'
+import { getTodayLocal, formatLocalDate } from '@dosiq/core'
 import ScreenContainer from '@shared/components/ui/ScreenContainer'
-import FormInput from '@shared/components/form/FormInput'
-import FormSelect from '@shared/components/form/FormSelect'
-import FormDatePicker from '@shared/components/form/FormDatePicker'
 import FormActions from '@shared/components/form/FormActions'
-import { useFormState } from '@shared/hooks/useFormState'
+import LoadingState from '@shared/components/states/LoadingState'
+import ErrorState from '@shared/components/states/ErrorState'
 import { useToast } from '@shared/components/feedback/Toast'
 import { lightTap } from '@shared/utils/haptics'
-import { colors, spacing, typography } from '@shared/styles/tokens'
-import MedicineSelectorRow from '@treatments/components/MedicineSelectorRow'
+import { colors, spacing, typography, borderRadius } from '@shared/styles/tokens'
 import MedicineSelectorSheet from '@treatments/components/MedicineSelectorSheet'
-import WeekdaySelector from '@treatments/components/WeekdaySelector'
-import TimeSchedulePicker from '@treatments/components/TimeSchedulePicker'
-import PlanSelectField from '@treatments/components/PlanSelectField'
-import { treatmentPlanService } from '@treatments/services/treatmentPlanService'
+import ProtocolFormBody from '@treatments/components/ProtocolFormBody'
 import { useProtocolMutation } from '@treatments/hooks/useProtocolMutation'
+import { useProtocolFormState } from '@treatments/hooks/useProtocolFormState'
+import { useProtocolFormSubmit } from '@treatments/hooks/useProtocolFormSubmit'
 import { ROUTES } from '@navigation/routes'
-
-const FREQUENCY_OPTIONS = [
-  { value: 'diário', label: 'Diário' },
-  { value: 'dias_alternados', label: 'Dias alternados' },
-  { value: 'semanal', label: 'Semanal' },
-  { value: 'personalizado', label: 'Personalizado' },
-  { value: 'quando_necessário', label: 'Quando necessário' },
-]
-
-const REQUIRES_WEEKDAYS = new Set(['semanal', 'personalizado'])
-
-function buildInitialValues({ todayIso, presetPlanId }) {
-  return {
-    medicine_id: '',
-    name: '',
-    dosage_per_intake: '',
-    frequency: 'diário',
-    weekdays: [],
-    time_schedule: [],
-    start_date: todayIso,
-    end_date: null,
-    notes: '',
-    active: true,
-    titration_status: 'estável',
-    titration_schedule: [],
-    current_stage_index: 0,
-    treatment_plan_id: presetPlanId || null,
-  }
-}
 
 export default function ProtocolFormScreen() {
   // States (R-010 — States → Memos → Effects → Handlers)
   const navigation = useNavigation()
   const route = useRoute()
-  const presetPlanId = route.params?.treatment_plan_id ?? null
+  const editId = route.params?.id ?? null
+  const isEdit = !!editId
+  const presetPlanId = isEdit ? null : (route.params?.treatment_plan_id ?? null)
   const todayIso = useMemo(() => getTodayLocal(), [])
   const { show } = useToast()
+  const scrollRef = useRef(null)
 
-  const form = useFormState(protocolCreateSchema, {
-    initialValues: buildInitialValues({ todayIso, presetPlanId }),
-  })
-
-  // Sidecar state — UI-only (não vai pro schema)
-  const [medicine, setMedicine] = useState(null) // objeto completo do medicamento selecionado
-  const [sheetOpen, setSheetOpen] = useState(false)
-  // Flag para reabrir o sheet ao voltar de MedicineFormScreen (UX: foco continua
-  // no contexto de selecionar medicamento; sheet recarrega lista e mostra novo).
-  const [pendingReopenSheet, setPendingReopenSheet] = useState(false)
-  const [plans, setPlans] = useState([])
-  const [planField, setPlanField] = useState(() => ({
-    mode: 'select',
-    planId: presetPlanId || null,
-    inline: null,
-  }))
-  const [submitting, setSubmitting] = useState(false)
+  const {
+    form,
+    medicine,
+    selectMedicine,
+    sheetOpen,
+    setSheetOpen,
+    pendingReopenSheet,
+    setPendingReopenSheet,
+    plans,
+    planField,
+    changePlanField,
+    existingLoading,
+    existingError,
+  } = useProtocolFormState({ editId, todayIso, presetPlanId })
 
   const mutation = useProtocolMutation()
 
-  // Memos
-  const showWeekdays = REQUIRES_WEEKDAYS.has(form.values.frequency)
+  const scrollToTop = useCallback(
+    () => scrollRef.current?.scrollTo?.({ y: 0, animated: true }),
+    []
+  )
 
-  const startDateAsDate = useMemo(
-    () => (form.values.start_date ? parseLocalDate(form.values.start_date) : null),
-    [form.values.start_date]
-  )
-  const endDateAsDate = useMemo(
-    () => (form.values.end_date ? parseLocalDate(form.values.end_date) : null),
-    [form.values.end_date]
-  )
+  const { submit, submitting } = useProtocolFormSubmit({
+    editId,
+    form,
+    planField,
+    mutation,
+    show,
+    onValidateFail: scrollToTop,
+  })
+
+  // Memos
+  const visibleErrorCount = useMemo(() => {
+    const errorKeys = Object.keys(form.errors)
+    return errorKeys.filter((k) => form.touched[k]).length
+  }, [form.errors, form.touched])
 
   // Effects — reabrir sheet ao retornar de MedicineFormScreen
   useFocusEffect(
@@ -116,24 +91,8 @@ export default function ProtocolFormScreen() {
         setPendingReopenSheet(false)
         setSheetOpen(true)
       }
-    }, [pendingReopenSheet])
+    }, [pendingReopenSheet, setPendingReopenSheet, setSheetOpen])
   )
-
-  // Effects — carregar planos terapêuticos para o seletor
-  useEffect(() => {
-    let cancelled = false
-    treatmentPlanService
-      .getAll()
-      .then((list) => {
-        if (!cancelled) setPlans(Array.isArray(list) ? list : [])
-      })
-      .catch(() => {
-        if (!cancelled) setPlans([])
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [])
 
   // Handlers
   const goBack = useCallback(() => {
@@ -141,33 +100,22 @@ export default function ProtocolFormScreen() {
     navigation.goBack()
   }, [navigation])
 
-  const handleSelectMedicine = useCallback(
-    (med) => {
-      setMedicine(med)
-      form.handleChange('medicine_id', med.id)
-    },
-    [form]
-  )
-
   const handleOpenSheet = useCallback(() => {
     lightTap()
     setSheetOpen(true)
-  }, [])
+  }, [setSheetOpen])
 
-  const handleCloseSheet = useCallback(() => setSheetOpen(false), [])
+  const handleCloseSheet = useCallback(() => setSheetOpen(false), [setSheetOpen])
 
   const handleCreateNewMedicine = useCallback(() => {
     setPendingReopenSheet(true)
     navigation.navigate(ROUTES.MEDICINE_CREATE)
-  }, [navigation])
+  }, [navigation, setPendingReopenSheet])
 
   const handleDoseChange = useCallback(
     (name, raw) => {
-      // Aceita decimais "0,5" / "0.5" / vazio / intermediários "0," "0.".
-      // Estados intermediários (trailing ponto/vírgula OU só ponto/vírgula)
-      // mantidos como STRING para preservar a digitação do usuário — converter
-      // para Number agora apagaria a vírgula e bloquearia decimais.
-      // Schema Zod faz coerce no submit (z.number()).
+      // Decimais "0,5" / "0.5". Intermediários ("0,", "0.", ".") mantidos como
+      // STRING — converter agora apagaria a vírgula. Coerce no submit.
       const str = String(raw ?? '')
       if (str === '') {
         form.handleChange(name, '')
@@ -186,242 +134,77 @@ export default function ProtocolFormScreen() {
   )
 
   const handleStartDateChange = useCallback(
-    (_name, date) => {
-      form.handleChange('start_date', date ? formatLocalDate(date) : null)
-    },
+    (_name, date) => form.handleChange('start_date', date ? formatLocalDate(date) : null),
     [form]
   )
-
   const handleEndDateChange = useCallback(
-    (_name, date) => {
-      form.handleChange('end_date', date ? formatLocalDate(date) : null)
-    },
+    (_name, date) => form.handleChange('end_date', date ? formatLocalDate(date) : null),
     [form]
   )
 
-  const handlePlanFieldChange = useCallback(
-    (next) => {
-      setPlanField(next)
-      form.handleChange('treatment_plan_id', next.mode === 'select' ? next.planId : null)
-    },
-    [form]
-  )
+  // Render — edge cases EDIT
+  if (existingLoading) {
+    return (
+      <ScreenContainer>
+        <LoadingState message="Carregando tratamento…" />
+      </ScreenContainer>
+    )
+  }
+  if (existingError) {
+    return (
+      <ScreenContainer>
+        <ErrorState message={existingError} onRetry={() => navigation.goBack()} />
+      </ScreenContainer>
+    )
+  }
 
-  const handleSubmit = useCallback(async () => {
-    if (submitting) return
-
-    // Coerce dose string→number. handleChange é assíncrono, mas validate()
-    // lê state atual no momento da call — fora de ciclo de re-render, ainda
-    // vê valor antigo. Usar `currentDose` local garante consistência tanto
-    // no validate quanto no payload final.
-    let currentDose = form.values.dosage_per_intake
-    if (typeof currentDose === 'string' && currentDose !== '') {
-      const normalized = currentDose.replace(',', '.')
-      const num = Number(normalized)
-      if (Number.isFinite(num)) {
-        currentDose = num
-        form.handleChange('dosage_per_intake', num)
-      }
-    }
-
-    // Validação Zod com refinements cross-campo (AP-156)
-    const ok = form.validate()
-    if (!ok) {
-      show('Verifique os campos destacados', { variant: 'error' })
-      return
-    }
-
-    setSubmitting(true)
-    try {
-      let planId = form.values.treatment_plan_id || null
-      // Plano inline: guard explícito por nome — visualmente o user pode ter
-      // entrado em modo inline e deixado nome vazio; sem este check o protocol
-      // seria criado sem plano + um plano órfão poderia aparecer no DB.
-      if (planField.mode === 'inline') {
-        const planName = planField.inline?.name?.trim()
-        if (!planName) {
-          show('Informe o nome do novo plano', { variant: 'error' })
-          setSubmitting(false)
-          return
-        }
-        const created = await treatmentPlanService.create({
-          name: planName,
-          color: planField.inline.color,
-          emoji: planField.inline.emoji,
-        })
-        planId = created?.id ?? null
-      }
-
-      const payload = {
-        ...form.values,
-        dosage_per_intake: currentDose,
-        treatment_plan_id: planId,
-      }
-
-      const result = await mutation.create(payload, { goBack: true })
-      if (!result) setSubmitting(false)
-    } catch (err) {
-      setSubmitting(false)
-      show(err?.message ?? 'Erro ao criar tratamento', { variant: 'error' })
-    }
-  }, [form, planField, mutation, submitting, show])
-
-  const handleCancel = useCallback(() => {
-    lightTap()
-    navigation.goBack()
-  }, [navigation])
+  const appbarTitle = isEdit ? 'Editar tratamento' : 'Novo tratamento'
+  const primaryLabel = isEdit ? 'Salvar alterações' : 'Criar tratamento'
 
   return (
     <ScreenContainer>
-      <View style={styles.appbar}>
-        <Pressable onPress={goBack} style={styles.iconBtn} accessibilityRole="button" accessibilityLabel="Voltar" hitSlop={12}>
-          <ArrowLeft size={24} color={colors.text.primary} />
-        </Pressable>
-        <Text style={styles.appbarTitle}>Novo tratamento</Text>
-        <View style={styles.appbarSpacer} />
-      </View>
+      <AppBar title={appbarTitle} onBack={goBack} />
 
       <KeyboardAvoidingView
         style={styles.flex}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         keyboardVerticalOffset={Platform.OS === 'ios' ? 60 : 0}
       >
-        <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
-          {/* MEDICAMENTO */}
-          <Section title="Medicamento">
-            <MedicineSelectorRow
-              medicine={medicine}
-              onPress={handleOpenSheet}
-              error={form.touched.medicine_id ? form.errors.medicine_id : null}
-            />
-          </Section>
+        <ScrollView
+          ref={scrollRef}
+          contentContainerStyle={styles.scroll}
+          keyboardShouldPersistTaps="handled"
+        >
+          <ErrorsBanner count={visibleErrorCount} />
 
-          {/* INFORMAÇÕES BÁSICAS */}
-          <Section title="Informações básicas">
-            <FormInput
-              name="name"
-              label="Nome do tratamento"
-              value={form.values.name}
-              error={form.touched.name ? form.errors.name : null}
-              onChange={form.handleChange}
-              onBlur={form.handleBlur}
-              placeholder="Ex: SeloZok manhã/noite"
-              required
-            />
-            <FormInput
-              name="dosage_per_intake"
-              label="Dose por tomada"
-              value={form.values.dosage_per_intake === '' ? '' : String(form.values.dosage_per_intake).replace('.', ',')}
-              error={form.touched.dosage_per_intake ? form.errors.dosage_per_intake : null}
-              onChange={handleDoseChange}
-              onBlur={form.handleBlur}
-              placeholder="0"
-              keyboardType="decimal-pad"
-              helperText="Quantas unidades do medicamento por tomada (aceita decimais, ex: 0,5)"
-              required
-            />
-          </Section>
-
-          {/* FREQUÊNCIA */}
-          <Section title="Frequência">
-            <FormSelect
-              name="frequency"
-              label="Periodicidade"
-              value={form.values.frequency}
-              options={FREQUENCY_OPTIONS}
-              onChange={form.handleChange}
-              onBlur={form.handleBlur}
-              error={form.touched.frequency ? form.errors.frequency : null}
-              required
-            />
-            {showWeekdays ? (
-              <View style={styles.fieldBlock}>
-                <Text style={styles.fieldLabel}>Dias da semana</Text>
-                <WeekdaySelector
-                  value={form.values.weekdays}
-                  onChange={(next) => form.handleChange('weekdays', next)}
-                  error={form.touched.weekdays ? form.errors.weekdays : null}
-                />
-              </View>
-            ) : null}
-            <View style={styles.fieldBlock}>
-              <Text style={styles.fieldLabel}>Horários</Text>
-              <TimeSchedulePicker
-                value={form.values.time_schedule}
-                onChange={(next) => form.handleChange('time_schedule', next)}
-                error={form.touched.time_schedule ? form.errors.time_schedule : null}
-              />
-            </View>
-          </Section>
-
-          {/* PERÍODO */}
-          <Section title="Período">
-            <View style={styles.dateRow}>
-              <View style={styles.flex}>
-                <FormDatePicker
-                  name="start_date"
-                  label="Início"
-                  value={startDateAsDate}
-                  onChange={handleStartDateChange}
-                  error={form.touched.start_date ? form.errors.start_date : null}
-                />
-              </View>
-              <View style={styles.flex}>
-                <FormDatePicker
-                  name="end_date"
-                  label="Término"
-                  value={endDateAsDate}
-                  onChange={handleEndDateChange}
-                  error={form.touched.end_date ? form.errors.end_date : null}
-                  helperText="Sem prazo = uso contínuo"
-                  minimumDate={startDateAsDate}
-                />
-              </View>
-            </View>
-          </Section>
-
-          {/* ORGANIZAÇÃO */}
-          <Section title="Organização">
-            <PlanSelectField
-              plans={plans}
-              value={planField}
-              onChange={handlePlanFieldChange}
-              error={form.touched.treatment_plan_id ? form.errors.treatment_plan_id : null}
-            />
-          </Section>
-
-          {/* OBSERVAÇÕES */}
-          <Section title="Observações">
-            <FormInput
-              name="notes"
-              label="Notas"
-              value={form.values.notes}
-              error={form.touched.notes ? form.errors.notes : null}
-              onChange={form.handleChange}
-              onBlur={form.handleBlur}
-              placeholder="Notas sobre este tratamento…"
-              multiline
-              numberOfLines={4}
-              helperText="Opcional"
-            />
-          </Section>
+          <ProtocolFormBody
+            form={form}
+            medicine={medicine}
+            onOpenMedicineSheet={handleOpenSheet}
+            plans={plans}
+            planField={planField}
+            onPlanFieldChange={changePlanField}
+            onDoseChange={handleDoseChange}
+            onStartDateChange={handleStartDateChange}
+            onEndDateChange={handleEndDateChange}
+          />
 
           <View style={styles.bottomSpacer} />
         </ScrollView>
 
         <FormActions
-          primaryLabel="Criar tratamento"
-          onPrimary={handleSubmit}
+          primaryLabel={primaryLabel}
+          onPrimary={submit}
           primaryLoading={submitting || mutation.isLoading}
           secondaryLabel="Cancelar"
-          onSecondary={handleCancel}
+          onSecondary={goBack}
         />
       </KeyboardAvoidingView>
 
       <MedicineSelectorSheet
         open={sheetOpen}
         onClose={handleCloseSheet}
-        onSelect={handleSelectMedicine}
+        onSelect={selectMedicine}
         onCreateNew={handleCreateNewMedicine}
         selectedId={medicine?.id}
       />
@@ -429,11 +212,34 @@ export default function ProtocolFormScreen() {
   )
 }
 
-function Section({ title, children }) {
+function AppBar({ title, onBack }) {
   return (
-    <View style={styles.section}>
-      <Text style={styles.sectionTitle}>{title}</Text>
-      <View style={styles.sectionBody}>{children}</View>
+    <View style={styles.appbar}>
+      <Pressable
+        onPress={onBack}
+        style={styles.iconBtn}
+        accessibilityRole="button"
+        accessibilityLabel="Voltar"
+        hitSlop={12}
+      >
+        <ArrowLeft size={24} color={colors.text.primary} />
+      </Pressable>
+      <Text style={styles.appbarTitle}>{title}</Text>
+      <View style={styles.appbarSpacer} />
+    </View>
+  )
+}
+
+function ErrorsBanner({ count }) {
+  if (count === 0) return null
+  const msg =
+    count === 1
+      ? 'Preencha o campo obrigatório para salvar'
+      : `Preencha os ${count} campos obrigatórios para salvar`
+  return (
+    <View style={styles.errorsBanner} accessibilityRole="alert">
+      <AlertCircle size={18} color={colors.status.error} />
+      <Text style={styles.errorsBannerText}>{msg}</Text>
     </View>
   )
 }
@@ -457,41 +263,31 @@ const styles = StyleSheet.create({
     color: colors.text.primary,
     fontFamily: typography.fontFamily.bold,
   },
+  appbarSpacer: {
+    width: 32,
+  },
   scroll: {
     paddingHorizontal: spacing[5],
     paddingTop: spacing[3],
     paddingBottom: spacing[6],
     gap: spacing[5],
   },
-  section: {
-    gap: spacing[2],
-  },
-  sectionTitle: {
-    fontSize: 12,
-    fontWeight: '700',
-    color: colors.text.secondary,
-    textTransform: 'uppercase',
-    letterSpacing: 0.4,
-  },
-  sectionBody: {
-    gap: spacing[3],
-  },
-  fieldBlock: {
-    gap: spacing[2],
-  },
-  fieldLabel: {
-    fontSize: 13,
-    fontWeight: '700',
-    color: colors.text.primary,
-  },
-  dateRow: {
-    flexDirection: 'row',
-    gap: spacing[3],
-  },
-  appbarSpacer: {
-    width: 32,
-  },
   bottomSpacer: {
     height: spacing[10],
+  },
+  errorsBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[3],
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.status.errorSoft ?? colors.neutral[100],
+  },
+  errorsBannerText: {
+    flex: 1,
+    fontSize: 13,
+    fontWeight: '700',
+    color: colors.status.error,
   },
 })

--- a/apps/mobile/src/shared/hooks/useFormState.js
+++ b/apps/mobile/src/shared/hooks/useFormState.js
@@ -73,24 +73,31 @@ export function useFormState(schema, { initialValues = EMPTY } = {}) {
     [schema, values],
   )
 
-  const validate = useCallback(() => {
-    const result = schema.safeParse(values)
-    if (result.success) {
-      setErrors(EMPTY)
-      return true
-    }
-    setErrors(mapIssues(result.error.issues))
-    // Marca todos campos com erro como touched (UX: mostra mensagens)
-    setTouched((prev) => {
-      const next = { ...prev }
-      for (const issue of result.error.issues) {
-        const path = issue.path[0]
-        if (path) next[path] = true
+  // `overrides`: merge sobre values antes do parse. Evita race entre
+  // handleChange (assíncrono) e validate quando submit precisa coerce
+  // um campo (ex: string "0,5" → number 0.5) na mesma frame.
+  const validate = useCallback(
+    (overrides) => {
+      const candidate = overrides ? { ...values, ...overrides } : values
+      const result = schema.safeParse(candidate)
+      if (result.success) {
+        setErrors(EMPTY)
+        return true
       }
-      return next
-    })
-    return false
-  }, [schema, values])
+      setErrors(mapIssues(result.error.issues))
+      // Marca todos campos com erro como touched (UX: mostra mensagens)
+      setTouched((prev) => {
+        const next = { ...prev }
+        for (const issue of result.error.issues) {
+          const path = issue.path[0]
+          if (path) next[path] = true
+        }
+        return next
+      })
+      return false
+    },
+    [schema, values],
+  )
 
   const reset = useCallback(
     (nextInitial) => {


### PR DESCRIPTION
## Summary

Sprint **T2.2 PR-C** — último PR da Sprint T2.2 da Fase 2 (CRUD Tratamentos mobile). Fecha as 3 tasks restantes + refactor de manutenção do screen principal antes de bater no Gate G1.

Smoke PO validado iOS + Android (incluindo API 24).

## Tasks entregues

### T2.7 — ProtocolFormScreen edit mode
- `route.params.id` presente → carrega via `useProtocol(editId)` + prefill one-shot (guard `prefilled` + `startTransition`)
- AppBar "Editar tratamento" + botão "Salvar alterações"
- Submit roteia para `mutation.update(id, payload)` em vez de `create`
- LoadingState/ErrorState enquanto carrega o protocolo

### T2.8 — Errors UX
- Banner topo (`status.errorSoft`) com contador de campos pendentes — só aparece após `validate()` fail (`touched ∩ errors`)
- Scroll-to-top automático no fail (UX gentle pra Dona Maria — ela vê o banner explicando, não fica perdida procurando o erro)
- Mensagem singular/plural correta

### T2.11 — ProtocolDeleteSheet (substitui `Alert` stub)
- Bottom sheet warning soft com 2 DepLineRows de stats reais via `useProtocolStats`
- Banner info reforça que histórico de doses NÃO é apagado
- Botões Cancelar / Excluir com loading state

## Refactor de manutenção (atendendo pedido PO antes do G1)

Screen principal estava 502 LOC, função 310 LOC, complexity 26. Extraído:

| Arquivo novo | Responsabilidade |
|---|---|
| `hooks/useProtocolFormState.js` | form + sidecar UI + plans load + prefill EDIT |
| `hooks/useProtocolFormSubmit.js` | coerce dose + plano inline + roteamento create/update |
| `components/ProtocolFormBody.jsx` | render das 6 seções (Med/Info/Freq/Período/Org/Notes) |

Resultado:
- `ProtocolFormScreen.jsx`: 502 → 226 LOC, função principal 310 → ~150 LOC, complexity 26 → <20
- 0 erros lint (2 warnings em `ProtocolDetailScreen.jsx` são pré-existentes — fora de escopo, R-221 SQP)

## Bugs corrigidos no smoke (4 ciclos)

| # | Bug | Causa-raiz | Fix |
|---|---|---|---|
| 1 | Card de exclusão mostrava "0 doses tomadas" sempre | `useProtocolStats` queryava `.from('logs')` — tabela inexistente | Trocado para `medicine_logs` (canônico, confirmado em `adherenceService.js`) |
| 2 | Linha "doses pendentes" sem valor informativo no contexto de exclusão | Decisão de produto durante smoke | Removida; stats mostra só confirmadas + agendadas |
| 3 | Android API 24: sheet de delete não cobria topo (sem overlay na status bar) + botões cortados pela bottom tab | `Modal` herda layout do parent navigator no Android | `statusBarTranslucent` + spacer manual `StatusBar.currentHeight` + `SafeAreaView edges=['bottom']` no sheet |
| 4 | Texto duplicado e quebras de linha desnecessárias no body do sheet | UX polish | Mensagem mais curta + warning subtitle reformulado |

## Testes
- ✅ Mobile jest: 148/148 (3 skipped pré-existentes)
- ✅ Lint: 0 errors
- ✅ Smoke iOS: edit completo (load + trocar med + salvar), banner topo + scroll, delete sheet com stats reais
- ✅ Smoke Android API 24: layout sheet correto (topo + bottom), todas as flows acima

## Próximos passos (após merge desta)

PR final mãe → main fechando Sprint T2.2 + abertura da Sprint T2.3 (Gate G2/G3 — extract factory `createProtocolRepository` em `@dosiq/core/repositories/` + web adota).

## Test plan
- [x] \`cd apps/mobile && rtk jest\` → 148/148
- [x] \`rtk lint\` arquivos novos/modificados → 0 errors
- [x] Smoke iOS: ProtocolDetail → edit completo, delete sheet com stats reais
- [x] Smoke Android API 24: sheet cobre status bar + bottom tab, stats reais
- [ ] PO smoke iPhone físico

🤖 Generated with [Claude Code](https://claude.com/claude-code)