### PR TITLE
chore: cache matrix R-236 + distill policy (P6+P7 RETRO Fase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,25 @@ Rodar do root via workspace:
 
 `.memory/` aposentado (somente leitura W01-W11). Tudo novo → `.agent/memory/`.
 
+## Distill Policy (dosiq — pós-Fase 2.5)
+
+**Threshold automático**: `genes.memory_distillation_threshold = 15` (mantido).
+Auto-trigger quando `journal_entries_since_distillation >= 15`.
+
+**Trigger manual obrigatório**: ao encerrar QUALQUER fase de evolução
+(Fase 0/1/2/2.5/3/4/5/6), rodar `/devflow distill` imediatamente após o PR de
+RETRO + DEVFLOW C5 ser mergeado — independente do threshold.
+
+**Por quê**: fases entregam ~3-8 journal entries cada; com threshold 15, distill
+auto pode atrasar 2-3 fases. Trigger manual pós-fase mantém memória "fresh" no
+ponto de transição, evitando counter drift (AP-161) e perdendo a janela em que
+os aprendizados ainda estão vivos no contexto.
+
+**Avaliar baixar threshold pra 10 após Fase 4** se distill manual virar overhead.
+
+Distill bem-feito DEVE incluir D5 self-clean profundo (reconciliar
+`state.json` contra índices markdown — fonte de verdade).
+
 ---
 
 ## Git Workflow

--- a/apps/mobile/src/features/medications/hooks/useMedicineDelete.js
+++ b/apps/mobile/src/features/medications/hooks/useMedicineDelete.js
@@ -17,6 +17,19 @@ import { medicineService } from '../services/medicineService'
 
 const MEDICINES_CACHE_KEY = '@dosiq/medicines-snapshot'
 
+/**
+ * Cache invalidation matrix (R-236) — useMedicineDelete:
+ *
+ * confirmDelete só dispara se preCheck.canDelete (hard block contra protocolos
+ * e stock > 0). Quando passa o pre-check, garantidamente:
+ *   - sem protocols → nada em treatments-snapshot/today-snapshot
+ *   - sem stock     → nada em stock-snapshot
+ * Logo invalida APENAS:
+ *   - @dosiq/medicines-snapshot
+ *
+ * Se algum dia o hard block virar soft, ESTA matrix muda — adicionar
+ * treatments-snapshot, today-snapshot e stock-snapshot ao Promise.all abaixo.
+ */
 export function useMedicineDelete(medicine) {
   const navigation = useNavigation()
   const { show } = useToast()

--- a/apps/mobile/src/features/medications/hooks/useMedicineMutation.js
+++ b/apps/mobile/src/features/medications/hooks/useMedicineMutation.js
@@ -2,12 +2,17 @@
 //
 // Encapsula:
 // - Toast feedback (success/error)
-// - Cache invalidation (@dosiq/medicines-snapshot)
+// - Cache invalidation (matrix R-236 — ver bloco por método abaixo)
 // - Navegação opcional pós-sucesso
 //
 // Uso:
 //   const { create, update, remove, isLoading } = useMedicineMutation()
 //   create(values, { goBack: true })
+//
+// ────────────────────────────────────────────────────────────────────────────
+// CACHE INVALIDATION MATRIX (R-236) — todo mutation deve listar TODOS
+// snapshots afetados. Esquecer um cache adjacente = bug latente (D11 Fase 2.5).
+// ────────────────────────────────────────────────────────────────────────────
 
 import { useCallback } from 'react'
 import { useNavigation } from '@react-navigation/native'
@@ -16,25 +21,69 @@ import { useToast } from '@shared/components/feedback/Toast'
 import { medicineService } from '../services/medicineService'
 
 const MEDICINES_CACHE_KEY = '@dosiq/medicines-snapshot'
+const PROTOCOLS_CACHE_KEY = '@dosiq/protocols-snapshot'
+const TREATMENTS_CACHE_KEY = '@dosiq/treatments-snapshot'
+const TODAY_CACHE_KEY = '@dosiq/today-snapshot'
+const STOCK_CACHE_KEY = '@dosiq/stock-snapshot'
 
 export function useMedicineMutation() {
   const navigation = useNavigation()
   const { show } = useToast()
 
+  /**
+   * create — cria medicamento novo.
+   * Caches invalidados:
+   *   - @dosiq/medicines-snapshot (listagem de medicamentos)
+   * Caches NÃO invalidados (intencionalmente):
+   *   - protocols/treatments/today/stock (novo medicamento sem treatment
+   *     ativo e sem stock não aparece em nenhum dos derivados)
+   */
   const mutationCreate = useMutation({
     invalidateKeys: [MEDICINES_CACHE_KEY],
     onSuccess: () => show('Medicamento criado', { variant: 'success' }),
     onError: (err) => show(err?.message ?? 'Erro ao criar medicamento', { variant: 'error' }),
   })
 
+  /**
+   * update — edita medicamento (nome, dose, etc).
+   * Caches invalidados:
+   *   - @dosiq/medicines-snapshot (listagem)
+   *   - @dosiq/protocols-snapshot (detail mostra medicine joinado)
+   *   - @dosiq/treatments-snapshot (listagem mostra nome do medicine)
+   *   - @dosiq/today-snapshot (dashboard mostra nome em doses do dia)
+   *   - @dosiq/stock-snapshot (entries de stock mostram nome do medicine)
+   * Caches NÃO invalidados (intencionalmente): nenhum aplicável.
+   */
   const mutationUpdate = useMutation({
-    invalidateKeys: [MEDICINES_CACHE_KEY],
+    invalidateKeys: [
+      MEDICINES_CACHE_KEY,
+      PROTOCOLS_CACHE_KEY,
+      TREATMENTS_CACHE_KEY,
+      TODAY_CACHE_KEY,
+      STOCK_CACHE_KEY,
+    ],
     onSuccess: () => show('Medicamento atualizado', { variant: 'success' }),
     onError: (err) => show(err?.message ?? 'Erro ao atualizar medicamento', { variant: 'error' }),
   })
 
+  /**
+   * remove — wrapper genérico de delete (sem pre-check). Pra fluxo com hard
+   * block contra dependências, use `useMedicineDelete` (preCheck + delete).
+   * Caches invalidados (defensivos — se chamado sem pre-check, deps órfãs):
+   *   - @dosiq/medicines-snapshot
+   *   - @dosiq/protocols-snapshot
+   *   - @dosiq/treatments-snapshot
+   *   - @dosiq/today-snapshot
+   *   - @dosiq/stock-snapshot
+   */
   const mutationDelete = useMutation({
-    invalidateKeys: [MEDICINES_CACHE_KEY],
+    invalidateKeys: [
+      MEDICINES_CACHE_KEY,
+      PROTOCOLS_CACHE_KEY,
+      TREATMENTS_CACHE_KEY,
+      TODAY_CACHE_KEY,
+      STOCK_CACHE_KEY,
+    ],
     onSuccess: () => show('Medicamento removido', { variant: 'success' }),
     onError: (err) => show(err?.message ?? 'Erro ao remover medicamento', { variant: 'error' }),
   })

--- a/apps/mobile/src/features/treatments/hooks/useProtocolDelete.js
+++ b/apps/mobile/src/features/treatments/hooks/useProtocolDelete.js
@@ -11,6 +11,9 @@ import { successHaptic, errorHaptic } from '@shared/utils/haptics'
 import { protocolService } from '../services/protocolService'
 
 const PROTOCOLS_CACHE_KEY = '@dosiq/protocols-snapshot'
+const TREATMENTS_CACHE_KEY = '@dosiq/treatments-snapshot'
+const TODAY_CACHE_KEY = '@dosiq/today-snapshot'
+const STOCK_CACHE_KEY = '@dosiq/stock-snapshot'
 
 export function useProtocolDelete(protocol) {
   // States (R-010 — States → Memos → Effects → Handlers)
@@ -19,12 +22,25 @@ export function useProtocolDelete(protocol) {
   const [isLoading, setIsLoading] = useState(false)
 
   // Handlers
+  /**
+   * confirmDelete — exclui tratamento (sem hard block — soft warning na sheet).
+   * Caches invalidados (matrix R-236):
+   *   - @dosiq/protocols-snapshot (detail/useProtocol)
+   *   - @dosiq/treatments-snapshot (listagem — item some)
+   *   - @dosiq/today-snapshot (agenda do dia pode ter dose desse protocol)
+   *   - @dosiq/stock-snapshot (consumo daily recalcula — daysRemaining sobe)
+   */
   const confirmDelete = useCallback(async () => {
     if (!protocol?.id) return false
     setIsLoading(true)
     try {
       await protocolService.delete(protocol.id)
-      await AsyncStorage.removeItem(PROTOCOLS_CACHE_KEY).catch(() => {})
+      await Promise.all([
+        AsyncStorage.removeItem(PROTOCOLS_CACHE_KEY),
+        AsyncStorage.removeItem(TREATMENTS_CACHE_KEY),
+        AsyncStorage.removeItem(TODAY_CACHE_KEY),
+        AsyncStorage.removeItem(STOCK_CACHE_KEY),
+      ]).catch(() => {})
       successHaptic()
       show('Tratamento excluído', { variant: 'success' })
       navigation.goBack()

--- a/apps/mobile/src/features/treatments/hooks/useProtocolDelete.js
+++ b/apps/mobile/src/features/treatments/hooks/useProtocolDelete.js
@@ -35,11 +35,12 @@ export function useProtocolDelete(protocol) {
     setIsLoading(true)
     try {
       await protocolService.delete(protocol.id)
-      await Promise.all([
-        AsyncStorage.removeItem(PROTOCOLS_CACHE_KEY),
-        AsyncStorage.removeItem(TREATMENTS_CACHE_KEY),
-        AsyncStorage.removeItem(TODAY_CACHE_KEY),
-        AsyncStorage.removeItem(STOCK_CACHE_KEY),
+      // multiRemove = 1 chamada à ponte nativa (vs N concorrentes) — atômico.
+      await AsyncStorage.multiRemove([
+        PROTOCOLS_CACHE_KEY,
+        TREATMENTS_CACHE_KEY,
+        TODAY_CACHE_KEY,
+        STOCK_CACHE_KEY,
       ]).catch(() => {})
       successHaptic()
       show('Tratamento excluído', { variant: 'success' })

--- a/apps/mobile/src/features/treatments/hooks/useProtocolMutation.js
+++ b/apps/mobile/src/features/treatments/hooks/useProtocolMutation.js
@@ -1,13 +1,18 @@
-// useProtocolMutation.js — wrappers create/update sobre useMutation
+// useProtocolMutation.js — wrappers create/update/toggleActive sobre useMutation
 //
 // Encapsula:
 // - Toast feedback (success/error)
-// - Cache invalidation (@dosiq/protocols-snapshot)
+// - Cache invalidation (matrix R-236 — ver bloco por método abaixo)
 // - Navegação opcional pós-sucesso
 //
 // Uso:
-//   const { create, update, isLoading } = useProtocolMutation()
+//   const { create, update, toggleActive, isLoading } = useProtocolMutation()
 //   create(values, { goBack: true })
+//
+// ────────────────────────────────────────────────────────────────────────────
+// CACHE INVALIDATION MATRIX (R-236) — todo mutation deve listar TODOS
+// snapshots afetados. Esquecer um cache adjacente = bug latente (D11 Fase 2.5).
+// ────────────────────────────────────────────────────────────────────────────
 
 import { useCallback } from 'react'
 import AsyncStorage from '@react-native-async-storage/async-storage'
@@ -17,24 +22,51 @@ import { useToast } from '@shared/components/feedback/Toast'
 import { protocolService } from '../services/protocolService'
 
 const PROTOCOLS_CACHE_KEY = '@dosiq/protocols-snapshot'
-// useTreatments (listagem) usa cache key próprio — toggleActive precisa
-// invalidar AMBOS pra que a listagem reflita a mudança de tab (Ativos↔Pausados)
-// mesmo se a rede falhar no refresh seguinte.
 const TREATMENTS_CACHE_KEY = '@dosiq/treatments-snapshot'
+const TODAY_CACHE_KEY = '@dosiq/today-snapshot'
+const STOCK_CACHE_KEY = '@dosiq/stock-snapshot'
 
 export function useProtocolMutation() {
   // States (R-010 — States → Memos → Effects → Handlers)
   const navigation = useNavigation()
   const { show } = useToast()
 
+  /**
+   * create — cria tratamento (protocol) novo.
+   * Caches invalidados:
+   *   - @dosiq/protocols-snapshot (detail/useProtocol)
+   *   - @dosiq/treatments-snapshot (listagem/useTreatments — contagem +
+   *     grouping precisam refletir o novo item)
+   *   - @dosiq/today-snapshot (dashboard pode mostrar nova dose hoje)
+   *   - @dosiq/stock-snapshot (consumo diário aumenta → daysRemaining recalcula)
+   */
   const mutationCreate = useMutation({
-    invalidateKeys: [PROTOCOLS_CACHE_KEY],
+    invalidateKeys: [
+      PROTOCOLS_CACHE_KEY,
+      TREATMENTS_CACHE_KEY,
+      TODAY_CACHE_KEY,
+      STOCK_CACHE_KEY,
+    ],
     onSuccess: () => show('Tratamento criado', { variant: 'success' }),
     onError: (err) => show(err?.message ?? 'Erro ao criar tratamento', { variant: 'error' }),
   })
 
+  /**
+   * update — edita tratamento (dose, horários, período, etc).
+   * Caches invalidados:
+   *   - @dosiq/protocols-snapshot
+   *   - @dosiq/treatments-snapshot (listagem mostra dose/freq)
+   *   - @dosiq/today-snapshot (horários podem ter mudado)
+   *   - @dosiq/stock-snapshot (mudança em dosage_per_intake ou time_schedule
+   *     altera consumo diário → daysRemaining recalcula)
+   */
   const mutationUpdate = useMutation({
-    invalidateKeys: [PROTOCOLS_CACHE_KEY],
+    invalidateKeys: [
+      PROTOCOLS_CACHE_KEY,
+      TREATMENTS_CACHE_KEY,
+      TODAY_CACHE_KEY,
+      STOCK_CACHE_KEY,
+    ],
     onSuccess: () => show('Tratamento atualizado', { variant: 'success' }),
     onError: (err) => show(err?.message ?? 'Erro ao atualizar tratamento', { variant: 'error' }),
   })
@@ -57,17 +89,26 @@ export function useProtocolMutation() {
     [mutationUpdate, navigation]
   )
 
+  /**
+   * toggleActive — alterna flag `active` do tratamento (pausar/retomar).
+   * Caches invalidados:
+   *   - @dosiq/protocols-snapshot (detail)
+   *   - @dosiq/treatments-snapshot (listagem — tab Ativos↔Pausados)
+   *   - @dosiq/today-snapshot (pause = some da agenda do dia)
+   *   - @dosiq/stock-snapshot (pause = consumo daily cai → daysRemaining sobe)
+   *
+   * Não usa wrapper useMutation pq toggleActive é direto (sem optimistic
+   * via useMutation; UI faz override local em ProtocolDetailScreen).
+   */
   const toggleActive = useCallback(
     async (id, nextValue) => {
       try {
         const result = await protocolService.update(id, { active: nextValue })
-        // Invalida AMBOS snapshots locais (best-effort): protocols-snapshot
-        // (detail/useProtocol) + treatments-snapshot (listagem/useTreatments).
-        // Sem este 2º removeItem, a listagem serviria cache stale com o item
-        // ainda na tab antiga caso o refresh on focus falhe.
         await Promise.all([
           AsyncStorage.removeItem(PROTOCOLS_CACHE_KEY),
           AsyncStorage.removeItem(TREATMENTS_CACHE_KEY),
+          AsyncStorage.removeItem(TODAY_CACHE_KEY),
+          AsyncStorage.removeItem(STOCK_CACHE_KEY),
         ]).catch(() => {})
         show(nextValue ? 'Tratamento ativo' : 'Tratamento pausado', { variant: 'success' })
         return result

--- a/apps/mobile/src/features/treatments/hooks/useProtocolMutation.js
+++ b/apps/mobile/src/features/treatments/hooks/useProtocolMutation.js
@@ -104,11 +104,12 @@ export function useProtocolMutation() {
     async (id, nextValue) => {
       try {
         const result = await protocolService.update(id, { active: nextValue })
-        await Promise.all([
-          AsyncStorage.removeItem(PROTOCOLS_CACHE_KEY),
-          AsyncStorage.removeItem(TREATMENTS_CACHE_KEY),
-          AsyncStorage.removeItem(TODAY_CACHE_KEY),
-          AsyncStorage.removeItem(STOCK_CACHE_KEY),
+        // multiRemove = 1 chamada à ponte nativa (vs N concorrentes) — atômico.
+        await AsyncStorage.multiRemove([
+          PROTOCOLS_CACHE_KEY,
+          TREATMENTS_CACHE_KEY,
+          TODAY_CACHE_KEY,
+          STOCK_CACHE_KEY,
         ]).catch(() => {})
         show(nextValue ? 'Tratamento ativo' : 'Tratamento pausado', { variant: 'success' })
         return result


### PR DESCRIPTION
## Summary

Fecha últimos 2 itens (P6 + P7) do plano de ação RETRO Fase 2.

**P6 — Cache invalidation matrix (R-236) nos hooks mobile**
- Auditoria + fix de 4 hooks: useMedicineMutation, useMedicineDelete, useProtocolMutation, useProtocolDelete
- Bugs latentes corrigidos:
  - Medicine update não invalidava protocols/treatments/today/stock (nome do medicine aparece em todos)
  - Protocol create/update não invalidava treatments-snapshot → listagem stale
  - Protocol create/update não invalidava today-snapshot → agenda do dia obsoleta
  - Protocol toggleActive/delete não invalidava today/stock → dose pausada continuava agendada, daysRemaining errado
- JSDoc R-236 documentando matrix completa (caches invalidados + NÃO invalidados intencionalmente)
- Base sólida pra `useStockMutation` da Fase 3 (S1.3 vai espelhar pattern)

**P7 — Distill policy (CLAUDE.md §Distill Policy)**
- Threshold auto mantido em 15
- Trigger manual obrigatório ao encerrar fase (independente do threshold)
- Rationale: evita counter drift (AP-161) + mantém memória fresh entre fases

## Test plan

- [x] `rtk npm run validate:agent`: 530/530 green
- [x] lint dos 4 hooks: 0 issues
- [ ] Smoke local: criar/editar/pausar/deletar protocol → confirmar dashboard + listagem atualizam sem refresh
- [ ] Smoke local: editar medicine name → confirmar listagem treatments mostra novo nome

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AI Review Response

| Suggestion | Priority | Decision | Reason |
|------------|----------|----------|--------|
| useProtocolDelete: multiRemove em vez de Promise.all | Medium | Applied | Commit e0a82006 — 1 chamada nativa vs N concorrentes |
| useProtocolDelete: loading state local + avoid wrappers | Medium | Already implemented | isLoading via useState; impl direta sem useMutation wrapper |
| useProtocolMutation.toggleActive: multiRemove | Medium | Applied | Commit e0a82006 |
| useProtocolMutation: encapsulate async + derive loading | Medium | Already implemented | toggleActive intencionalmente direto (UI faz override optimistic local); isLoading dos outros métodos já derivado |
