### PR TITLE
feat(core/mobile): Sprint T2.3 PR-A — factories @dosiq/core + mobile adopts (G2)

### DIFF
--- a/apps/mobile/src/features/medications/components/MedicineAnvisaSheet.jsx
+++ b/apps/mobile/src/features/medications/components/MedicineAnvisaSheet.jsx
@@ -7,7 +7,10 @@ import {
   Pressable,
   FlatList,
   StyleSheet,
+  Platform,
+  StatusBar,
 } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { Search, X, Pill, PillBottle } from 'lucide-react-native'
 import { useMedicineDatabase } from '@shared/hooks/useMedicineDatabase'
 import { selectionTap } from '@shared/utils/haptics'
@@ -91,10 +94,16 @@ export function MedicineAnvisaSheet({ open, onClose, onSelect }) {
       transparent
       animationType="slide"
       onRequestClose={handleClose}
+      // Android: cobre o stack inteiro (sem isso inputs do form parent vazam
+      // por cima do overlay no Android 7/API 24).
+      statusBarTranslucent
     >
       <View style={styles.root}>
+        {Platform.OS === 'android' ? (
+          <View style={{ height: StatusBar.currentHeight ?? 0 }} />
+        ) : null}
         <Pressable style={styles.backdrop} onPress={handleClose} />
-        <View style={styles.sheet}>
+        <SafeAreaView edges={['bottom']} style={styles.sheet}>
           <View style={styles.handle} />
           <Text style={styles.title}>Base ANVISA</Text>
 
@@ -133,7 +142,7 @@ export function MedicineAnvisaSheet({ open, onClose, onSelect }) {
             keyboardDismissMode="on-drag"
             contentContainerStyle={styles.listContent}
           />
-        </View>
+        </SafeAreaView>
       </View>
     </Modal>
   )

--- a/apps/mobile/src/features/medications/components/MedicineDeleteBlockedSheet.jsx
+++ b/apps/mobile/src/features/medications/components/MedicineDeleteBlockedSheet.jsx
@@ -7,7 +7,8 @@
 // - Footer: Voltar + Abrir tratamentos (CTA verde)
 
 import { useMemo } from 'react'
-import { View, Text, Modal, Pressable, ScrollView, StyleSheet } from 'react-native'
+import { View, Text, Modal, Pressable, ScrollView, StyleSheet, Platform, StatusBar } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { AlertCircle, Layers, Package, ChevronRight } from 'lucide-react-native'
 import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
 
@@ -32,9 +33,19 @@ export function MedicineDeleteBlockedSheet({
   )
 
   return (
-    <Modal visible={visible} transparent animationType="slide" onRequestClose={onCancel}>
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onCancel}
+      // Android: cobre window stack inteiro (parent inputs/tab bar vazam sem isso no API 24).
+      statusBarTranslucent
+    >
+      {Platform.OS === 'android' ? (
+        <View style={{ height: StatusBar.currentHeight ?? 0 }} />
+      ) : null}
       <Pressable style={styles.backdrop} onPress={onCancel} />
-      <View style={styles.sheet}>
+      <SafeAreaView edges={['bottom']} style={styles.sheet}>
         <View style={styles.handle} />
 
         <View style={styles.headerIcon}>
@@ -108,7 +119,7 @@ export function MedicineDeleteBlockedSheet({
             <Text style={styles.btnPrimaryText}>Abrir tratamentos</Text>
           </Pressable>
         </View>
-      </View>
+      </SafeAreaView>
     </Modal>
   )
 }

--- a/apps/mobile/src/features/treatments/components/MedicineSelectorSheet.jsx
+++ b/apps/mobile/src/features/treatments/components/MedicineSelectorSheet.jsx
@@ -14,7 +14,10 @@ import {
   Pressable,
   FlatList,
   StyleSheet,
+  Platform,
+  StatusBar,
 } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { Search, X, Pill, PillBottle, Plus } from 'lucide-react-native'
 import { useMedicines } from '../../medications/hooks/useMedicines'
 import { selectionTap, lightTap } from '@shared/utils/haptics'
@@ -140,10 +143,22 @@ export default function MedicineSelectorSheet({
   }
 
   return (
-    <Modal visible={!!open} transparent animationType="slide" onRequestClose={handleClose}>
+    <Modal
+      visible={!!open}
+      transparent
+      animationType="slide"
+      onRequestClose={handleClose}
+      // Android: statusBarTranslucent faz o Modal cobrir o stack do parent
+      // navigator inteiro (sem isso o sheet só ocupa a área do screen atual
+      // e inputs do form atrás vazam por cima do overlay no Android 7/API 24).
+      statusBarTranslucent
+    >
       <View style={styles.root}>
+        {Platform.OS === 'android' ? (
+          <View style={{ height: StatusBar.currentHeight ?? 0 }} />
+        ) : null}
         <Pressable style={styles.backdrop} onPress={handleClose} />
-        <View style={styles.sheet}>
+        <SafeAreaView edges={['bottom']} style={styles.sheet}>
           <View style={styles.handle} />
           <Text style={styles.title}>Escolher medicamento</Text>
 
@@ -200,7 +215,7 @@ export default function MedicineSelectorSheet({
             <Plus size={18} color={colors.primary[700]} />
             <Text style={styles.footerBtnText}>Cadastrar novo medicamento</Text>
           </Pressable>
-        </View>
+        </SafeAreaView>
       </View>
     </Modal>
   )

--- a/apps/mobile/src/features/treatments/components/ProtocolFormBody.jsx
+++ b/apps/mobile/src/features/treatments/components/ProtocolFormBody.jsx
@@ -69,7 +69,7 @@ export default function ProtocolFormBody({
           error={form.touched.name ? form.errors.name : null}
           onChange={form.handleChange}
           onBlur={form.handleBlur}
-          placeholder="Ex: SeloZok manhã/noite"
+          placeholder="Ex: Hipertensão"
           maxLength={200}
           required
         />

--- a/apps/mobile/src/features/treatments/services/protocolService.js
+++ b/apps/mobile/src/features/treatments/services/protocolService.js
@@ -1,21 +1,11 @@
-// protocolService.js — CRUD mobile de protocolos (Fase 2 G1: cópia web → mobile).
+// protocolService.js — CRUD mobile de tratamentos (Fase 2 G2: adopt factory).
 //
-// G1 (cópia) por design: arquivo independente, sem factory, para validar
-// contrato + schemas no Hermes antes de extrair para @dosiq/core em G2 (Sprint T2.3).
-// Espelha apps/web/src/features/protocols/services/protocolService.js — qualquer
-// divergência intencional deve ser comentada inline.
-//
-// DI mobile:
-// - client: nativeSupabaseClient (Expo)
-// - getUserId via supabase.auth.getUser()
-// - schemas/utils via @dosiq/core (validateProtocolCreate/Update, getTodayLocal, getServerTimestamp)
+// G2: thin wrapper sobre createProtocolRepository de @dosiq/core/repositories.
+// DI mobile: nativeSupabaseClient + getUserId via supabase.auth.
+// detailSelect customizado pra trazer treatment_plan completo (ProtocolDetailScreen
+// renderiza emoji/name/etc; default da factory traz só medicine).
 
-import {
-  validateProtocolCreate,
-  validateProtocolUpdate,
-  getTodayLocal,
-  getServerTimestamp,
-} from '@dosiq/core'
+import { createProtocolRepository } from '@dosiq/core'
 import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
 
 async function getUserId() {
@@ -25,120 +15,14 @@ async function getUserId() {
   return user.id
 }
 
-function formatValidationError(errors) {
-  const msg = errors.map((e) => `${e.field}: ${e.message}`).join('; ')
-  return new Error(`Erro de validação: ${msg}`)
-}
-
-// Selects compostos — espelhar web. Detail/list incluem medicine + treatment_plan.
-const LIST_SELECT = `
-  *,
-  medicine:medicines(*),
-  treatment_plan:treatment_plans(id, name, emoji, color)
-`
-
-const DETAIL_SELECT = `
+const MOBILE_DETAIL_SELECT = `
   *,
   medicine:medicines(*),
   treatment_plan:treatment_plans(*)
 `
 
-export const protocolService = {
-  async getAll() {
-    const { data, error } = await supabase
-      .from('protocols')
-      .select(LIST_SELECT)
-      .eq('user_id', await getUserId())
-      .order('created_at', { ascending: false })
-
-    if (error) throw error
-    return data ?? []
-  },
-
-  async getActive(date = getTodayLocal()) {
-    const { data, error } = await supabase
-      .from('protocols')
-      .select(LIST_SELECT)
-      .eq('user_id', await getUserId())
-      .eq('active', true)
-      .lte('start_date', date)
-      .or(`end_date.is.null,end_date.gte.${date}`)
-      .order('created_at', { ascending: false })
-
-    if (error) throw error
-    return data ?? []
-  },
-
-  async getById(id) {
-    const { data, error } = await supabase
-      .from('protocols')
-      .select(DETAIL_SELECT)
-      .eq('id', id)
-      .eq('user_id', await getUserId())
-      .single()
-
-    if (error) throw error
-    return data
-  },
-
-  async create(protocol) {
-    const validation = validateProtocolCreate(protocol)
-    if (!validation.success) throw formatValidationError(validation.errors)
-
-    const validated = validation.data
-    const { data, error } = await supabase
-      .from('protocols')
-      .insert([
-        {
-          ...validated,
-          user_id: await getUserId(),
-          titration_schedule: validated.titration_schedule || [],
-          current_stage_index: validated.current_stage_index || 0,
-          stage_started_at:
-            validated.titration_schedule?.length > 0 ? getServerTimestamp() : null,
-        },
-      ])
-      .select(DETAIL_SELECT)
-      .single()
-
-    if (error) throw error
-    return data
-  },
-
-  async update(id, updates) {
-    const validation = validateProtocolUpdate(updates)
-    if (!validation.success) throw formatValidationError(validation.errors)
-
-    const { data, error } = await supabase
-      .from('protocols')
-      .update(validation.data)
-      .eq('id', id)
-      .eq('user_id', await getUserId())
-      .select(DETAIL_SELECT)
-      .single()
-
-    if (error) throw error
-    return data
-  },
-
-  async delete(id) {
-    const { error } = await supabase
-      .from('protocols')
-      .delete()
-      .eq('id', id)
-      .eq('user_id', await getUserId())
-
-    if (error) throw error
-  },
-
-  async getByMedicineId(medicineId) {
-    const { data, error } = await supabase
-      .from('protocols')
-      .select('*')
-      .eq('medicine_id', medicineId)
-      .eq('user_id', await getUserId())
-
-    if (error) throw error
-    return data ?? []
-  },
-}
+export const protocolService = createProtocolRepository({
+  client: supabase,
+  getUserId,
+  detailSelect: MOBILE_DETAIL_SELECT,
+})

--- a/apps/mobile/src/features/treatments/services/treatmentPlanService.js
+++ b/apps/mobile/src/features/treatments/services/treatmentPlanService.js
@@ -1,9 +1,9 @@
-// treatmentPlanService.js — CRUD mobile de planos terapêuticos (Fase 2 G1).
+// treatmentPlanService.js — CRUD mobile de planos terapêuticos (Fase 2 G2).
 //
-// G1 cópia direta de apps/web/src/features/protocols/services/treatmentPlanService.js
-// DI: nativeSupabaseClient + getUserId via supabase.auth.
-// Web não valida Zod (não há schema canônico); mobile espelha.
+// G2: thin wrapper sobre createTreatmentPlanRepository de @dosiq/core/repositories.
+// DI mobile: nativeSupabaseClient + getUserId via supabase.auth.
 
+import { createTreatmentPlanRepository } from '@dosiq/core'
 import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
 
 async function getUserId() {
@@ -13,70 +13,7 @@ async function getUserId() {
   return user.id
 }
 
-const FULL_SELECT = `
-  *,
-  protocols:protocols(
-    *,
-    medicine:medicines(*)
-  )
-`
-
-export const treatmentPlanService = {
-  async getAll() {
-    const { data, error } = await supabase
-      .from('treatment_plans')
-      .select(FULL_SELECT)
-      .eq('user_id', await getUserId())
-      .order('created_at', { ascending: false })
-
-    if (error) throw error
-    return data ?? []
-  },
-
-  async getById(id) {
-    const { data, error } = await supabase
-      .from('treatment_plans')
-      .select(FULL_SELECT)
-      .eq('id', id)
-      .eq('user_id', await getUserId())
-      .single()
-
-    if (error) throw error
-    return data
-  },
-
-  async create(plan) {
-    const { data, error } = await supabase
-      .from('treatment_plans')
-      .insert([{ ...plan, user_id: await getUserId() }])
-      .select()
-      .single()
-
-    if (error) throw error
-    return data
-  },
-
-  async update(id, updates) {
-    const { data, error } = await supabase
-      .from('treatment_plans')
-      .update(updates)
-      .eq('id', id)
-      .eq('user_id', await getUserId())
-      .select()
-      .single()
-
-    if (error) throw error
-    return data
-  },
-
-  // Nota: protocols associados têm treatment_plan_id setado para NULL via ON DELETE SET NULL.
-  async delete(id) {
-    const { error } = await supabase
-      .from('treatment_plans')
-      .delete()
-      .eq('id', id)
-      .eq('user_id', await getUserId())
-
-    if (error) throw error
-  },
-}
+export const treatmentPlanService = createTreatmentPlanRepository({
+  client: supabase,
+  getUserId,
+})

--- a/docs/reference/GLOSSARY.md
+++ b/docs/reference/GLOSSARY.md
@@ -45,7 +45,7 @@ Aplicam-se a TODA UI do app (mobile + web).
 | Termo UI (PT) | Variável código (EN) | DB | Notas |
 |---------------|---------------------|-----|-------|
 | Tratamento(s) | `protocol(s)` | `protocols` | Sempre "tratamento" em UI |
-| Nome do tratamento | `name` | string | Ex: "SeloZok manhã/noite" |
+| Nome do tratamento | `name` | string | Ex: "Hipertensão" |
 | Plano terapêutico / Organização | `treatment_plan` | `treatment_plans` | "Plano" curto OU "Organização" em forms |
 | Dose por tomada | `dosage_per_intake` | number | Em unidades farmacêuticas; render via `formatDoseUnit` |
 | Frequência / Periodicidade | `frequency` | enum (`diario`, `dias_alternados`, `semanal`, `personalizado`, `quando_necessario`) | PT-BR snake_case |

--- a/packages/core/src/repositories/__tests__/createProtocolRepository.test.js
+++ b/packages/core/src/repositories/__tests__/createProtocolRepository.test.js
@@ -1,0 +1,376 @@
+// Parity tests — createProtocolRepository (Fase 2 T3.3)
+//
+// Garante que web e mobile, ao injetarem suas opções/transforms, produzem:
+//   - As mesmas chamadas Supabase (table, filter, payload)
+//   - O mesmo formato de erro de validação
+//   - Transforms são aplicados em getAll/getActive/getById
+//
+// Não tocamos no Supabase real — mock builder fluente (espelha createMedicineRepository.test.js).
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createProtocolRepository } from '../createProtocolRepository.js'
+
+// ---------- Mock Supabase fluent builder ----------
+function makeBuilder(result) {
+  const builder = {
+    _calls: [],
+    select: vi.fn(function (...args) { this._calls.push(['select', args]); return this }),
+    insert: vi.fn(function (...args) { this._calls.push(['insert', args]); return this }),
+    update: vi.fn(function (...args) { this._calls.push(['update', args]); return this }),
+    delete: vi.fn(function (...args) { this._calls.push(['delete', args]); return this }),
+    eq:     vi.fn(function (...args) { this._calls.push(['eq', args]); return this }),
+    lte:    vi.fn(function (...args) { this._calls.push(['lte', args]); return this }),
+    or:     vi.fn(function (...args) { this._calls.push(['or', args]); return this }),
+    order:  vi.fn(function (...args) { this._calls.push(['order', args]); return this }),
+    single: vi.fn(function ()        { this._calls.push(['single', []]); return Promise.resolve(result) }),
+    then:   (resolve) => resolve(result),
+  }
+  return builder
+}
+
+function makeClient(result) {
+  const builder = makeBuilder(result)
+  const client = {
+    _builder: builder,
+    _from: null,
+    from: vi.fn((table) => { client._from = table; return builder }),
+  }
+  return client
+}
+
+const FAKE_USER = 'user-123'
+const getUserId = async () => FAKE_USER
+
+// Fixture base para criação válida (sem titração)
+const VALID_PROTOCOL = {
+  medicine_id: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d',
+  name: 'Atenolol 25mg',
+  frequency: 'diário',
+  time_schedule: ['08:00'],
+  dosage_per_intake: 25,
+  start_date: '2026-01-01',
+}
+
+// Fixture com titração (2 stages — exige titration_status='titulando')
+const TITRATION_SCHEDULE = [
+  { dosage: 25, duration_days: 14 },
+  { dosage: 50, duration_days: 28 },
+]
+const VALID_PROTOCOL_TITRATION = {
+  ...VALID_PROTOCOL,
+  titration_schedule: TITRATION_SCHEDULE,
+  titration_status: 'titulando',
+  current_stage_index: 0,
+}
+
+// ---------- Suite ----------
+describe('createProtocolRepository — parity', () => {
+  let client
+
+  beforeEach(() => {
+    client = makeClient({ data: [{ id: 'p-1', name: 'Atenolol' }], error: null })
+  })
+
+  // ── Constructor validation ────────────────────────────────────────────────
+
+  it('throws se client ausente', () => {
+    expect(() => createProtocolRepository({ getUserId })).toThrow(/client/)
+  })
+
+  it('throws se getUserId não for função', () => {
+    expect(() => createProtocolRepository({ client, getUserId: null })).toThrow(/getUserId/)
+  })
+
+  // ── getAll ────────────────────────────────────────────────────────────────
+
+  describe('getAll', () => {
+    it('selects from protocols + eq user_id + order created_at desc', async () => {
+      const repo = createProtocolRepository({ client, getUserId })
+      await repo.getAll()
+      expect(client.from).toHaveBeenCalledWith('protocols')
+      const calls = client._builder._calls
+      expect(calls).toEqual([
+        ['select', [expect.stringContaining('medicine:medicines')]],
+        ['eq', ['user_id', FAKE_USER]],
+        ['order', ['created_at', { ascending: false }]],
+      ])
+    })
+
+    it('propaga erro do supabase', async () => {
+      client = makeClient({ data: null, error: new Error('db down') })
+      const repo = createProtocolRepository({ client, getUserId })
+      await expect(repo.getAll()).rejects.toThrow('db down')
+    })
+  })
+
+  // ── getActive ─────────────────────────────────────────────────────────────
+
+  describe('getActive', () => {
+    it('aplica filtros active + lte start_date + or end_date com data padrão (getTodayLocal)', async () => {
+      const repo = createProtocolRepository({ client, getUserId })
+      await repo.getActive()
+      const calls = client._builder._calls
+      expect(calls).toContainEqual(['eq', ['active', true]])
+      const lteCall = calls.find(([m]) => m === 'lte')
+      expect(lteCall).toBeDefined()
+      expect(lteCall[1][0]).toBe('start_date')
+      const orCall = calls.find(([m]) => m === 'or')
+      expect(orCall).toBeDefined()
+      expect(orCall[1][0]).toMatch(/end_date\.is\.null/)
+    })
+
+    it('aceita date customizado e usa no lte/or', async () => {
+      const repo = createProtocolRepository({ client, getUserId })
+      await repo.getActive('2026-06-01')
+      const calls = client._builder._calls
+      const lteCall = calls.find(([m]) => m === 'lte')
+      expect(lteCall[1]).toEqual(['start_date', '2026-06-01'])
+      const orCall = calls.find(([m]) => m === 'or')
+      expect(orCall[1][0]).toContain('2026-06-01')
+    })
+
+    it('aplica listTransform no resultado', async () => {
+      client = makeClient({ data: [{ id: 'p-1' }, { id: 'p-2' }], error: null })
+      const repo = createProtocolRepository({
+        client, getUserId,
+        listTransform: (rows) => rows.map((r) => ({ ...r, active: true })),
+      })
+      const result = await repo.getActive('2026-01-01')
+      expect(result).toEqual([{ id: 'p-1', active: true }, { id: 'p-2', active: true }])
+    })
+  })
+
+  // ── getById ───────────────────────────────────────────────────────────────
+
+  describe('getById', () => {
+    beforeEach(() => {
+      client = makeClient({ data: { id: 'p-1', name: 'Atenolol' }, error: null })
+    })
+
+    it('select + eq id + eq user_id + .single()', async () => {
+      const repo = createProtocolRepository({ client, getUserId })
+      await repo.getById('p-1')
+      const calls = client._builder._calls
+      expect(calls).toEqual([
+        ['select', [expect.stringContaining('medicine:medicines')]],
+        ['eq', ['id', 'p-1']],
+        ['eq', ['user_id', FAKE_USER]],
+        ['single', []],
+      ])
+    })
+
+    it('aplica detailTransform', async () => {
+      const repo = createProtocolRepository({
+        client, getUserId,
+        detailTransform: (row) => ({ ...row, decorated: true }),
+      })
+      const result = await repo.getById('p-1')
+      expect(result).toEqual({ id: 'p-1', name: 'Atenolol', decorated: true })
+    })
+  })
+
+  // ── getByMedicineId ───────────────────────────────────────────────────────
+
+  describe('getByMedicineId', () => {
+    it('filtra por medicine_id + user_id e retorna [] se data null', async () => {
+      client = makeClient({ data: null, error: null })
+      const repo = createProtocolRepository({ client, getUserId })
+      const result = await repo.getByMedicineId('med-uuid-999')
+      expect(client.from).toHaveBeenCalledWith('protocols')
+      const calls = client._builder._calls
+      expect(calls).toContainEqual(['eq', ['medicine_id', 'med-uuid-999']])
+      expect(calls).toContainEqual(['eq', ['user_id', FAKE_USER]])
+      expect(result).toEqual([])
+    })
+  })
+
+  // ── create ────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    beforeEach(() => {
+      client = makeClient({ data: { id: 'new-p-1', ...VALID_PROTOCOL }, error: null })
+    })
+
+    it('validation fail → throws "Erro de validação"', async () => {
+      const repo = createProtocolRepository({ client, getUserId })
+      await expect(repo.create({ name: 'Incompleto' })).rejects.toThrow(/Erro de validação/)
+    })
+
+    it('validation ok → insert recebe payload com user_id e defaults de titulação', async () => {
+      const repo = createProtocolRepository({ client, getUserId })
+      await repo.create(VALID_PROTOCOL)
+      const insertCall = client._builder._calls.find(([m]) => m === 'insert')
+      expect(insertCall[1][0]).toEqual([
+        expect.objectContaining({
+          name: 'Atenolol 25mg',
+          dosage_per_intake: 25,
+          user_id: FAKE_USER,
+          titration_schedule: [],
+          current_stage_index: 0,
+          stage_started_at: null,
+        }),
+      ])
+    })
+
+    it('titration_schedule preenchido → stage_started_at é string (getServerTimestamp)', async () => {
+      client = makeClient({ data: { id: 'new-p-2', ...VALID_PROTOCOL_TITRATION }, error: null })
+      const repo = createProtocolRepository({ client, getUserId })
+      await repo.create(VALID_PROTOCOL_TITRATION)
+      const insertCall = client._builder._calls.find(([m]) => m === 'insert')
+      const payload = insertCall[1][0][0]
+      expect(typeof payload.stage_started_at).toBe('string')
+      expect(payload.stage_started_at).not.toBeNull()
+    })
+
+    it('usa writeSelect customizado se passado', async () => {
+      const customSelect = 'id, name'
+      client = makeClient({ data: { id: 'new-p-3' }, error: null })
+      const repo = createProtocolRepository({ client, getUserId, writeSelect: customSelect })
+      await repo.create(VALID_PROTOCOL)
+      const selectCall = client._builder._calls.find(
+        ([m, args]) => m === 'select' && args[0] === customSelect
+      )
+      expect(selectCall).toBeDefined()
+    })
+  })
+
+  // ── update ────────────────────────────────────────────────────────────────
+
+  describe('update', () => {
+    beforeEach(() => {
+      client = makeClient({ data: { id: 'p-1', name: 'Novo Nome' }, error: null })
+    })
+
+    it('validation fail → throws "Erro de validação"', async () => {
+      const repo = createProtocolRepository({ client, getUserId })
+      // dosage_per_intake negativo deve falhar
+      await expect(repo.update('p-1', { dosage_per_intake: -1 })).rejects.toThrow(/Erro de validação/)
+    })
+
+    it('validation ok → envia validated.data via .update()', async () => {
+      const repo = createProtocolRepository({ client, getUserId })
+      await repo.update('p-1', { name: 'Nome Atualizado' })
+      const calls = client._builder._calls
+      const updateCall = calls.find(([m]) => m === 'update')
+      expect(updateCall[1][0]).toMatchObject({ name: 'Nome Atualizado' })
+      expect(calls).toContainEqual(['eq', ['id', 'p-1']])
+      expect(calls).toContainEqual(['eq', ['user_id', FAKE_USER]])
+    })
+  })
+
+  // ── delete ────────────────────────────────────────────────────────────────
+
+  describe('delete', () => {
+    it('chama .delete().eq(id).eq(user_id)', async () => {
+      client = makeClient({ data: null, error: null })
+      const repo = createProtocolRepository({ client, getUserId })
+      await repo.delete('p-1')
+      const calls = client._builder._calls
+      expect(calls).toEqual([
+        ['delete', []],
+        ['eq', ['id', 'p-1']],
+        ['eq', ['user_id', FAKE_USER]],
+      ])
+    })
+  })
+
+  // ── advanceTitrationStage ─────────────────────────────────────────────────
+
+  describe('advanceTitrationStage', () => {
+    it('throws se protocol sem titration_schedule', async () => {
+      // getById retorna protocolo sem schedule
+      client = makeClient({ data: { id: 'p-1', titration_schedule: [], current_stage_index: 0 }, error: null })
+      const repo = createProtocolRepository({ client, getUserId })
+      await expect(repo.advanceTitrationStage('p-1')).rejects.toThrow(/titulação/)
+    })
+
+    it('próximo stage normal → update com nextIndex, dosage do nextStage, status=titulando', async () => {
+      // getById retorna protocolo com 2 stages, current=0
+      // update retorna o mesmo objeto (não importa o shape neste teste)
+      const protocol = {
+        id: 'p-1',
+        titration_schedule: TITRATION_SCHEDULE,
+        current_stage_index: 0,
+      }
+      let callCount = 0
+      // Precisamos que getById use .single() e update também — fazemos um client
+      // que alterna respostas: 1a chamada (getById→single) retorna protocol,
+      // 2a chamada (update) retorna o updated.
+      const builder = makeBuilder(null)
+      let singleCallCount = 0
+      builder.single = vi.fn(function () {
+        singleCallCount++
+        if (singleCallCount === 1) return Promise.resolve({ data: protocol, error: null })
+        return Promise.resolve({ data: { ...protocol, current_stage_index: 1 }, error: null })
+      })
+      builder.then = (resolve) => {
+        callCount++
+        resolve({ data: [protocol], error: null })
+      }
+      const advClient = {
+        _builder: builder,
+        from: vi.fn(() => builder),
+      }
+
+      const repo = createProtocolRepository({ client: advClient, getUserId })
+      await repo.advanceTitrationStage('p-1')
+
+      const updateCall = builder._calls.find(([m]) => m === 'update')
+      expect(updateCall[1][0]).toMatchObject({
+        current_stage_index: 1,
+        dosage_per_intake: 50, // nextStage.dosage
+        titration_status: 'titulando',
+      })
+    })
+
+    it('markAsCompleted=true → status=alvo_atingido mesmo no meio do schedule', async () => {
+      const protocol = {
+        id: 'p-1',
+        titration_schedule: TITRATION_SCHEDULE,
+        current_stage_index: 0,
+      }
+      const builder = makeBuilder(null)
+      let singleCallCount = 0
+      builder.single = vi.fn(function () {
+        singleCallCount++
+        if (singleCallCount === 1) return Promise.resolve({ data: protocol, error: null })
+        return Promise.resolve({ data: { ...protocol, titration_status: 'alvo_atingido' }, error: null })
+      })
+      builder.then = (resolve) => resolve({ data: [protocol], error: null })
+      const advClient = { _builder: builder, from: vi.fn(() => builder) }
+
+      const repo = createProtocolRepository({ client: advClient, getUserId })
+      await repo.advanceTitrationStage('p-1', true)
+
+      const updateCall = builder._calls.find(([m]) => m === 'update')
+      expect(updateCall[1][0]).toMatchObject({ titration_status: 'alvo_atingido' })
+    })
+
+    it('esgotou schedule (nextIndex >= length) → status=alvo_atingido, index=length-1', async () => {
+      // current_stage_index=1, schedule length=2 → nextIndex=2 >= 2
+      const protocol = {
+        id: 'p-1',
+        titration_schedule: TITRATION_SCHEDULE,
+        current_stage_index: 1,
+      }
+      const builder = makeBuilder(null)
+      let singleCallCount = 0
+      builder.single = vi.fn(function () {
+        singleCallCount++
+        if (singleCallCount === 1) return Promise.resolve({ data: protocol, error: null })
+        return Promise.resolve({ data: { ...protocol, titration_status: 'alvo_atingido' }, error: null })
+      })
+      builder.then = (resolve) => resolve({ data: [protocol], error: null })
+      const advClient = { _builder: builder, from: vi.fn(() => builder) }
+
+      const repo = createProtocolRepository({ client: advClient, getUserId })
+      await repo.advanceTitrationStage('p-1')
+
+      const updateCall = builder._calls.find(([m]) => m === 'update')
+      expect(updateCall[1][0]).toMatchObject({
+        titration_status: 'alvo_atingido',
+        current_stage_index: 1, // length-1 = 2-1
+      })
+    })
+  })
+})

--- a/packages/core/src/repositories/__tests__/createTreatmentPlanRepository.test.js
+++ b/packages/core/src/repositories/__tests__/createTreatmentPlanRepository.test.js
@@ -1,0 +1,229 @@
+// Parity tests — createTreatmentPlanRepository (Fase 2 T2.3)
+//
+// Garante que web e mobile, ao injetarem suas opções/transforms, produzem:
+//   - As mesmas chamadas Supabase (table, filter, payload)
+//   - O mesmo comportamento de erro
+//   - Transforms são aplicados em getAll/getById
+//
+// Não tocamos no Supabase real — mock builder fluente.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createTreatmentPlanRepository } from '../createTreatmentPlanRepository.js'
+
+// ---------- Mock Supabase fluent builder ----------
+function makeBuilder(result) {
+  const builder = {
+    _calls: [],
+    select: vi.fn(function (...args) { this._calls.push(['select', args]); return this }),
+    insert: vi.fn(function (...args) { this._calls.push(['insert', args]); return this }),
+    update: vi.fn(function (...args) { this._calls.push(['update', args]); return this }),
+    delete: vi.fn(function (...args) { this._calls.push(['delete', args]); return this }),
+    eq:     vi.fn(function (...args) { this._calls.push(['eq', args]); return this }),
+    order:  vi.fn(function (...args) { this._calls.push(['order', args]); return this }),
+    single: vi.fn(function ()        { this._calls.push(['single', []]); return Promise.resolve(result) }),
+    then:   (resolve) => resolve(result), // permite await em chain sem .single()
+  }
+  return builder
+}
+
+function makeClient(result) {
+  const builder = makeBuilder(result)
+  const client = {
+    _builder: builder,
+    _from: null,
+    from: vi.fn((table) => { client._from = table; return builder }),
+  }
+  return client
+}
+
+const FAKE_USER = 'user-uuid-123'
+const getUserId = async () => FAKE_USER
+
+const VALID_PLAN = {
+  name: 'Tratamento hipertensão',
+  description: 'Acompanhamento crônico',
+}
+
+// ---------- Suite ----------
+describe('createTreatmentPlanRepository — parity', () => {
+  let client
+
+  beforeEach(() => {
+    client = makeClient({ data: [{ id: 'plan-1', name: 'X', protocols: [] }], error: null })
+  })
+
+  it('throws if client missing', () => {
+    expect(() => createTreatmentPlanRepository({ getUserId })).toThrow(/client/)
+  })
+
+  it('throws if getUserId not function', () => {
+    expect(() => createTreatmentPlanRepository({ client, getUserId: null })).toThrow(/getUserId/)
+  })
+
+  describe('getAll', () => {
+    it('selects from treatment_plans + filters by user_id + orders desc by created_at', async () => {
+      const repo = createTreatmentPlanRepository({ client, getUserId })
+      await repo.getAll()
+      expect(client.from).toHaveBeenCalledWith('treatment_plans')
+      const calls = client._builder._calls
+      expect(calls).toEqual([
+        ['select', ['*, protocols:protocols(*, medicine:medicines(*))']],
+        ['eq', ['user_id', FAKE_USER]],
+        ['order', ['created_at', { ascending: false }]],
+      ])
+    })
+
+    it('honors listSelect override (web preset)', async () => {
+      const repo = createTreatmentPlanRepository({
+        client, getUserId,
+        listSelect: '*, protocols(id)',
+      })
+      await repo.getAll()
+      expect(client._builder.select).toHaveBeenCalledWith('*, protocols(id)')
+    })
+
+    it('applies listTransform', async () => {
+      client = makeClient({ data: [{ id: 'a' }, { id: 'b' }], error: null })
+      const repo = createTreatmentPlanRepository({
+        client, getUserId,
+        listTransform: (rows) => rows.map((r) => ({ ...r, tagged: true })),
+      })
+      const result = await repo.getAll()
+      expect(result).toEqual([{ id: 'a', tagged: true }, { id: 'b', tagged: true }])
+    })
+
+    it('returns [] when data null', async () => {
+      client = makeClient({ data: null, error: null })
+      const repo = createTreatmentPlanRepository({ client, getUserId })
+      const result = await repo.getAll()
+      expect(result).toEqual([])
+    })
+
+    it('throws on supabase error', async () => {
+      client = makeClient({ data: null, error: new Error('boom') })
+      const repo = createTreatmentPlanRepository({ client, getUserId })
+      await expect(repo.getAll()).rejects.toThrow('boom')
+    })
+  })
+
+  describe('getById', () => {
+    beforeEach(() => {
+      client = makeClient({ data: { id: 'plan-1', name: 'X', protocols: [] }, error: null })
+    })
+
+    it('selects detail + filters id + user_id + .single()', async () => {
+      const repo = createTreatmentPlanRepository({ client, getUserId })
+      await repo.getById('plan-1')
+      const calls = client._builder._calls
+      expect(calls).toEqual([
+        ['select', ['*, protocols:protocols(*, medicine:medicines(*))']],
+        ['eq', ['id', 'plan-1']],
+        ['eq', ['user_id', FAKE_USER]],
+        ['single', []],
+      ])
+    })
+
+    it('applies detailTransform', async () => {
+      const repo = createTreatmentPlanRepository({
+        client, getUserId,
+        detailTransform: (row) => ({ ...row, decorated: 1 }),
+      })
+      const result = await repo.getById('plan-1')
+      expect(result).toEqual({ id: 'plan-1', name: 'X', protocols: [], decorated: 1 })
+    })
+  })
+
+  describe('create', () => {
+    beforeEach(() => {
+      client = makeClient({ data: { id: 'new-1', ...VALID_PLAN, protocols: [] }, error: null })
+    })
+
+    it('insere payload com user_id', async () => {
+      const repo = createTreatmentPlanRepository({ client, getUserId })
+      await repo.create(VALID_PLAN)
+      const insertCall = client._builder._calls.find(([m]) => m === 'insert')
+      expect(insertCall[1][0]).toEqual([
+        expect.objectContaining({
+          name: 'Tratamento hipertensão',
+          description: 'Acompanhamento crônico',
+          user_id: FAKE_USER,
+        }),
+      ])
+    })
+
+    it('propaga erro supabase', async () => {
+      client = makeClient({ data: null, error: new Error('duplicate key') })
+      const repo = createTreatmentPlanRepository({ client, getUserId })
+      await expect(repo.create(VALID_PLAN)).rejects.toThrow('duplicate key')
+    })
+  })
+
+  describe('update', () => {
+    beforeEach(() => {
+      client = makeClient({ data: { id: 'plan-1', name: 'Novo', protocols: [] }, error: null })
+    })
+
+    it('update por id + user_id', async () => {
+      const repo = createTreatmentPlanRepository({ client, getUserId })
+      await repo.update('plan-1', { name: 'Novo' })
+      const calls = client._builder._calls
+      expect(calls[0]).toEqual(['update', [expect.objectContaining({ name: 'Novo' })]])
+      expect(calls[1]).toEqual(['eq', ['id', 'plan-1']])
+      expect(calls[2]).toEqual(['eq', ['user_id', FAKE_USER]])
+    })
+  })
+
+  describe('delete', () => {
+    beforeEach(() => {
+      client = makeClient({ data: null, error: null })
+    })
+
+    it('deleta filtrando id + user_id (ON DELETE SET NULL em protocols é só SQL)', async () => {
+      const repo = createTreatmentPlanRepository({ client, getUserId })
+      await repo.delete('plan-1')
+      const calls = client._builder._calls
+      expect(calls).toEqual([
+        ['delete', []],
+        ['eq', ['id', 'plan-1']],
+        ['eq', ['user_id', FAKE_USER]],
+      ])
+    })
+  })
+
+  describe('parity: web vs mobile presets produzem CRUD idêntico', () => {
+    it('create payload é idêntico para web/mobile (mesmo schema canônico)', async () => {
+      const clientWeb = makeClient({ data: { id: 'w' }, error: null })
+      const clientMob = makeClient({ data: { id: 'm' }, error: null })
+
+      const repoWeb = createTreatmentPlanRepository({
+        client: clientWeb, getUserId,
+        listSelect: '*, protocols(id)',
+      })
+      const repoMob = createTreatmentPlanRepository({
+        client: clientMob, getUserId,
+        listSelect: '*, protocols(*, medicine(id))',
+      })
+
+      await repoWeb.create(VALID_PLAN)
+      await repoMob.create(VALID_PLAN)
+
+      const webInsert = clientWeb._builder._calls.find(([m]) => m === 'insert')[1][0][0]
+      const mobInsert = clientMob._builder._calls.find(([m]) => m === 'insert')[1][0][0]
+      expect(webInsert).toEqual(mobInsert)
+    })
+
+    it('update e delete são idênticos entre presets', async () => {
+      const clientWeb = makeClient({ data: { id: 'w' }, error: null })
+      const clientMob = makeClient({ data: { id: 'm' }, error: null })
+      const repoWeb = createTreatmentPlanRepository({ client: clientWeb, getUserId })
+      const repoMob = createTreatmentPlanRepository({ client: clientMob, getUserId })
+
+      await repoWeb.update('id-1', { name: 'Atualizado' })
+      await repoMob.update('id-1', { name: 'Atualizado' })
+
+      const webUpdate = clientWeb._builder._calls.find(([m]) => m === 'update')[1][0]
+      const mobUpdate = clientMob._builder._calls.find(([m]) => m === 'update')[1][0]
+      expect(webUpdate).toEqual(mobUpdate)
+    })
+  })
+})

--- a/packages/core/src/repositories/createProtocolRepository.js
+++ b/packages/core/src/repositories/createProtocolRepository.js
@@ -190,7 +190,9 @@ export function createProtocolRepository({
         throw new Error('Este protocolo não possui regime de titulação')
       }
 
-      const userId = await getUserId()
+      // user_id já veio em getById (que validou posse via getUserId interno).
+      // Reutilizar evita 2º await desnecessário.
+      const userId = protocol.user_id
       const currentStageIndex = protocol.current_stage_index || 0
       const nextStageIndex = currentStageIndex + 1
 

--- a/packages/core/src/repositories/createProtocolRepository.js
+++ b/packages/core/src/repositories/createProtocolRepository.js
@@ -1,0 +1,236 @@
+// createProtocolRepository.js — Factory CRUD canônico de tratamentos (Fase 2 G2).
+//
+// Espelha o pattern de createMedicineRepository (Fase 1).
+// Web e mobile injetam: client Supabase, getUserId, e (opcional) selects/transforms.
+// Defaults cobrem o caso real (web/mobile precisam de medicine + treatment_plan aninhados).
+// Validação Zod create/update é canônica (via @dosiq/core protocolSchema).
+//
+// Métodos:
+// - getAll / getById / create / update / delete  → CRUD CRUD básico
+// - getActive(date)                              → filtro por janela period (active=true ∧ start ≤ date ∧ end ≥ date|null)
+// - getByMedicineId(medicineId)                  → lista protocolos vinculados a um medicamento
+// - advanceTitrationStage(id, markAsCompleted)   → web-only (mobile v1 não expõe; mantido na factory pra paridade)
+
+import {
+  validateProtocolCreate,
+  validateProtocolUpdate,
+} from '../schemas/protocolSchema.js'
+import { getTodayLocal, getServerTimestamp } from '../utils/dateUtils.js'
+
+const DEFAULT_SELECT = `
+        *,
+        medicine:medicines(*),
+        treatment_plan:treatment_plans(id, name, emoji, color)
+      `
+
+const FULL_SELECT_AFTER_WRITE = `
+        *,
+        medicine:medicines(*),
+        treatment_plan:treatment_plans(*)
+      `
+
+const DETAIL_SELECT = `
+        *,
+        medicine:medicines(*)
+      `
+
+const identity = (x) => x
+
+function formatValidationError(errors) {
+  const msg = errors.map((e) => `${e.field}: ${e.message}`).join('; ')
+  return new Error(`Erro de validação: ${msg}`)
+}
+
+/**
+ * Cria um repositório CRUD de tratamentos (protocols) parametrizado por plataforma.
+ *
+ * @param {Object} deps
+ * @param {Object} deps.client       Cliente Supabase (`createClient(...)` ou nativeSupabaseClient).
+ * @param {Function} deps.getUserId  Async () => string. Resolve user_id da sessão.
+ * @param {string}   [deps.listSelect]    Select fragment usado em getAll/getActive/getByMedicineId.
+ * @param {string}   [deps.detailSelect]  Select fragment usado em getById.
+ * @param {string}   [deps.writeSelect]   Select fragment usado após create/update/advance.
+ * @param {Function} [deps.listTransform]     (rows) => rows. Pós-processamento de getAll.
+ * @param {Function} [deps.detailTransform]   (row) => row. Pós-processamento de getById/create/update.
+ */
+// NOTA: factory excede max-lines-per-function por agregar 7 métodos CRUD +
+// advanceTitrationStage no mesmo objeto (pattern canônico de createMedicineRepository).
+// Quebrar prejudica leitura; warning aceito (R-221 SQP).
+export function createProtocolRepository({
+  client,
+  getUserId,
+  listSelect = DEFAULT_SELECT,
+  detailSelect = DETAIL_SELECT,
+  writeSelect = FULL_SELECT_AFTER_WRITE,
+  listTransform = identity,
+  detailTransform = identity,
+}) {
+  if (!client) throw new Error('createProtocolRepository: client é obrigatório')
+  if (typeof getUserId !== 'function') {
+    throw new Error('createProtocolRepository: getUserId deve ser função async')
+  }
+
+  return {
+    async getAll() {
+      const userId = await getUserId()
+      const { data, error } = await client
+        .from('protocols')
+        .select(listSelect)
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false })
+
+      if (error) throw error
+      return listTransform(data ?? [])
+    },
+
+    async getActive(date = getTodayLocal()) {
+      const userId = await getUserId()
+      const { data, error } = await client
+        .from('protocols')
+        .select(listSelect)
+        .eq('user_id', userId)
+        .eq('active', true)
+        .lte('start_date', date)
+        .or(`end_date.is.null,end_date.gte.${date}`)
+        .order('created_at', { ascending: false })
+
+      if (error) throw error
+      return listTransform(data ?? [])
+    },
+
+    async getById(id) {
+      const userId = await getUserId()
+      const { data, error } = await client
+        .from('protocols')
+        .select(detailSelect)
+        .eq('id', id)
+        .eq('user_id', userId)
+        .single()
+
+      if (error) throw error
+      return detailTransform(data)
+    },
+
+    async getByMedicineId(medicineId) {
+      const userId = await getUserId()
+      const { data, error } = await client
+        .from('protocols')
+        .select('*')
+        .eq('medicine_id', medicineId)
+        .eq('user_id', userId)
+
+      if (error) throw error
+      return data ?? []
+    },
+
+    async create(protocol) {
+      const validation = validateProtocolCreate(protocol)
+      if (!validation.success) throw formatValidationError(validation.errors)
+
+      const userId = await getUserId()
+      const validated = validation.data
+
+      const payload = {
+        ...validated,
+        user_id: userId,
+        // Defaults para titração (web usa, mobile v1 não expõe — mas factory mantém)
+        titration_schedule: validated.titration_schedule || [],
+        current_stage_index: validated.current_stage_index || 0,
+        stage_started_at:
+          validated.titration_schedule?.length > 0 ? getServerTimestamp() : null,
+      }
+
+      const { data, error } = await client
+        .from('protocols')
+        .insert([payload])
+        .select(writeSelect)
+        .single()
+
+      if (error) throw error
+      return detailTransform(data)
+    },
+
+    async update(id, updates) {
+      const validation = validateProtocolUpdate(updates)
+      if (!validation.success) throw formatValidationError(validation.errors)
+
+      const userId = await getUserId()
+      const { data, error } = await client
+        .from('protocols')
+        .update(validation.data)
+        .eq('id', id)
+        .eq('user_id', userId)
+        .select(writeSelect)
+        .single()
+
+      if (error) throw error
+      return detailTransform(data)
+    },
+
+    async delete(id) {
+      const userId = await getUserId()
+      const { error } = await client
+        .from('protocols')
+        .delete()
+        .eq('id', id)
+        .eq('user_id', userId)
+
+      if (error) throw error
+    },
+
+    /**
+     * Avança para o próximo estágio de titulação. Web-only no v1 (mobile não
+     * expõe UI). Se markAsCompleted=true, força status alvo_atingido mesmo
+     * antes de esgotar o schedule.
+     */
+    async advanceTitrationStage(id, markAsCompleted = false) {
+      const protocol = await this.getById(id)
+
+      if (!protocol.titration_schedule || protocol.titration_schedule.length === 0) {
+        throw new Error('Este protocolo não possui regime de titulação')
+      }
+
+      const userId = await getUserId()
+      const currentStageIndex = protocol.current_stage_index || 0
+      const nextStageIndex = currentStageIndex + 1
+
+      // Esgotou o schedule — marca como alvo_atingido e fixa no último stage
+      if (nextStageIndex >= protocol.titration_schedule.length) {
+        const { data, error } = await client
+          .from('protocols')
+          .update({
+            titration_status: 'alvo_atingido',
+            current_stage_index: protocol.titration_schedule.length - 1,
+            stage_started_at: getServerTimestamp(),
+          })
+          .eq('id', id)
+          .eq('user_id', userId)
+          .select(writeSelect)
+          .single()
+
+        if (error) throw error
+        return detailTransform(data)
+      }
+
+      // Avança normalmente — pega dose do próximo stage do schedule
+      const nextStage = protocol.titration_schedule[nextStageIndex]
+      const updates = {
+        current_stage_index: nextStageIndex,
+        stage_started_at: getServerTimestamp(),
+        dosage_per_intake: nextStage.dosage,
+        titration_status: markAsCompleted ? 'alvo_atingido' : 'titulando',
+      }
+
+      const { data, error } = await client
+        .from('protocols')
+        .update(updates)
+        .eq('id', id)
+        .eq('user_id', userId)
+        .select(writeSelect)
+        .single()
+
+      if (error) throw error
+      return detailTransform(data)
+    },
+  }
+}

--- a/packages/core/src/repositories/createTreatmentPlanRepository.js
+++ b/packages/core/src/repositories/createTreatmentPlanRepository.js
@@ -1,0 +1,106 @@
+// createTreatmentPlanRepository.js — Factory CRUD canônico de planos terapêuticos (Fase 2 G2).
+//
+// Web e mobile injetam: client Supabase, getUserId, e (opcional) selects/transforms.
+// Default selects incluem protocolos aninhados (necessário para agrupamento web/mobile).
+// Sem validação Zod — treatmentPlanSchema canônico não existe ainda; fora de escopo desta task.
+
+const identity = (x) => x
+
+const DEFAULT_SELECT = '*, protocols:protocols(*, medicine:medicines(*))'
+
+/**
+ * Cria um repositório CRUD de planos terapêuticos parametrizado por plataforma.
+ *
+ * @param {Object} deps
+ * @param {Object} deps.client       Cliente Supabase (`createClient(...)` ou nativeSupabaseClient).
+ * @param {Function} deps.getUserId  Async () => string. Resolve user_id da sessão.
+ * @param {string}   [deps.listSelect]    Select fragment usado em getAll. Default: join completo com protocolos.
+ * @param {string}   [deps.detailSelect]  Select fragment usado em getById. Default: join completo com protocolos.
+ * @param {Function} [deps.listTransform]     (rows) => rows. Pós-processamento de getAll.
+ * @param {Function} [deps.detailTransform]   (row) => row. Pós-processamento de getById.
+ * @returns {{
+ *   getAll: () => Promise<Array>,
+ *   getById: (id: string) => Promise<Object>,
+ *   create: (plan: Object) => Promise<Object>,
+ *   update: (id: string, updates: Object) => Promise<Object>,
+ *   delete: (id: string) => Promise<void>,
+ * }}
+ */
+export function createTreatmentPlanRepository({
+  client,
+  getUserId,
+  listSelect = DEFAULT_SELECT,
+  detailSelect = DEFAULT_SELECT,
+  listTransform = identity,
+  detailTransform = identity,
+}) {
+  if (!client) throw new Error('createTreatmentPlanRepository: client é obrigatório')
+  if (typeof getUserId !== 'function') {
+    throw new Error('createTreatmentPlanRepository: getUserId deve ser função async')
+  }
+
+  return {
+    async getAll() {
+      const userId = await getUserId()
+      const { data, error } = await client
+        .from('treatment_plans')
+        .select(listSelect)
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false })
+
+      if (error) throw error
+      return listTransform(data ?? [])
+    },
+
+    async getById(id) {
+      const userId = await getUserId()
+      const { data, error } = await client
+        .from('treatment_plans')
+        .select(detailSelect)
+        .eq('id', id)
+        .eq('user_id', userId)
+        .single()
+
+      if (error) throw error
+      return detailTransform(data)
+    },
+
+    async create(plan) {
+      const userId = await getUserId()
+      const { data, error } = await client
+        .from('treatment_plans')
+        .insert([{ ...plan, user_id: userId }])
+        .select()
+        .single()
+
+      if (error) throw error
+      return data
+    },
+
+    async update(id, updates) {
+      const userId = await getUserId()
+      const { data, error } = await client
+        .from('treatment_plans')
+        .update(updates)
+        .eq('id', id)
+        .eq('user_id', userId)
+        .select()
+        .single()
+
+      if (error) throw error
+      return data
+    },
+
+    async delete(id) {
+      // Nota: protocolos associados têm treatment_plan_id setado para NULL via ON DELETE SET NULL.
+      const userId = await getUserId()
+      const { error } = await client
+        .from('treatment_plans')
+        .delete()
+        .eq('id', id)
+        .eq('user_id', userId)
+
+      if (error) throw error
+    },
+  }
+}

--- a/packages/core/src/repositories/createTreatmentPlanRepository.js
+++ b/packages/core/src/repositories/createTreatmentPlanRepository.js
@@ -74,7 +74,7 @@ export function createTreatmentPlanRepository({
         .single()
 
       if (error) throw error
-      return data
+      return detailTransform(data)
     },
 
     async update(id, updates) {
@@ -88,7 +88,7 @@ export function createTreatmentPlanRepository({
         .single()
 
       if (error) throw error
-      return data
+      return detailTransform(data)
     },
 
     async delete(id) {

--- a/packages/core/src/repositories/index.js
+++ b/packages/core/src/repositories/index.js
@@ -1,1 +1,3 @@
 export { createMedicineRepository } from './createMedicineRepository.js'
+export { createProtocolRepository } from './createProtocolRepository.js'
+export { createTreatmentPlanRepository } from './createTreatmentPlanRepository.js'

--- a/plans/backlog-native_app/EXEC_SPEC_FASE2_5_STATUS_TRATAMENTOS.md
+++ b/plans/backlog-native_app/EXEC_SPEC_FASE2_5_STATUS_TRATAMENTOS.md
@@ -1,0 +1,254 @@
+# EXEC SPEC — Fase 2.5: Status de Tratamentos (Ativo / Pausado / Finalizado)
+
+> **Tipo**: Sprint expansiva pós-Fase 2 — fecha gap de paridade com a web
+> **Duração estimada**: 1 sprint (5-7 dias)
+> **Branch base (mãe)**: `feat/treatments-status` (a criar; sai de `main` após merge da Fase 2)
+> **Pré-condição**: ✅ Fase 2 completa (PRs #561-#566 mergeados + PR final mãe→main)
+> **Quality Gates**: G1 (mobile feature flag) → G2 (extract filter logic em @dosiq/core se necessário)
+> **Versão do app**: bump menor `v0.3.x` durante; bump `v0.4.0` ainda só ao final da Fase 3
+> **Reviewer humano**: PO valida iOS + Android (incluindo API 24)
+> **PR strategy**: 1 PR único contra `main` (escopo pequeno, atômico)
+> **Origem**: feedback PO 2026-05-17 — após smoke da Fase 2, percebeu que a flag `active` (true/false) do tratamento + lógica de período (`end_date < hoje` = finalizado) não estão expostas no mobile, ao contrário da web que já possui 3 tabs.
+
+---
+
+## 0. Spec Reading Protocol (R-228)
+
+Toda sessão de implementação Fase 2.5 começa com:
+
+1. Ler esta spec **inteira**
+2. Conferir state.json + RULES_INDEX + ANTI_PATTERNS_INDEX (bootstrap DEVFLOW)
+3. Ler referência web canônica:
+   - `apps/web/src/features/protocols/hooks/_treatmentListUtils.js` — `resolveTabStatus` (canônico)
+   - `apps/web/src/features/protocols/hooks/useTreatmentsState.js` — gerenciamento de tabs + counts
+   - `apps/web/src/features/protocols/components/redesign/TreatmentTabBar.jsx` — UI segmented control
+4. Conferir mocks aprovados pelo PO em `plans/backlog-native_app/MOCKS_APP_CRUD/export/fase-2-5/` — **podem não existir ainda**; nesse caso, PO aprova a referência web durante sprint kickoff
+5. Conferir glossário em `docs/reference/GLOSSARY.md` (termos: ativo/pausado/finalizado)
+
+**Mocks ausentes na pasta `fase-2-5/` ⇒ trabalhar a partir da paridade web + revisão visual PO durante a sprint**. Não bloquear o sprint por falta de PNG quando a referência web é clara.
+
+---
+
+## 1. Diagnóstico — gap entre web e mobile (estado em 2026-05-17)
+
+| Aspecto | Web | Mobile (pós-Fase 2) | Gap |
+|---------|-----|---------------------|-----|
+| Listagem traz tratamentos pausados | ✅ `active=true` removido do query, tabStatus derivado client-side | ❌ `treatmentsService.getActiveTreatments` faz `.eq('active', true)` — pausados NUNCA aparecem | 🔴 |
+| Listagem traz finalizados | ✅ Sem filtro de período no query; client filtra `end_date < hoje` | ❌ Filtro `isProtocolInPeriod` exclui finalizados | 🔴 |
+| TabBar Ativos/Pausados/Finalizados | ✅ `TreatmentTabBar` com counts | ❌ Não existe | 🔴 |
+| Toggle pause/resume | ✅ Ação no detail (atualiza `active`) | ❌ Não existe; `protocolService.update({active})` existe na factory mas UI não dispara | 🟠 |
+| `tabStatus` derivado por item | ✅ `resolveTabStatus(protocol)` | ❌ Não existe equivalente mobile | 🔴 |
+| Adherence score só na tab "ativos" | ✅ `ProtocolRow` conditional | N/A — adherence ainda não está na listagem mobile | 🟢 (não regressivo) |
+
+**Implicação UX atual no mobile**: usuário só vê tratamentos com `active=true` E em período. Não consegue:
+1. Pausar um tratamento temporariamente (não tem ação)
+2. Retomar tratamento pausado (não consegue encontrá-lo)
+3. Revisitar histórico de tratamentos finalizados (somem da listagem)
+
+---
+
+## 2. Objetivo
+
+Levar para o mobile a mesma capacidade da web de **categorizar tratamentos por status operacional**, expondo:
+
+- **Listagem completa** (sem filtro server-side de `active`)
+- **TabBar com 3 tabs** (Ativos | Pausados | Finalizados) e contadores
+- **Ação Pausar/Retomar** no `ProtocolDetailScreen`
+- **Helper canônico `resolveTabStatus`** (extraído para `@dosiq/core/utils/treatmentStatus.js` para web e mobile compartilharem)
+
+**Exclusões v1**:
+- Tab dedicada para tratamentos arquivados (não existe na web)
+- Bulk pause/resume (não existe na web)
+- Filtros adicionais (frequency, plano) — Fase futura
+
+---
+
+## 3. Especificação de Telas
+
+### 3.1 — TreatmentsScreen com TabBar
+
+**Layout atual** (pós-Fase 2): header "Tratamentos" + lista agrupada por plano + FAB + link "Medicamentos".
+
+**Adições Fase 2.5**:
+
+1. **TreatmentTabBar** (novo componente mobile, espelha visualmente o segmented control web):
+   - Posicionado abaixo do header, antes do conteúdo da lista
+   - 3 tabs: `Ativos (N)`, `Pausados (N)`, `Finalizados (N)`
+   - Counts entre parênteses; omitir parênteses quando count=0
+   - Tab ativa: bg primary[100] + text primary[700] weight 700
+   - Tabs inativas: text muted
+   - Tap altera state local da screen + scroll para o topo da lista
+   - **Tab default = `Ativos`** ao abrir a tela (sem persistência cross-session na v1; cada entrada na tela resetar pra `Ativos`). Se voltar via `useFocusEffect` da mesma sessão, mantém a tab que o user selecionou (não resetar em refresh, só em mount).
+
+2. **Estado vazio por tab** (cobrir gracefully):
+   - Tab "Ativos" vazia + zero pausados + zero finalizados → mantém `TreatmentEmptyState` atual (CTA criar primeiro)
+   - Tab "Pausados" vazia (mas há ativos ou finalizados) → texto centralizado "Nenhum tratamento pausado." sem CTA
+   - Tab "Finalizados" vazia → "Nenhum tratamento finalizado ainda."
+
+3. **Conteúdo da tab**:
+   - **Ativos**: comportamento atual (heurística SIMPLE/COMPLEX já implementada)
+   - **Pausados**: lista flat com badge "Pausado" cinza no card (sem agrupamento por plano — paridade web)
+   - **Finalizados**: lista flat com badge "Finalizado em DD MMM YYYY" cinza-claro (data do `end_date`)
+
+4. **FAB** continua na tela mesmo nas tabs pausados/finalizados (criar novo sempre disponível).
+
+### 3.2 — ProtocolDetailScreen — toggle Desligado / Ligado
+
+**Adição** (acima do botão Excluir existente, dentro de um `SectionCard` próprio para destaque):
+
+- **Row com toggle nativo (`Switch` do react-native)**:
+  - Esquerda: label `"Tratamento ligado"` (titleSM weight 600) + helper text logo abaixo (caption muted):
+    - Quando ligado: `"Recebendo lembretes e contando aderência."`
+    - Quando desligado: `"Pausado — sem lembretes, sem impacto na aderência."`
+  - Direita: `Switch` nativo (`trackColor={{ true: colors.primary[500], false: colors.neutral[300] }}`); haptics `selectionTap` no toggle
+  - **Tratamento finalizado (`end_date < hoje`)**: ocultar a row inteira do toggle (não faz sentido ligar/desligar algo já fora de período; user deve editar `end_date` se quiser reativar). Em vez disso, mostrar caption inerte: `"Tratamento finalizado em DD MMM YYYY. Edite o período para reativar."`
+
+- **Tap no toggle**: SEM confirmação modal — ação reversível e o feedback visual do switch já comunica a intenção. Apenas:
+  - Toast success: `"Tratamento ligado"` ou `"Tratamento desligado"`
+  - Chamada `protocolService.update(id, { active: nextValue })` em background
+  - Optimistic update do toggle visual + reverte se erro + toast error
+  - Invalida cache `useProtocols` + `@dosiq/protocols-snapshot` → próximo focus na listagem reagrupa por tab
+
+**Justificativa do toggle vs botão Pausar/Retomar**: feedback PO 2026-05-17 — analogia play/pause carrega conotação temporal ("vou voltar logo") que nem sempre é o caso. Toggle ligado/desligado é cognitivamente mais simples, alinhado com padrão de switches do iOS/Android e binário sem ambiguidade semântica.
+
+### 3.3 — Card de tratamento na listagem
+
+**Estado novo (Pausado)**:
+- Background do card: `colors.bg.card` normal
+- Ícone medicamento: opacity 0.6 (visual "apagado")
+- Nome + DosagePill: opacity 0.8
+- Badge `Pausado` (chip `colors.neutral[200]` + text `colors.neutral[700]` weight 600 fontSize 11)
+
+**Estado novo (Finalizado)**:
+- Background do card: `colors.neutral[50]`
+- Ícone + textos: opacity 0.7
+- Badge `Finalizado em DD MMM YYYY` (chip `colors.neutral[100]` + text `colors.neutral[600]`)
+- Chevron right MANTIDO (user pode reabrir detail mesmo finalizado)
+
+---
+
+## 4. Sprint Breakdown
+
+### Sprint T2.5.1 — Status Tratamentos (PR único)
+
+| # | Task | Path | Agente | Complexidade |
+|---|------|------|--------|-------------|
+| T1 | Criar helper canônico `resolveTreatmentStatus(protocol, today)` em `@dosiq/core/utils/treatmentStatus.js` (lê: end_date, active) — extrair lógica de `_treatmentListUtils.js` web sem regredir comportamento | `packages/core/src/utils/treatmentStatus.js` + barrel | 👤 Opus | ⭐⭐ |
+| T2 | Tests do helper (`status: 'ativo' \| 'pausado' \| 'finalizado'`; edge cases: end_date hoje = ativo; active=null=ativo; finalizado vence pausado) | `packages/core/src/utils/__tests__/treatmentStatus.test.js` | 🤖 Haiku | ⭐ |
+| T3 | Web adopt helper canônico — `_treatmentListUtils.resolveTabStatus` vira wrapper de `resolveTreatmentStatus` (mapping de nome: 'ativo'→'ativos' label segmented; mas storage interno usa singular novo) | `apps/web/src/features/protocols/hooks/_treatmentListUtils.js` | 🤖 Sonnet | ⭐⭐ |
+| T4 | `treatmentsService.getActiveTreatments` mobile renomeado para `getAllTreatments(userId)` — remove `.eq('active', true)` + remove filtro `isProtocolInPeriod` (helper agora decide). Manter assinatura de retorno `{ success, data, error }` | `apps/mobile/src/features/treatments/services/treatmentsService.js` | 👤 Opus | ⭐⭐ |
+| T5 | `_treatmentsTransformer` agora anota cada item com `tabStatus` via helper + computa `counts` ({ ativos, pausados, finalizados }) — ainda agrupa só ativos por plano | `apps/mobile/src/features/treatments/hooks/_treatmentsTransformer.js` | 🤖 Sonnet | ⭐⭐ |
+| T6 | `useTreatments` mobile expõe `{ data, counts, activeTab, setActiveTab, refresh }` — state interno mantém qual tab está selecionada | `apps/mobile/src/features/treatments/hooks/useTreatments.js` | 👤 Opus | ⭐⭐ |
+| T7 | `TreatmentTabBar.jsx` novo (espelha web visualmente) | `apps/mobile/src/features/treatments/components/TreatmentTabBar.jsx` | 🤖 Sonnet | ⭐⭐ |
+| T8 | `TreatmentCard` ganha props `tabStatus` + `endDate` + badges visuais (pausado/finalizado) | `apps/mobile/src/features/treatments/components/TreatmentCard.jsx` | 🤖 Sonnet | ⭐⭐ |
+| T9 | `TreatmentsScreen` consome `useTreatments` novo + renderiza `TreatmentTabBar` + handle empty per-tab | `apps/mobile/src/features/treatments/screens/TreatmentsScreen.jsx` | 👤 Opus | ⭐⭐⭐ |
+| T10 | `ProtocolDetailScreen` ganha row de toggle `Tratamento ligado` (Switch nativo, optimistic update, ocultar se finalizado) | `apps/mobile/src/features/treatments/screens/ProtocolDetailScreen.jsx` | 👤 Opus | ⭐⭐ |
+| T11 | `useProtocolMutation` ganha helper `toggleActive(id, nextValue)` com optimistic update (wrapper sobre update + rollback em erro) | `apps/mobile/src/features/treatments/hooks/useProtocolMutation.js` | 🤖 Haiku | ⭐ |
+| T12 | Atualizar EXEC_SPEC_FASE2 (§3.2) — listagem agora cobre 3 status; adicionar nota cross-ref pra Fase 2.5 | `plans/backlog-native_app/EXEC_SPEC_FASE2_PROTOCOLOS.md` | 🤖 Haiku | ⭐ |
+| T13 | Smoke E2E iOS + Android API 24 | Manual | 👤 Humano | — |
+
+**Entrega**: PR único `feat/treatments-status` → review Gemini → smoke PO → merge `main`.
+
+---
+
+## 5. Quality Gates
+
+### 5.1 — G1 (Status mobile)
+
+| Critério | Validação |
+|----------|-----------|
+| `resolveTreatmentStatus` retorna corretamente para os 3 status (incluindo edge cases) | `npx vitest run packages/core/src/utils/__tests__/treatmentStatus.test.js` |
+| Web continua passando todos os testes após adopt do helper canônico | `rtk npm run validate:agent` |
+| Mobile lista carrega TODOS os tratamentos (ativos + pausados + finalizados); counts batem com DB | Smoke + cross-check via Supabase MCP |
+| Tap em tab muda conteúdo + scroll para o topo | Smoke manual |
+| Desligar tratamento (toggle OFF) move da tab Ativos para Pausados sem refresh manual ao voltar pra listagem | Smoke (focus refresh + cache invalidation) |
+| Religar tratamento (toggle ON) volta para Ativos | Smoke |
+| Tratamento finalizado (end_date < hoje) aparece SOMENTE na tab Finalizados; toggle ligado/desligado oculto no detail (caption inerte no lugar) | Smoke |
+| Tab default ao abrir a tela Tratamentos = `Ativos` | Smoke |
+| Jest mobile suite > +3 tests novos (helper aplicado em transformer + hook) | CI |
+| Lint clean nos arquivos novos/modificados | `rtk lint` |
+
+---
+
+## 6. Schema & data layer
+
+`protocols.active` já é `boolean default true` no DB e no `protocolSchema.js` — **nenhuma migração necessária**.
+
+`end_date` já é `date nullable` — sem mudanças.
+
+**Sem refator no schema canônico**. Apenas leitura/escrita do campo existente.
+
+### Helper canônico
+
+```js
+// packages/core/src/utils/treatmentStatus.js
+
+import { formatLocalDate, getNow } from './dateUtils.js'
+
+export const TREATMENT_STATUS = Object.freeze({
+  ATIVO: 'ativo',
+  PAUSADO: 'pausado',
+  FINALIZADO: 'finalizado',
+})
+
+/**
+ * Resolve o status operacional de um tratamento.
+ *
+ * Ordem de precedência (igual à web em _treatmentListUtils.js):
+ *   1. end_date && end_date < hoje  → FINALIZADO
+ *   2. active === false             → PAUSADO
+ *   3. caso contrário               → ATIVO
+ *
+ * @param {{ active?: boolean, end_date?: string|null }} protocol
+ * @param {string} [today=formatLocalDate(getNow())]
+ * @returns {'ativo'|'pausado'|'finalizado'}
+ */
+export function resolveTreatmentStatus(protocol, today) {
+  const ref = today ?? formatLocalDate(getNow())
+  if (protocol?.end_date && protocol.end_date < ref) return TREATMENT_STATUS.FINALIZADO
+  if (protocol?.active === false) return TREATMENT_STATUS.PAUSADO
+  return TREATMENT_STATUS.ATIVO
+}
+```
+
+Re-export no `packages/core/src/utils/index.js`.
+
+---
+
+## 7. Brief padrão cavecrew (R-230)
+
+Cada spawn recebe:
+
+1. Read-only refs absolutas (esta spec + referência web + arquivo Fase 2 análogo)
+2. Path absoluto do arquivo
+3. Contrato exato (assinatura/props/return)
+4. Regras críticas (R-010, R-020, R-130 quando aplicável)
+5. Output esperado + ponto de integração
+6. Sem commits (Write/Edit only)
+
+---
+
+## 8. PR Strategy
+
+| Sprint | PR contra | Reviewer humano | Reviewer LLM |
+|--------|-----------|-----------------|--------------|
+| T2.5.1 | `main` | PO valida iOS + Android API 24 | Gemini-Code-Assist |
+
+PR pequeno o suficiente pra um único review cycle; sem necessidade de mãe→main fan-out.
+
+---
+
+## 9. Critérios para encerramento da Fase 2.5
+
+- [ ] G1 passou (humano)
+- [ ] PR mergeado em main
+- [ ] DEVFLOW C5: novo R-NNN sobre resolveTreatmentStatus canônico se for considerado pattern de paridade web↔mobile; journal entry
+- [ ] EXEC_SPEC_FASE2 atualizada com cross-ref
+- [ ] Master plan (`MASTER_PLAN_HIBRIDO_EVOLUCAO_CRUD.md`) registra Fase 2.5 como completa
+
+---
+
+## 10. Histórico
+
+- **2026-05-17 (criação)**: Spec criada após smoke PO da Fase 2 PR-A T2.3 revelar gap de paridade com web (`active` flag + categorização de status). Origem: feedback explícito do PO durante o sprint final da Fase 2.
+- **2026-05-17 (revisão pós-PO)**: §3.1 — tornado explícito que tab default ao mount = `Ativos`. §3.2 — botão Pausar/Retomar trocado por toggle `Tratamento ligado` (Switch nativo, optimistic update, sem confirmação modal). Feedback PO: analogia play/pause carrega conotação temporal indesejada; toggle binário ligado/desligado é cognitivamente mais simples e alinhado com switches nativos do SO.

--- a/plans/backlog-native_app/EXEC_SPEC_FASE2_PROTOCOLOS.md
+++ b/plans/backlog-native_app/EXEC_SPEC_FASE2_PROTOCOLOS.md
@@ -206,7 +206,7 @@ Implementar CRUD completo de **Tratamentos** (entidade DB: `protocols`) no mobil
    - `MedicineSelectorRow` em estado vazio: card dashed border + ícone "+" no quadrado + label `"Selecionar medicamento"` + subtitle `"Escolha da biblioteca ou cadastre um novo"` + chevron right
    - Tap → abre bottom sheet `MedicineSelectorSheet` (§3.5)
 2. **`INFORMAÇÕES BÁSICAS`**:
-   - `FormInput name="name"` label `"Nome do tratamento"` required, placeholder `"Ex: SeloZok manhã/noite"`
+   - `FormInput name="name"` label `"Nome do tratamento"` required, placeholder `"Ex: Hipertensão"`
    - `FormInput name="dosage_per_intake"` label `"Dose por tomada"` required, placeholder `"0"`, `keyboardType="decimal-pad"`. **helperText fixo**: `"Quantas unidades do medicamento por tomada (aceita decimais, ex: 0,5)"`. Sem suffix dinâmico baseado em medicine.dosage_unit (padronização em "unidade(s)" — ver §3.3).
      - **Decimais (`0,5`)**: `handleDoseChange` DEVE preservar estados intermediários como STRING no form state (`"0,"`, `"."`, vazio). Conversão para number só acontece no `handleSubmit` antes do `form.validate()`. Eager parse a cada keystroke apaga a vírgula e bloqueia decimais (bug detectado em smoke 2026-05-17).
 3. **`FREQUÊNCIA`**:

--- a/plans/backlog-native_app/MASTER_PLAN_HIBRIDO_EVOLUCAO_CRUD.md
+++ b/plans/backlog-native_app/MASTER_PLAN_HIBRIDO_EVOLUCAO_CRUD.md
@@ -1,8 +1,39 @@
 # Dosiq Native App — Plano Estratégico de Evolução CRUD
 
-> **Versão Final (v3)** — Todas as decisões aprovadas pelo Product Owner  
-> **Data**: 14 de maio de 2026  
-> **Autor**: Arquiteto-chefe (AI) + PO (humano)  
+> **Versão atual (v4)** — Status reconciliado pós-Fase 2 (17/05/2026)
+> **Autor**: Arquiteto-chefe (AI) + PO (humano)
+> **Status**: 🔄 Em execução — Pré-requisitos + Fase 1 + Fase 2 entregues; Fase 2.5 e Fase 3 em fila
+
+---
+
+## 🚦 Status de Execução (snapshot 2026-05-17)
+
+| Fase | Status | PRs principais | Quality Gates | Observações |
+|------|--------|----------------|---------------|-------------|
+| **Pré-requisitos** (Form Kit, useMutation, infra ANVISA) | ✅ Completa | Sprint P1.x | — | Form Kit serviu de fundação para Fases 1 e 2 sem retrabalho |
+| **Fase 1 — Medicamentos** | ✅ Completa | #555-#559 (+ distill) | G1 ✅ G2 ✅ G3 ✅ | `createMedicineRepository` em `@dosiq/core/repositories/` (ADR-045); RETRO documentada em `RETRO_FASE1_CRUD_MEDICAMENTOS.md` |
+| **Fase 2 — Tratamentos (Protocolos)** | ✅ Completa | #561 (PR-A T2.1) · #562 (T2.1 fan-out) · #563 (PR-A T2.2) · #564 (PR-B T2.2) · #565 (PR-C T2.2) · #566 (PR-A T2.3 — factory G2) · PR-B T2.3 (web G3) · PR final mãe→main | G1 ✅ G2 ✅ G3 🟡 (em PR final do PR-B T2.3) | Lições críticas: `isProtocolActiveOnDate` strict vs `isProtocolInPeriod`, `statusBarTranslucent` em todos `Modal`s mobile (AP-163), padronização "unidade(s)" |
+| **Fase 2.5 — Status de Tratamentos** | 🆕 Planejada | A definir (sprint único `feat/treatments-status`) | G1 | Origem: gap detectado no smoke da Fase 2 — flag `active` + period `end_date < hoje` (categorização ativo/pausado/finalizado já presente na web). Spec: `EXEC_SPEC_FASE2_5_STATUS_TRATAMENTOS.md` |
+| **Fase 3 — Estoque** | 🟡 Pendente | — | — | Spec inicial existe (`EXEC_SPEC_FASE3_ESTOQUE.md`); aguarda kickoff pós-Fase 2 + 2.5 |
+| **Fase 4 — Perfil completo** | ⏸️ Não iniciada | — | — | Spec não escrita |
+| **Fase 5 — Analíticas (Histórico, Aderência expandida, Ficha)** | ⏸️ Não iniciada | — | — | Spec não escrita |
+| **Fase 6 — Avançadas (Emergência, Chatbot, PDF, mobile-only)** | ⏸️ Não iniciada | — | — | Spec não escrita |
+
+### Lições aprendidas até aqui (consolidado de RETRO + spec histories)
+
+1. **Quality Gates G1→G2→G3 funcionam** — bug encontrado em mobile (G1) não chegou na web (G3) graças à ordem cópia→extract→adopt.
+2. **Cavecrew distribution (ADR-044) bom equilíbrio** — Opus arquiteta o sensível inline, Sonnet/Haiku paralelizam tasks mecânicas. Tempo de sprint caiu vs. sequencial.
+3. **Smoke PO ANTES de abrir PR** (pattern adotado pós-Fase 1) reduz churn de fixes com Gemini. Push pra EAS OK; HOLD em `gh pr create` até PO validar.
+4. **Modal Android < 8 precisa `statusBarTranslucent`** (AP-163) — bug recorrente; sweep aplicado em todos sheets Fase 1+2 (PR #566).
+5. **Spec viva** — atualizar `EXEC_SPEC_*` ao longo da execução (não só no kickoff) evita gaps de paridade voltarem como surpresa.
+
+---
+
+## ✏️ Original (v3, 14/05/2026)
+
+> **Versão Final (v3)** — Todas as decisões aprovadas pelo Product Owner
+> **Data**: 14 de maio de 2026
+> **Autor**: Arquiteto-chefe (AI) + PO (humano)
 > **Status**: ✅ Pronto para planejamento de execução
 
 ---
@@ -330,6 +361,21 @@ function MedicineFormScreen({ route }) {
 
 ---
 
+### Fase 2.5 — Status de Tratamentos (Ativo / Pausado / Finalizado) — ~1 sprint
+
+> Adicionada em 17/05/2026 após smoke da Fase 2 revelar gap de paridade com web.
+
+| Item | Detalhes |
+|------|---------|
+| TabBar Ativos/Pausados/Finalizados | Espelha `TreatmentTabBar` da web; counts por tab |
+| Helper canônico `resolveTreatmentStatus` | Em `@dosiq/core/utils/treatmentStatus.js`; web adopt no mesmo PR (G1 implícito) |
+| Botão Pausar / Retomar no detail | `protocolService.update({ active })` via `useProtocolMutation.toggleActive` |
+| Card visual por status | Pausado (opacity + chip cinza); Finalizado (bg cinza claro + badge "Finalizado em DD MMM YYYY") |
+| Smoke | iOS + Android API 24 obrigatório (cobertura dos 3 status) |
+| Spec | `EXEC_SPEC_FASE2_5_STATUS_TRATAMENTOS.md` |
+
+---
+
 ### Fase 3 — Estoque — ~2 semanas
 
 | Item | Detalhes |
@@ -376,14 +422,14 @@ function MedicineFormScreen({ route }) {
 ### Timeline Visual
 
 ```
-Semana  1  2  3   4  5  6   7  8   9 10  11 12 13  14 15 16  17 18 19 20
-        ├──────┤  ├────────┤  ├────┤  ├───┤  ├──────┤  ├─────────────────┤
-        Pré-Req   Fase 1      Fase2  Fase3  Fase 4    Fase 5      Fase 6
-        Fundação  Medicam.    Proto.  Estoq  Perfil    Analíticas  Avançadas
-                  G1→G2→G3   G1→G3  G1→G3  G1→G3
+Semana  1  2  3   4  5  6   7  8   9 10  11  12 13 14  15 16 17  18 19 20 21
+        ├──────┤  ├────────┤  ├────┤  ├──┤  ├────┤  ├──────┤  ├─────────────┤
+        Pré-Req   Fase 1     Fase2  F2.5  Fase3   Fase 4    Fase 5    Fase 6
+        Fundação  Medic. ✅  Trat. 🆕  Est.   Perfil    Analít.   Avançadas
+        ✅        G1G2G3 ✅  G1G2G3 ✅
 ```
 
-**Total estimado: 14-20 semanas** (sprints semanais)
+**Total estimado revisado: 15-21 semanas** (Fase 2.5 = +1 sprint)
 
 ---
 


### PR DESCRIPTION
## Summary

**Sprint T2.3 PR-A** — Gate G2 da Fase 2 (CRUD Tratamentos mobile).

Extrai lógica CRUD compartilhada web↔mobile para `@dosiq/core/repositories/` seguindo pattern canônico de `createMedicineRepository` (Fase 1). Mobile adopts ANTES de web (G3 vem em PR-B desta sprint).

Smoke PO validado iOS + Android (incluindo API 24).

## Tasks entregues

### T3.1 — createProtocolRepository
- 7 métodos: `getAll` / `getActive(date)` / `getById` / `getByMedicineId` / `create` / `update` / `delete` + `advanceTitrationStage`
- Validação Zod (create/update) via `validateProtocolCreate` / `validateProtocolUpdate`
- Defaults cobrem o caso real (listSelect com `medicine + treatment_plan`, writeSelect com plan completo)
- `advanceTitrationStage` mantido na factory mesmo mobile v1 não usando — paridade com web pra futuro

### T3.2 — createTreatmentPlanRepository
- 5 métodos CRUD básicos
- Sem Zod (não há schema canônico — alinhado com web atual)
- Default listSelect aninhado `protocols + medicine`

### T3.3 + T3.4 — Parity tests (vitest)
- `createProtocolRepository.test.js`: **21 tests** (CRUD + getActive presets/transforms + validation fail/success + titration flow completo + getByMedicineId + error propagation)
- `createTreatmentPlanRepository.test.js`: **15 tests** (CRUD + presets web/mobile + parity cross-preset)
- Total core repositories: **55/55** (19 medicine + 21 protocol + 15 plan)

### T3.5 — Mobile services adopt factory
- `apps/mobile/.../protocolService.js`: **140 → 28 LOC** (thin wrapper sobre factory)
- `apps/mobile/.../treatmentPlanService.js`: **79 → 17 LOC**
- `detailSelect` customizado no protocol pra trazer `treatment_plan(*)` completo (ProtocolDetailScreen precisa de emoji/name; default da factory traz só medicine)
- `getUserId` helper mantido nos wrappers (defensive auth destructure)

## Bug Android API 24 — sheets sweep

Durante smoke do MedicineSelectorSheet no Android 7, detectado mesmo bug já corrigido em PR-C (ProtocolDeleteSheet): \`Modal\` sem \`statusBarTranslucent\` não cobre window stack do parent — overlay fica truncado no topo + inputs do form vazam por cima do sheet.

Sweep aplicado em todos os sheets de Fase 1+2:
- ✅ MedicineSelectorSheet (Fase 2)
- ✅ MedicineAnvisaSheet (Fase 1)
- ✅ MedicineDeleteBlockedSheet (Fase 1)

Pattern unificado: \`statusBarTranslucent\` + spacer \`StatusBar.currentHeight\` (Android only) + \`SafeAreaView edges=['bottom']\` no sheet.

TimeSchedulePicker tem Modal mas é iOS-only (Android usa picker imperativo) — skip. Modals fora de escopo recente (dose/, shared/form/, profile/) não tocados (R-221 SQP).

## Testes
- ✅ Vitest core: **55/55** (factories + parity)
- ✅ Jest mobile: **148/148** (zero regressões)
- ✅ Lint: 0 errors (1 warning aceito em createProtocolRepository — factory canônica com 7 métodos no objeto retornado; R-221 SQP)
- ✅ Smoke iOS: CRUD completo via factory (criar tratamento + plano inline + edit trocar medicamento + delete sheet)
- ✅ Smoke Android API 24: idem + sheets cobrem tela toda sem vazamento de inputs

## Cavecrew distribution (ADR-044)
- **Opus inline**: T3.1 (factory protocol — sensível, carrega titration) + T3.5 (mobile adopts, smoke G2 depende)
- **Spawn paralelo Sonnet**: T3.2 (factory plan) + T3.3 (parity tests protocol)
- **Spawn paralelo Haiku**: T3.4 (parity tests plan)
- 3 waves: factories → tests → mobile adopts

## Próximo passo

**G2 GATE humano** (este PR) → após merge, **PR-B T2.3** com web adopts (T3.7+T3.8+T3.9 — Gate G3) → **PR final mãe→main** fecha Fase 2.

## Test plan
- [x] \`npx vitest run packages/core/src/repositories/\` → 55/55
- [x] \`cd apps/mobile && rtk jest\` → 148/148
- [x] \`rtk lint\` arquivos novos/modificados → 0 errors
- [x] Smoke iOS: CRUD tratamento via factory + sheets
- [x] Smoke Android API 24: CRUD via factory + sheets cobrem tela toda

🤖 Generated with [Claude Code](https://claude.com/claude-code)