### PR TITLE
feat(stock): Wave 1 S3.1 — helpers canônicos + stockService consolidado

### DIFF
--- a/.agent/state.json
+++ b/.agent/state.json
@@ -3,15 +3,15 @@
   "sprint": "2026-W20",
   "session": {
     "mode": "coding",
-    "status": "completed",
-    "goal": "Fase 2.5 fechada (PR #570) + RETRO Fase 2+2.5 + DEVFLOW C5 (3 APs + 2 R)",
+    "status": "coding",
+    "goal": "Fase 3 Sprint S3.1 Wave 1 — helpers @dosiq/core/utils/stock + stockService consolidado mobile",
     "goal_type": "feature"
   },
   "memory": {
     "last_distillation": "2026-05-16T13:35:00Z",
     "journal_entries_since_distillation": 3,
     "rules_count": 188,
-    "anti_patterns_count": 169,
+    "anti_patterns_count": 171,
     "decisions_count": 46,
     "contracts_count": 20,
     "distillation_due": false
@@ -21,6 +21,6 @@
     "auto_promote_rule_after_incidents": 3
   },
   "quality_gates": {
-    "index_loaded_at": "2026-05-18T15:05:00Z"
+    "index_loaded_at": "2026-05-18T19:50:00Z"
   }
 }

--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -22,3 +22,4 @@ dist/
 google-services*.json
 GoogleService-Info*.plist
 credentials.json
+*.jks

--- a/apps/mobile/src/features/stock/services/stockService.js
+++ b/apps/mobile/src/features/stock/services/stockService.js
@@ -1,28 +1,42 @@
-// ADR-029: thin local service — chama Supabase directamente via nativeSupabaseClient
-// R-125: validação Zod na camada de serviço (R-NNN sugerido em review PR #467)
+// stockService.js — Fase 3 CRUD Estoque mobile.
+//
+// Consolidação dos 2 services web (`stockService` + `purchaseService`) num
+// único módulo mobile. Pattern thin local (ADR-029) — chama Supabase direto
+// via nativeSupabaseClient. Validação Zod via @dosiq/core (R-125 + R-232).
+//
+// Diferenças vs web:
+// - userId é param explícito (consistente com treatmentsService.js mobile)
+// - Sem `delete` de purchase (PO-1 — escopo cortado; correção via Ajuste)
+// - getStockData (legacy MVP read-only) preservado pra não quebrar useStock atual
+//
+// Refactor pra factory createStockRepository + createPurchaseRepository em S2
+// (G2/G3). Por enquanto este service é a fonte mobile.
 
 import { z } from 'zod'
-import { getTodayLocal, isProtocolActiveOnDate } from '@dosiq/core'
+import {
+  getTodayLocal,
+  isProtocolActiveOnDate,
+  validateStockCreate,
+  validateStockDecrease,
+  validateStockIncrease,
+} from '@dosiq/core'
 import { supabase as nativeSupabaseClient } from '../../../platform/supabase/nativeSupabaseClient'
 import { debugLog, errorLog } from '@shared/utils/debugLog'
 
+// ───────────────────────────────────────────────────────────────────────────
+// LEGACY — getStockData (MVP read-only, mantido pra useStock atual)
+// ───────────────────────────────────────────────────────────────────────────
+
 /**
- * Busca a lista de medicamentos com seu estoque e protocolos ativos para cálculo de consumo.
- * 
- * @param {string} userId - UUID do usuário
+ * Busca medicamentos com estoque + protocolos ativos pra cálculo de consumo.
+ * @param {string} userId
  * @returns {Promise<{success: boolean, data?: Array, error?: string}>}
  */
 export async function getStockData(userId) {
   try {
-    // Validação de entrada conforme R-125
     z.string().uuid().parse(userId)
+    debugLog('stockService', `getStockData: ${userId}`)
 
-    debugLog('stockService', `Buscando dados de estoque para: ${userId}`)
-
-    // Buscamos medicamentos com: 
-    // 1. Quantidade total (da view medicine_stock_summary)
-    // 2. Protocolos ativos (para calcular consumo diário)
-    // Nota: O join com medicine_stock_summary usa a relação automática baseada em medicine_id
     const { data: rawData, error } = await nativeSupabaseClient
       .from('medicines')
       .select(`
@@ -49,22 +63,313 @@ export async function getStockData(userId) {
       .order('name')
 
     if (error) {
-      errorLog('stockService', 'Erro na query', error)
+      errorLog('stockService', 'getStockData query error', error)
       return { success: false, error: 'Erro ao carregar dados de estoque' }
     }
 
-    // Filtro de validade de protocolos (Wave v0.1.5)
-    // Na fase Read-Only, só mostramos estoque do que tem tratamento "rodando" hoje.
     const today = getTodayLocal()
-    const validData = (rawData || []).filter(m => {
-      // Verifica se existe pelo menos um protocolo vinculado que seja válido para hoje
-      const hasValidProtocol = (m.protocols || []).some(p => isProtocolActiveOnDate(p, today))
-      return hasValidProtocol
-    })
+    const validData = (rawData || []).filter((m) =>
+      (m.protocols || []).some((p) => isProtocolActiveOnDate(p, today)),
+    )
 
     return { success: true, data: validData }
   } catch (err) {
-    errorLog('stockService', 'Erro inesperado', err)
+    errorLog('stockService', 'getStockData unexpected', err)
     return { success: false, error: err.message }
   }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// FASE 3 — stockService object (CRUD completo)
+// ───────────────────────────────────────────────────────────────────────────
+
+function fmtZodErr(errors) {
+  return errors.map((e) => `${e.field}: ${e.message}`).join('; ')
+}
+
+export const stockService = {
+  // === READS ===
+
+  /**
+   * Stock entries de um medicamento (FIFO order).
+   */
+  async getByMedicine(medicineId, userId) {
+    const { data, error } = await nativeSupabaseClient
+      .from('stock')
+      .select('*')
+      .eq('medicine_id', medicineId)
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+
+    if (error) throw error
+    return data || []
+  },
+
+  /**
+   * Summary agregado (total_quantity, entries_count, datas).
+   * Usa view medicine_stock_summary.
+   */
+  async getStockSummary(medicineId, userId) {
+    const { data, error } = await nativeSupabaseClient
+      .from('medicine_stock_summary')
+      .select('*')
+      .eq('medicine_id', medicineId)
+      .eq('user_id', userId)
+      .maybeSingle()
+
+    if (error) throw error
+    return (
+      data ?? {
+        medicine_id: medicineId,
+        user_id: userId,
+        total_quantity: 0,
+        stock_entries_count: 0,
+        oldest_entry_date: null,
+        newest_entry_date: null,
+      }
+    )
+  },
+
+  /**
+   * Total quantity (com fallback manual caso view não retorne).
+   */
+  async getTotalQuantity(medicineId, userId) {
+    const { data: summary, error: summaryError } = await nativeSupabaseClient
+      .from('medicine_stock_summary')
+      .select('total_quantity')
+      .eq('medicine_id', medicineId)
+      .eq('user_id', userId)
+      .maybeSingle()
+
+    if (!summaryError && summary) return summary.total_quantity
+
+    const { data, error } = await nativeSupabaseClient
+      .from('stock')
+      .select('quantity')
+      .eq('medicine_id', medicineId)
+      .eq('user_id', userId)
+
+    if (error) throw error
+    return (data || []).reduce((acc, e) => acc + (e.quantity || 0), 0)
+  },
+
+  /**
+   * Medicamentos com stock baixo. Usa RPC; fallback view direto.
+   */
+  async getLowStockMedicines(userId, threshold = 10) {
+    const { data, error } = await nativeSupabaseClient.rpc('get_low_stock_medicines', {
+      p_user_id: userId,
+      p_threshold: threshold,
+    })
+
+    if (error) {
+      const { data: fallback, error: fbErr } = await nativeSupabaseClient
+        .from('medicine_stock_summary')
+        .select('*')
+        .eq('user_id', userId)
+        .lte('total_quantity', threshold)
+        .order('total_quantity', { ascending: true })
+
+      if (fbErr) throw fbErr
+      return fallback || []
+    }
+    return data || []
+  },
+
+  // === PURCHASES (read) ===
+
+  /**
+   * Histórico de compras de um medicamento.
+   */
+  async getPurchasesByMedicine(medicineId, userId) {
+    const { data, error } = await nativeSupabaseClient
+      .from('purchases')
+      .select('*')
+      .eq('medicine_id', medicineId)
+      .eq('user_id', userId)
+      .order('purchase_date', { ascending: false })
+      .order('created_at', { ascending: false })
+
+    if (error) throw error
+    return data || []
+  },
+
+  /**
+   * Última compra de cada medicineId (mapa medicineId → purchase).
+   */
+  async getLatestPurchasesByMedicineIds(medicineIds, userId) {
+    if (!medicineIds || medicineIds.length === 0) return {}
+    const { data, error } = await nativeSupabaseClient
+      .from('purchases')
+      .select('*')
+      .eq('user_id', userId)
+      .in('medicine_id', medicineIds)
+      .order('purchase_date', { ascending: false })
+      .order('created_at', { ascending: false })
+
+    if (error) throw error
+    return (data || []).reduce((map, p) => {
+      if (!map[p.medicine_id]) map[p.medicine_id] = p
+      return map
+    }, {})
+  },
+
+  // === WRITES ===
+
+  /**
+   * Cria compra + atualiza saldo (atômico via RPC).
+   * @throws {Error} se validation Zod falhar
+   */
+  async createPurchase(input, userId) {
+    const validation = validateStockCreate(input)
+    if (!validation.success) throw new Error(`Erro de validação: ${fmtZodErr(validation.errors)}`)
+    const p = validation.data
+
+    const { data, error } = await nativeSupabaseClient.rpc('create_purchase_with_stock', {
+      p_medicine_id: p.medicine_id,
+      p_quantity: p.quantity,
+      p_unit_price: p.unit_price ?? 0,
+      p_purchase_date: p.purchase_date,
+      p_expiration_date: p.expiration_date,
+      p_pharmacy: p.pharmacy,
+      p_laboratory: p.laboratory,
+      p_notes: p.notes,
+    })
+
+    if (error) throw error
+    debugLog('stockService', `createPurchase OK medicineId=${p.medicine_id} userId=${userId}`)
+    return data
+  },
+
+  /**
+   * Edita uma purchase existente. Sem RPC dedicada na web — update direto na
+   * tabela purchases. NÃO mexe em stock (saldo é decremento via consume_stock).
+   */
+  async updatePurchase(id, input, userId) {
+    const validation = validateStockCreate(input)
+    if (!validation.success) throw new Error(`Erro de validação: ${fmtZodErr(validation.errors)}`)
+    const p = validation.data
+
+    const { data, error } = await nativeSupabaseClient
+      .from('purchases')
+      .update({
+        quantity: p.quantity,
+        unit_price: p.unit_price ?? 0,
+        purchase_date: p.purchase_date,
+        expiration_date: p.expiration_date,
+        pharmacy: p.pharmacy,
+        laboratory: p.laboratory,
+        notes: p.notes,
+      })
+      .eq('id', id)
+      .eq('user_id', userId)
+      .select()
+      .single()
+
+    if (error) throw error
+    return data
+  },
+
+  /**
+   * Consumo FIFO (chamado quando dose é registrada).
+   * @throws {Error} se medicineLogId ausente ou validation falhar
+   */
+  async decreaseStock(medicineId, quantity, medicineLogId, userId) {
+    const validation = validateStockDecrease({ medicine_id: medicineId, quantity })
+    if (!validation.success) throw new Error(`Erro de validação: ${fmtZodErr(validation.errors)}`)
+    if (!medicineLogId) throw new Error('medicineLogId é obrigatório para consumo FIFO rastreável')
+
+    const { data, error } = await nativeSupabaseClient.rpc('consume_stock_fifo', {
+      p_medicine_id: medicineId,
+      p_quantity: quantity,
+      p_medicine_log_id: medicineLogId,
+    })
+
+    if (error) throw error
+    debugLog('stockService', `decreaseStock OK medicineId=${medicineId} userId=${userId}`)
+    return data
+  },
+
+  /**
+   * Estorna stock (delete de log) OU ajuste manual positivo.
+   * Se `options.medicine_log_id` presente → restore_stock_for_log RPC.
+   * Senão → apply_manual_stock_adjustment RPC.
+   */
+  async increaseStock(medicineId, quantity, options = {}, userId) {
+    const normalized =
+      typeof options === 'string'
+        ? { reason: options, quantity }
+        : { ...options, quantity }
+
+    const validation = validateStockIncrease({
+      medicine_id: medicineId,
+      quantity,
+      medicine_log_id: normalized.medicine_log_id ?? null,
+      reason: normalized.reason ?? 'Ajuste de estoque',
+      notes: normalized.notes ?? null,
+    })
+
+    if (!validation.success) throw new Error(`Erro de validação: ${fmtZodErr(validation.errors)}`)
+    const payload = validation.data
+
+    if (payload.medicine_log_id) {
+      const { data, error } = await nativeSupabaseClient.rpc('restore_stock_for_log', {
+        p_medicine_log_id: payload.medicine_log_id,
+        p_reason: payload.reason,
+      })
+      if (error) throw error
+      return data
+    }
+
+    const { data, error } = await nativeSupabaseClient.rpc('apply_manual_stock_adjustment', {
+      p_medicine_id: medicineId,
+      p_quantity_delta: quantity,
+      p_reason: payload.reason,
+      p_notes: payload.notes,
+    })
+
+    if (error) throw error
+    debugLog('stockService', `increaseStock OK medicineId=${medicineId} userId=${userId}`)
+    return data
+  },
+
+  /**
+   * Ajuste manual — modo único "Acertar saldo" (PO-6).
+   * Calcula delta = newBalance - currentTotal e dispara increase/decrease.
+   *
+   * @param {string} medicineId
+   * @param {number} newBalance - saldo final desejado (>=0)
+   * @param {string} reason - motivo (obrigatório PO-6)
+   * @param {string|null} notes
+   * @param {string} userId
+   */
+  async adjustToBalance(medicineId, newBalance, reason, notes, userId) {
+    if (!reason) throw new Error('Motivo é obrigatório para ajuste manual')
+    if (newBalance < 0) throw new Error('Saldo final não pode ser negativo')
+
+    const current = await this.getTotalQuantity(medicineId, userId)
+    const delta = newBalance - current
+
+    if (delta === 0) {
+      debugLog('stockService', `adjustToBalance: delta=0, no-op medicineId=${medicineId}`)
+      return { delta: 0, before: current, after: newBalance }
+    }
+
+    if (delta > 0) {
+      await this.increaseStock(medicineId, delta, { reason, notes }, userId)
+    } else {
+      // delta negativo — ajuste manual decrementa via RPC com quantity_delta negativo
+      const { data, error } = await nativeSupabaseClient.rpc('apply_manual_stock_adjustment', {
+        p_medicine_id: medicineId,
+        p_quantity_delta: delta,
+        p_reason: reason,
+        p_notes: notes ?? null,
+      })
+      if (error) throw error
+      debugLog('stockService', `adjustToBalance decrement OK medicineId=${medicineId} delta=${delta}`)
+      return data
+    }
+
+    return { delta, before: current, after: newBalance }
+  },
 }

--- a/apps/mobile/src/features/stock/services/stockService.js
+++ b/apps/mobile/src/features/stock/services/stockService.js
@@ -347,7 +347,10 @@ export const stockService = {
     if (!reason) throw new Error('Motivo é obrigatório para ajuste manual')
     if (newBalance < 0) throw new Error('Saldo final não pode ser negativo')
 
-    const current = await this.getTotalQuantity(medicineId, userId)
+    // Usar stockService.* (não this.*) — adjustToBalance pode ser destructurado
+    // em hooks (ex: const { adjustToBalance } = useStockMutation()), perdendo
+    // referência a `this`.
+    const current = await stockService.getTotalQuantity(medicineId, userId)
     const delta = newBalance - current
 
     if (delta === 0) {
@@ -356,10 +359,11 @@ export const stockService = {
     }
 
     if (delta > 0) {
-      await this.increaseStock(medicineId, delta, { reason, notes }, userId)
+      await stockService.increaseStock(medicineId, delta, { reason, notes }, userId)
     } else {
       // delta negativo — ajuste manual decrementa via RPC com quantity_delta negativo
-      const { data, error } = await nativeSupabaseClient.rpc('apply_manual_stock_adjustment', {
+      // (depende de migration S2.0 pendente — ver EXEC_SPEC_FASE3 §0.8)
+      const { error } = await nativeSupabaseClient.rpc('apply_manual_stock_adjustment', {
         p_medicine_id: medicineId,
         p_quantity_delta: delta,
         p_reason: reason,
@@ -367,9 +371,9 @@ export const stockService = {
       })
       if (error) throw error
       debugLog('stockService', `adjustToBalance decrement OK medicineId=${medicineId} delta=${delta}`)
-      return data
     }
 
+    // Return padronizado nos 3 branches — API previsível
     return { delta, before: current, after: newBalance }
   },
 }

--- a/apps/web/vitest.critical.config.js
+++ b/apps/web/vitest.critical.config.js
@@ -36,6 +36,8 @@ export default mergeConfig(
         'src/features/**/services/**/*.test.{js,jsx}',
         'src/features/**/utils/**/*.test.{js,jsx}',
         'src/features/**/hooks/**/*.test.{js,jsx}',
+        // Helpers canônicos compartilhados (Fase 2.5+) — críticos pra paridade web↔mobile
+        '../../packages/core/src/**/*.test.{js,jsx}',
       ],
       exclude: [
         '**/*.smoke.test.*',

--- a/packages/core/src/utils/__tests__/stock.test.js
+++ b/packages/core/src/utils/__tests__/stock.test.js
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import {
+  STOCK_STATUS,
+  STOCK_THRESHOLDS,
+  resolveStockStatus,
+  computeAverageUnitPrice,
+  computeExpiryDays,
+  formatBRL,
+} from '../stock.js'
+
+describe('resolveStockStatus', () => {
+  it('retorna critico quando daysRemaining < 7', () => {
+    // 12 un. / 2 un./dia = 6 dias
+    expect(resolveStockStatus(12, 2)).toBe(STOCK_STATUS.CRITICO)
+  })
+
+  it('retorna baixo quando 7 <= daysRemaining < 14', () => {
+    // 20 / 2 = 10 dias
+    expect(resolveStockStatus(20, 2)).toBe(STOCK_STATUS.BAIXO)
+  })
+
+  it('retorna normal quando 14 <= daysRemaining < 30', () => {
+    // 40 / 2 = 20 dias
+    expect(resolveStockStatus(40, 2)).toBe(STOCK_STATUS.NORMAL)
+  })
+
+  it('retorna alto quando daysRemaining >= 30', () => {
+    // 100 / 2 = 50 dias
+    expect(resolveStockStatus(100, 2)).toBe(STOCK_STATUS.ALTO)
+  })
+
+  it('retorna critico quando qty <= 0 e sem consumo', () => {
+    expect(resolveStockStatus(0, 0)).toBe(STOCK_STATUS.CRITICO)
+  })
+
+  it('retorna normal quando qty > 0 e sem consumo', () => {
+    expect(resolveStockStatus(50, 0)).toBe(STOCK_STATUS.NORMAL)
+  })
+
+  it('retorna vencido se validade < hoje (sobrepoe critico)', () => {
+    // hoje: '2026-05-18'; expiry "04/2026" (ultimo dia abril) já vencido
+    expect(resolveStockStatus(100, 0, '04/2026', '2026-05-18')).toBe(STOCK_STATUS.VENCIDO)
+  })
+
+  it('NAO retorna vencido se validade no futuro', () => {
+    expect(resolveStockStatus(100, 0, '12/2027', '2026-05-18')).toBe(STOCK_STATUS.NORMAL)
+  })
+})
+
+describe('computeAverageUnitPrice', () => {
+  it('retorna 0 para array vazio ou null', () => {
+    expect(computeAverageUnitPrice([])).toBe(0)
+    expect(computeAverageUnitPrice(null)).toBe(0)
+    expect(computeAverageUnitPrice(undefined)).toBe(0)
+  })
+
+  it('calcula media ponderada pela quantidade', () => {
+    // (30 * 0.90 + 60 * 1.00) / 90 = (27 + 60) / 90 = 0.9666...
+    const result = computeAverageUnitPrice([
+      { quantity: 30, unit_price: 0.90 },
+      { quantity: 60, unit_price: 1.00 },
+    ])
+    expect(result).toBeCloseTo(0.9667, 4)
+  })
+
+  it('ignora compras sem unit_price ou quantity <= 0', () => {
+    const result = computeAverageUnitPrice([
+      { quantity: 30, unit_price: 0.90 },
+      { quantity: 0, unit_price: 5 },
+      { quantity: 30 },
+      { quantity: 30, unit_price: null },
+    ])
+    // só conta o primeiro: 30 * 0.90 / 30 = 0.90
+    expect(result).toBe(0.90)
+  })
+
+  it('retorna 0 se todas invalidas', () => {
+    expect(computeAverageUnitPrice([{ quantity: 0, unit_price: 5 }])).toBe(0)
+  })
+})
+
+describe('computeExpiryDays', () => {
+  it('retorna null para input invalido', () => {
+    expect(computeExpiryDays(null)).toBe(null)
+    expect(computeExpiryDays('')).toBe(null)
+    expect(computeExpiryDays('foo')).toBe(null)
+    expect(computeExpiryDays('13/2026')).toBe(null)
+  })
+
+  it('calcula dias para MM/YYYY (ultimo dia do mes)', () => {
+    // "05/2026" = 31/05/2026; ref = 18/05/2026 → 13 dias
+    expect(computeExpiryDays('05/2026', '2026-05-18')).toBe(13)
+  })
+
+  it('aceita YYYY-MM-DD', () => {
+    expect(computeExpiryDays('2026-06-01', '2026-05-18')).toBe(14)
+  })
+
+  it('retorna negativo se vencido', () => {
+    expect(computeExpiryDays('04/2026', '2026-05-18')).toBeLessThan(0)
+  })
+})
+
+describe('formatBRL', () => {
+  it('formata valor positivo', () => {
+    // Intl pode usar NBSP entre R$ e número; normalizar pra teste
+    const formatted = formatBRL(1234.56)
+    expect(formatted.replace(/\s/g, ' ')).toContain('1.234,56')
+    expect(formatted).toContain('R$')
+  })
+
+  it('formata zero', () => {
+    expect(formatBRL(0)).toMatch(/R\$\s?0,00/)
+  })
+
+  it('formata valor invalido como 0', () => {
+    expect(formatBRL(null)).toMatch(/R\$\s?0,00/)
+    expect(formatBRL(undefined)).toMatch(/R\$\s?0,00/)
+    expect(formatBRL('xyz')).toMatch(/R\$\s?0,00/)
+  })
+})
+
+describe('STOCK_THRESHOLDS', () => {
+  it('expõe constantes esperadas', () => {
+    expect(STOCK_THRESHOLDS.CRITICAL_DAYS).toBe(7)
+    expect(STOCK_THRESHOLDS.LOW_DAYS).toBe(14)
+    expect(STOCK_THRESHOLDS.NORMAL_DAYS).toBe(30)
+    expect(STOCK_THRESHOLDS.EXPIRY_WARNING_DAYS).toBe(90)
+  })
+})

--- a/packages/core/src/utils/index.js
+++ b/packages/core/src/utils/index.js
@@ -89,3 +89,15 @@ export {
   TREATMENT_STATUS,
   resolveTreatmentStatus,
 } from './treatmentStatus.js'
+
+// Stock helpers (Fase 3 — paridade web↔mobile)
+// REUSA calculateDailyIntake + calculateDaysRemaining de adherenceLogic.js
+// (exportados acima) — não duplicar derivações de consumo/dias-restantes.
+export {
+  STOCK_STATUS,
+  STOCK_THRESHOLDS,
+  resolveStockStatus,
+  computeAverageUnitPrice,
+  computeExpiryDays,
+  formatBRL,
+} from './stock.js'

--- a/packages/core/src/utils/stock.js
+++ b/packages/core/src/utils/stock.js
@@ -1,0 +1,143 @@
+/**
+ * stock.js — Helpers puros de estoque (web↔mobile, sem deps de plataforma).
+ *
+ * Convencao: thresholds em DIAS restantes, alinhados com CLAUDE.md:
+ *   CRITICAL <7d  ·  LOW <14d  ·  NORMAL <30d  ·  HIGH >=30d
+ *
+ * Para `vencendo`: itens com expDays < EXPIRY_WARNING_DAYS (90 dias).
+ *
+ * `calculateDailyIntake` e `calculateDaysRemaining` ja existem em
+ * adherenceLogic.js — REUSAR (nao duplicar). Ver index.js barrel.
+ */
+
+import { getNow, formatLocalDate, parseLocalDate, daysDifference, getLastDayOfMonth } from './dateUtils.js'
+
+export const STOCK_STATUS = Object.freeze({
+  CRITICO: 'critico',
+  BAIXO: 'baixo',
+  NORMAL: 'normal',
+  ALTO: 'alto',
+  VENCIDO: 'vencido',
+})
+
+export const STOCK_THRESHOLDS = Object.freeze({
+  CRITICAL_DAYS: 7,
+  LOW_DAYS: 14,
+  NORMAL_DAYS: 30,
+  EXPIRY_WARNING_DAYS: 90,
+})
+
+/**
+ * resolveStockStatus — deriva status do estoque a partir de saldo + consumo
+ * + data de validade mais proxima.
+ *
+ * @param {number} qty - saldo em unidades
+ * @param {number} dailyConsumption - consumo diario (un./dia)
+ * @param {string|null} [nearestExpiryYYYYMM] - validade mais proxima em "MM/YYYY"
+ *   ou "YYYY-MM" (opcional)
+ * @param {string} [today] - data ref em YYYY-MM-DD (default: hoje local)
+ * @returns {'critico'|'baixo'|'normal'|'alto'|'vencido'}
+ */
+export function resolveStockStatus(qty, dailyConsumption, nearestExpiryYYYYMM = null, today = null) {
+  const ref = today ?? formatLocalDate(getNow())
+
+  // Vencido sobrepoe qualquer outra classificacao por seguranca.
+  if (nearestExpiryYYYYMM) {
+    const expDays = computeExpiryDays(nearestExpiryYYYYMM, ref)
+    if (expDays != null && expDays < 0) return STOCK_STATUS.VENCIDO
+  }
+
+  // Sem consumo: classificar por saldo absoluto (proxy para "tem ou nao tem").
+  if (!dailyConsumption || dailyConsumption <= 0) {
+    if (qty <= 0) return STOCK_STATUS.CRITICO
+    return STOCK_STATUS.NORMAL
+  }
+
+  const daysRemaining = qty / dailyConsumption
+  if (daysRemaining < STOCK_THRESHOLDS.CRITICAL_DAYS) return STOCK_STATUS.CRITICO
+  if (daysRemaining < STOCK_THRESHOLDS.LOW_DAYS) return STOCK_STATUS.BAIXO
+  if (daysRemaining < STOCK_THRESHOLDS.NORMAL_DAYS) return STOCK_STATUS.NORMAL
+  return STOCK_STATUS.ALTO
+}
+
+/**
+ * computeAverageUnitPrice — preco medio ponderado pela quantidade comprada.
+ *
+ * Ignora compras com `quantity <= 0` ou `unit_price` ausente/nulo.
+ *
+ * @param {Array<{quantity: number, unit_price: number}>} purchases
+ * @returns {number} preco medio (0 se nao houver compras validas)
+ */
+export function computeAverageUnitPrice(purchases) {
+  if (!Array.isArray(purchases) || purchases.length === 0) return 0
+
+  let totalCost = 0
+  let totalQty = 0
+  for (const p of purchases) {
+    const qty = Number(p?.quantity) || 0
+    // Rejeitar explicitamente null/undefined ANTES de Number() —
+    // Number(null) === 0 (finito) escaparia o filtro de isFinite.
+    if (p?.unit_price == null || qty <= 0) continue
+    const price = Number(p.unit_price)
+    if (!Number.isFinite(price)) continue
+    totalCost += qty * price
+    totalQty += qty
+  }
+
+  if (totalQty === 0) return 0
+  return totalCost / totalQty
+}
+
+/**
+ * computeExpiryDays — calcula dias restantes ate validade.
+ * Aceita "MM/YYYY" (mock format) ou "YYYY-MM-DD".
+ *
+ * Para "MM/YYYY", assume ultimo dia do mes como vencimento.
+ *
+ * @param {string} expiry
+ * @param {string} [today] - data ref YYYY-MM-DD (default: hoje local)
+ * @returns {number|null} dias (negativo se vencido) ou null se invalido
+ */
+export function computeExpiryDays(expiry, today = null) {
+  if (!expiry || typeof expiry !== 'string') return null
+  const ref = today ?? formatLocalDate(getNow())
+
+  let expiryDate
+  // MM/YYYY -> ultimo dia do mes (getLastDayOfMonth aceita month 0-indexed)
+  const mmYYYY = /^(\d{2})\/(\d{4})$/.exec(expiry)
+  if (mmYYYY) {
+    const month = parseInt(mmYYYY[1], 10)
+    const year = parseInt(mmYYYY[2], 10)
+    if (month < 1 || month > 12) return null
+    const lastDay = getLastDayOfMonth(year, month - 1)
+    const mm = String(month).padStart(2, '0')
+    const dd = String(lastDay).padStart(2, '0')
+    expiryDate = `${year}-${mm}-${dd}`
+  } else if (/^\d{4}-\d{2}-\d{2}$/.test(expiry)) {
+    expiryDate = expiry
+  } else {
+    return null
+  }
+
+  const refDate = parseLocalDate(ref)
+  const expDate = parseLocalDate(expiryDate)
+  if (!refDate || !expDate) return null
+  return daysDifference(refDate, expDate)
+}
+
+/**
+ * formatBRL — formata valor em BRL com locale pt-BR.
+ *
+ * Canonico para todo o monorepo. `apps/web/.../costAnalysisService.formatBRL`
+ * ainda existe (duplicado); sera substituido em G3 quando web adotar factory.
+ *
+ * @param {number} value
+ * @returns {string}
+ */
+export function formatBRL(value) {
+  const n = Number.isFinite(Number(value)) ? Number(value) : 0
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  }).format(n)
+}

--- a/plans/archive_old/stock_refactor/exec_spec_stock_refactor.md
+++ b/plans/archive_old/stock_refactor/exec_spec_stock_refactor.md
@@ -45,6 +45,7 @@ Esta execução deve:
 5. Não usar `notes` como mecanismo canônico de classificação depois da migração.
 6. Não implementar ajuste manual negativo nesta entrega.
    - se `p_quantity_delta < 0`, a função deve falhar explicitamente.
+   - **NOTA pós-entrega (2026-05-19, Fase 3 mobile)**: regra desbloqueada via nova migration documentada em §21.2. Ajuste negativo PERMITIDO com audit FIFO obrigatória. Regra original mantida historicamente — implementação atual segue §21.2.
 7. Não usar `stock.quantity` remanescente para calcular histórico de compra, última compra ou preço médio.
 8. Não inventar enums novos fora dos listados nesta spec.
 9. Não omitir testes de `logService.create`, `logService.update` e `logService.delete`.
@@ -751,7 +752,7 @@ apply_manual_stock_adjustment(
 )
 ```
 
-### Regras
+### Regras (versão original — 2026-04-02)
 
 - usar para correções manuais e casos de sistema sem origem em compra;
 - se `p_quantity_delta > 0`, criar entrada `stock` com:
@@ -760,7 +761,11 @@ apply_manual_stock_adjustment(
   - `original_quantity = p_quantity_delta`
 - se `p_quantity_delta < 0`, falhar explicitamente com exceção `Ajuste manual negativo não suportado nesta entrega`.
 
-**Decisão fechada desta spec:** ajuste manual de saída não entra no fluxo de produto desta onda; implementar apenas ajustes positivos e restauração por log.
+**Decisão fechada desta spec (original):** ajuste manual de saída não entra no fluxo de produto desta onda; implementar apenas ajustes positivos e restauração por log.
+
+### ⚠️ Atualização pós-entrega — ver §21.2
+
+A regra de bloqueio do delta negativo foi REVOGADA em 2026-05-19 quando Fase 3 mobile precisou implementar PO-6 (modo único "Acertar saldo" — usuário digita valor final, delta pode ser negativo). Ver §21.2 pra novo comportamento canônico + migration.
 
 ---
 
@@ -1932,3 +1937,167 @@ FOR UPDATE
 #### Invariante adicionada
 
 > `medicine_stock_summary` e `consume_stock_fifo` devem estar em sincronia: se a view inclui uma entrada no total, o FIFO deve poder consumi-la.
+
+---
+
+### 21.2 Desbloqueio de ajuste manual negativo
+
+**Data planejada**: 2026-05-19+ (Wave 5 do Sprint S3.2 — Fase 3 mobile)
+**Driver**: Mobile Fase 3 PO-6 (modo único "Acertar saldo" — usuário digita valor final; cenários: perda/doação/descarte/vencimento/correção)
+**Spec consumidora**: [`plans/backlog-native_app/EXEC_SPEC_FASE3_ESTOQUE.md`](../../backlog-native_app/EXEC_SPEC_FASE3_ESTOQUE.md) §0.8
+
+#### Mudança
+
+Regra original (§1.1 #6 e §7.4): `apply_manual_stock_adjustment` falha quando `p_quantity_delta < 0`. Razão histórica: cautela, evitar criar fluxo perigoso sem auditoria adequada.
+
+Realidade pós-mobile: usuários precisam reduzir saldo sem registrar dose (caí pílula, doação pra terceiro, descarte, etc). Sem essa função, a UI mobile não consegue implementar PO-6 sem workaround sujo.
+
+#### Migration nova
+
+Path: `docs/migrations/YYYYMMDD_allow_negative_manual_adjustments.sql` (data definida quando criada)
+
+Reescreve `apply_manual_stock_adjustment` (mantendo nome/assinatura) com comportamento:
+
+```sql
+CREATE OR REPLACE FUNCTION public.apply_manual_stock_adjustment(
+  p_medicine_id uuid,
+  p_quantity_delta numeric,
+  p_reason text,
+  p_notes text DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_stock_id uuid;
+  v_remaining numeric;
+  v_lot record;
+  v_take numeric;
+  v_total_available numeric;
+  v_adjustment_id uuid;
+BEGIN
+  v_user_id := auth.uid();
+
+  -- delta == 0: no-op explicito
+  IF p_quantity_delta = 0 THEN
+    RAISE EXCEPTION 'Delta zero não é permitido';
+  END IF;
+
+  -- ── Delta POSITIVO: mantém comportamento original ──
+  IF p_quantity_delta > 0 THEN
+    INSERT INTO public.stock (
+      user_id, medicine_id, quantity, original_quantity,
+      purchase_date, entry_type, purchase_id, notes
+    ) VALUES (
+      v_user_id, p_medicine_id, p_quantity_delta, p_quantity_delta,
+      CURRENT_DATE, 'adjustment', NULL, p_notes
+    ) RETURNING id INTO v_stock_id;
+
+    INSERT INTO public.stock_adjustments (
+      user_id, medicine_id, stock_id, quantity_delta, reason, notes
+    ) VALUES (
+      v_user_id, p_medicine_id, v_stock_id, p_quantity_delta, p_reason, p_notes
+    ) RETURNING id INTO v_adjustment_id;
+
+    RETURN v_adjustment_id;
+  END IF;
+
+  -- ── Delta NEGATIVO: novo comportamento ──
+  -- 1. Validar saldo total disponível >= abs(delta)
+  SELECT COALESCE(SUM(quantity), 0) INTO v_total_available
+  FROM public.stock
+  WHERE user_id = v_user_id
+    AND medicine_id = p_medicine_id
+    AND quantity > 0
+    AND entry_type != 'legacy_unrecoverable';
+
+  IF v_total_available < abs(p_quantity_delta) THEN
+    RAISE EXCEPTION 'Saldo insuficiente para ajuste negativo (disponível: %, solicitado: %)',
+      v_total_available, abs(p_quantity_delta);
+  END IF;
+
+  -- 2. Iterar lotes FIFO + decrementar (sem criar stock_consumptions — não é dose)
+  v_remaining := abs(p_quantity_delta);
+
+  FOR v_lot IN
+    SELECT * FROM public.stock
+    WHERE user_id = v_user_id
+      AND medicine_id = p_medicine_id
+      AND quantity > 0
+      AND entry_type != 'legacy_unrecoverable'
+    ORDER BY purchase_date ASC, created_at ASC, id ASC
+    FOR UPDATE
+  LOOP
+    EXIT WHEN v_remaining <= 0;
+
+    v_take := LEAST(v_lot.quantity, v_remaining);
+
+    UPDATE public.stock
+    SET quantity = quantity - v_take,
+        updated_at = now()
+    WHERE id = v_lot.id;
+
+    -- Audit por lote afetado
+    INSERT INTO public.stock_adjustments (
+      user_id, medicine_id, stock_id, quantity_delta, reason, notes
+    ) VALUES (
+      v_user_id, p_medicine_id, v_lot.id, -v_take, p_reason, p_notes
+    );
+
+    v_remaining := v_remaining - v_take;
+  END LOOP;
+
+  -- Retorna ID do último adjustment criado (audit head)
+  SELECT id INTO v_adjustment_id
+  FROM public.stock_adjustments
+  WHERE user_id = v_user_id AND medicine_id = p_medicine_id
+  ORDER BY created_at DESC LIMIT 1;
+
+  RETURN v_adjustment_id;
+END;
+$$;
+
+-- Grants/RLS conforme template CLAUDE.md
+REVOKE EXECUTE ON FUNCTION public.apply_manual_stock_adjustment(uuid, numeric, text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.apply_manual_stock_adjustment(uuid, numeric, text, text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.apply_manual_stock_adjustment(uuid, numeric, text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.apply_manual_stock_adjustment(uuid, numeric, text, text) TO service_role;
+```
+
+#### Reasons aceitos (canonical pós-§21.2)
+
+**Delta positivo** (set original archive §4.1.1):
+- `'ajuste_manual_positivo'`
+- `'correcao_erro'`
+- `'backfill_system_adjustment'`
+- `'outro'`
+
+**Delta negativo** (NOVO):
+- `'perda'`
+- `'doacao'`
+- `'descarte'`
+- `'vencimento_manual'` (distinto de vencimento detectado por job)
+- `'correcao_erro'`
+- `'outro'`
+
+#### Invariantes pós-mudança
+
+1. Delta zero: rejeitado (exceção). Sem mudança no banco.
+2. Delta positivo: comportamento idêntico ao original — cria 1 linha `stock` + 1 `stock_adjustments`.
+3. Delta negativo: nunca cria linha `stock` nova; decrementa lotes FIFO existentes; cria N `stock_adjustments` (1 por lote afetado).
+4. Saldo insuficiente: rejeitado antes de qualquer side effect (compatível com `consume_stock_fifo`).
+5. `stock_consumptions` NÃO é tocada por ajuste manual (ajuste não é dose; reversibilidade via novo ajuste compensatório).
+6. `medicine_stock_summary` reflete novo saldo automaticamente (view agregada).
+
+#### Não afeta
+
+- `consume_stock_fifo` (dose normal — continua usando `stock_consumptions`)
+- `restore_stock_for_log` (estorno de dose excluída — continua)
+- `create_purchase_with_stock` (compra normal — continua)
+
+#### Aplicação
+
+Migration é aplicada manualmente pelo PO via Supabase SQL Editor OU CLI. NÃO auto-migra. Versão Mobile (`adjustToBalance`) DEPENDE da aplicação prévia — sem isso, runtime falha com exceção da regra original.

--- a/plans/backlog-native_app/EXEC_SPEC_FASE3_ESTOQUE.md
+++ b/plans/backlog-native_app/EXEC_SPEC_FASE3_ESTOQUE.md
@@ -1,4 +1,4 @@
-# EXEC SPEC — Fase 3: CRUD Estoque (v2 — 2026-05-18)
+# EXEC SPEC — Fase 3: CRUD Estoque (v2.1 — 2026-05-19)
 
 > **Duração**: 2 sprints semanais
 > **Branch base**: `feat/crud-stock`
@@ -62,9 +62,120 @@ Esquecer um cache = bug latente (D11 Fase 2.5; G7 retro Fase 3).
 | PO-3 | **Form de compra sempre com med travado no topo** | Sem `MedicineSelectableRow` no form; seleção é `PurchaseMedicineSheet` (do FAB Hub) ou param da rota (do FAB Detail) |
 | PO-4 | **Editar compra ≠ Registrar compra** | Mesma tela, mode prop diferente; push do "..." em PurchaseCard do Histórico |
 | PO-5 | **Indicadores v1 = KPI grid 2×2** (skip variant C colapsável; ir direto pra A) | StockIndicators componente único; mock detalhes reflete |
-| PO-6 | **Ajuste manual = modo único "Acertar saldo"** (digitar valor final) | Sem segmented `+ / −`. Preview teal do delta. Motivo obrigatório |
+| PO-6 | **Ajuste manual = modo único "Acertar saldo"** (digitar valor final, delta pode ser negativo) | Sem segmented `+ / −`. Preview teal do delta. Motivo obrigatório. **Requer migration nova pra desbloquear delta negativo** (ver §0.8) |
 | PO-7 | Glossário UI: "Estoque", "compra", "lote", "validade", "saldo", "farmácia", "laboratório" | Adotar nos labels |
 | PO-8 | **Stock = 0 é cenário válido** (validação acontece em LogForm dose) | Spec NÃO bloqueia stock=0; UI mostra status crítico + CTA "Registrar compra". Designer não precisa novo mock |
+| PO-9 | **Regra de listagem do Hub** (NOVA, corrige bug atual em produção) | StockScreen mostra meds onde `hasActiveProtocol \|\| totalStock > 0`. Bug atual: `getStockData` legacy filtra só `protocols.active=true` → meds com estoque órfão (treatment finalizado/pausado/inexistente) ficam invisíveis. Fix é INERENTE à reescrita Wave 4 — não fix retroativo separado |
+| PO-10 | **`regulatory_category` FORA escopo Fase 3 v1** | Mocks não diferenciam Genérico/Similar/Novo. `StockForm` mobile NÃO implementa matriz regulatória (web archived spec §11.5). Defer pra v2 quando UI mobile expandir cadastro de medicamentos |
+
+### 0.6.5 Alignment com archive_old/stock_refactor (canonical SQL/RPC contract)
+
+Reference: [`plans/archive_old/stock_refactor/exec_spec_stock_refactor.md`](../archive_old/stock_refactor/exec_spec_stock_refactor.md)
+
+Refactor stock (PR #443, 2026-04-02) estabeleceu o modelo canônico que mobile Fase 3 DEVE respeitar:
+
+**Tabelas + colunas** (já existem em produção):
+- `purchases` (fonte canônica histórico — quantity_bought, unit_price, purchase_date, expiration_date, pharmacy, laboratory, notes)
+- `stock` (saldo por lote — purchase_id, original_quantity, **entry_type** {purchase/adjustment/legacy_unrecoverable})
+- `stock_adjustments` (audit trail — quantity_delta, reason, reference_id)
+- `stock_consumptions` (consumo por log + lote — medicine_log_id, stock_id, quantity_consumed, reversed_at)
+- view `medicine_stock_summary` (agregado pra leitura rápida — total_quantity)
+- `medicines.regulatory_category` (genérico/similar/novo — FORA escopo mobile v1, ver PO-10)
+
+**RPCs canônicos** (mobile usa via `stockService.js`):
+- `create_purchase_with_stock(p_medicine_id, p_quantity, p_unit_price, p_purchase_date, p_expiration_date, p_pharmacy, p_laboratory, p_notes)` — atomic compra + lote
+- `consume_stock_fifo(p_medicine_id, p_quantity, p_medicine_log_id)` — FIFO com `entry_type != 'legacy_unrecoverable'` (fix Phantom Stock 2026-05-13 — §21.1 archive)
+- `restore_stock_for_log(p_medicine_log_id, p_reason)` — estorna exato por lote
+- `apply_manual_stock_adjustment(p_medicine_id, p_quantity_delta, p_reason, p_notes)` — **atualmente bloqueia delta < 0** (archive §1.1 regra 6); ver §0.8 pra mudança Fase 3
+
+**Read-side regras (Wave 4 StockScreen + Wave 3 PurchaseHistory)**:
+- Histórico de compras → SEMPRE `purchases` (via `getPurchasesByMedicine`), NUNCA `stock.quantity`
+- Última compra → `purchases ORDER BY purchase_date DESC LIMIT 1`
+- Saldo total → `medicine_stock_summary.total_quantity` (já filtra entry_type apropriadamente na view)
+- Preço médio → `computeAverageUnitPrice(purchases)` com `quantity_bought × unit_price` (helper §0.6)
+- **NUNCA** filtrar `notes LIKE 'Dose excluída%'` ou similares — esse hack do legacy foi eliminado em PR #443
+
+**Write-side regras (Wave 2/3/5)**:
+- Mobile NUNCA faz `insert` direto em `stock` — só via RPCs
+- Mobile NUNCA cria entry de compra fake pra representar ajuste (anti-pattern morto)
+- LogForm dose (já existente) usa `consume_stock_fifo` server-side ao registrar dose
+- `useStockMutation.toggleActive` ou similar pra purchase NÃO existe (PO-1 sem delete)
+
+### 0.7 Regra de listagem do Hub (PO-9 — corrige bug em produção)
+
+`StockScreen` (Wave 4) DEVE listar medicamentos onde:
+```js
+hasActiveProtocol || totalStock > 0
+```
+
+Onde:
+- `hasActiveProtocol = protocols.some(p => p.active && isProtocolActiveOnDate(p, today))`
+- `totalStock = medicine_stock_summary.total_quantity ?? 0`
+
+**Bug atual em produção** (`getStockData` legacy em `stockService.js`):
+```js
+.eq('protocols.active', true)        // ← filtra protocols antes do join
+.filter((m) => m.protocols.some(isProtocolActiveOnDate))  // ← exclui meds sem treatment ativo
+```
+
+Cenários quebrados hoje (que Wave 4 corrige por reescrita):
+- Med cadastrado com 30cp + sem treatment criado → invisível
+- Med com treatment finalizado mas estoque sobrando → invisível
+- Med com treatment **pausado** + estoque positivo → invisível (Fase 2.5 introduziu pausa, agravou o problema)
+
+**Query refactor pra Wave 4** (substitui `getStockData`):
+```js
+// Em useStock.js ou stockService.getMedicinesWithStockOrActiveProtocol
+const { data, error } = await nativeSupabaseClient
+  .from('medicines')
+  .select(`
+    id, name, laboratory, dosage_unit, dosage_per_pill,
+    medicine_stock_summary!left ( total_quantity ),
+    protocols ( id, dosage_per_intake, time_schedule, frequency, active, start_date, end_date )
+  `)
+  .eq('user_id', userId)
+  // SEM filtro protocols.active — queremos avaliar atividade no client
+  .order('name')
+
+const today = getTodayLocal()
+return (data || []).filter((m) => {
+  const hasActiveProtocol = (m.protocols || []).some(
+    (p) => p.active && isProtocolActiveOnDate(p, today),
+  )
+  const totalStock = m.medicine_stock_summary?.total_quantity ?? 0
+  return hasActiveProtocol || totalStock > 0
+})
+```
+
+**Deprecação**: `getStockData` legacy fica preservada até Wave 4 reescrever `useStock`. Após Wave 4 mergeada, marcar `getStockData` como `@deprecated` + remover em fix-pack pós-Fase 3.
+
+### 0.8 Migration pendente pra Wave 5 — ajuste manual negativo
+
+`adjustToBalance` (modo único "Acertar saldo" — PO-6) precisa funcionar pra **delta negativo** (cenários: perda, doação, descarte, vencimento manual sem usar lote vencido). RPC atual `apply_manual_stock_adjustment` **falha explicitamente** quando `p_quantity_delta < 0` (archive §1.1 regra 6 — decisão conservadora de 2026-04-02).
+
+**Decisão Fase 3**: desbloquear via nova migration durante Wave 5.
+
+**Migration a criar** (Wave 5, antes do `StockAdjustmentScreen` ser implementado):
+- Path: `docs/migrations/YYYYMMDD_allow_negative_manual_adjustments.sql`
+- Conteúdo: ALTER FUNCTION `apply_manual_stock_adjustment` removendo check `p_quantity_delta < 0 → raise exception`
+- Comportamento novo pra delta negativo:
+  1. Validar `total_quantity` atual >= `abs(p_quantity_delta)` (não permitir saldo negativo)
+  2. Iterar lotes FIFO (`stock` com `entry_type != 'legacy_unrecoverable'` + `quantity > 0`)
+  3. Decrementar lotes (consumir FIFO igual `consume_stock_fifo`, mas SEM criar `stock_consumptions` — não é dose)
+  4. Inserir `stock_adjustments` negativo com `reason = p_reason` + `notes = p_notes`
+  5. NÃO cria `stock_consumptions` (não há `medicine_log_id`)
+- Grants + RLS conforme template CLAUDE.md (REVOKE EXECUTE FROM PUBLIC/anon, search_path='', SECURITY DEFINER)
+- Aplicação manual pelo PO (não auto-merge migration)
+
+**Reasons aceitos pra delta negativo** (alinhado com archive §4.1.1 + extensões PO-6):
+- `'perda'`
+- `'doacao'`
+- `'descarte'`
+- `'vencimento_manual'`
+- `'correcao_erro'`
+- `'outro'`
+
+Archive spec original (`exec_spec_stock_refactor.md`) tem update correspondente em §21.2 (nova seção) marcando essa mudança como pós-entrega.
 
 ### 0.6 Helpers canônicos a criar em `@dosiq/core/utils/`
 Antes do spawn de telas/cards, criar estes helpers (Wave 1 inline Opus):
@@ -143,7 +254,7 @@ Na web, o domínio de estoque é dividido em:
 | S1.5 | Tela `PurchaseFormScreen` (modes create/edit; med travado no topo — PO-3) | `apps/mobile/src/features/stock/screens/PurchaseFormScreen.jsx` | 🤖 Sonnet | ⭐⭐⭐ |
 | S1.6 | Tela `PurchaseHistoryScreen` (header resumo + PurchaseCards full + "..." → Editar) | `apps/mobile/src/features/stock/screens/PurchaseHistoryScreen.jsx` | 🤖 Sonnet | ⭐⭐ |
 | S1.7 | Componente `PurchaseMedicineSheet` (R-233 statusBarTranslucent) | `apps/mobile/src/features/stock/components/PurchaseMedicineSheet.jsx` | 🤖 Sonnet | ⭐⭐ |
-| S1.8 | Expandir `StockScreen` (chips filtro + FAB → sheet) + `StockDetailScreen` (FAB → form med travado — PO-2) | `apps/mobile/src/features/stock/screens/StockScreen.jsx`, `StockDetailScreen.jsx` | 🤖 Sonnet | ⭐⭐⭐ |
+| S1.8 | Expandir `StockScreen` (chips filtro + FAB → sheet) + `StockDetailScreen` (FAB → form med travado — PO-2) · **regra listagem expandida PO-9** (substitui `getStockData` legacy) | `apps/mobile/src/features/stock/screens/StockScreen.jsx`, `StockDetailScreen.jsx`, `apps/mobile/src/features/stock/hooks/useStock.js` | 🤖 Sonnet | ⭐⭐⭐ |
 | S1.9 | `StockStack` navigation + rotas | `apps/mobile/src/navigation/StockStack.jsx` | 🤖 Haiku | ⭐ |
 | S1.10 | Atualizar `routes.js` + `RootTabs.jsx` (StockStack) | `apps/mobile/src/navigation/routes.js`, `RootTabs.jsx` | 🤖 Haiku | ⭐ |
 | S1.11 | Testes do `stockService` mobile + helpers `@dosiq/core/utils/stock` | `apps/mobile/.../__tests__/`, `packages/core/.../__tests__/` | 🤖 Haiku | ⭐⭐ |
@@ -155,16 +266,18 @@ Na web, o domínio de estoque é dividido em:
 ### Sprint S3.2 — Indicadores + Ajuste + Extract + Migrate (Semana ~11)
 
 > **Wave plan**:
-> - **Wave 1 spawn paralelo**: S2.1 (Sonnet StockIndicators KPI grid 2×2), S2.2 (Sonnet StockAdjustment), S2.3/S2.4 (Sonnet factories)
-> - **Wave 2 spawn**: S2.5 (Sonnet parity tests factories), S2.6 (Sonnet mobile adopt) — depende Wave 1
-> - **Wave 3 inline Opus**: G2 gate check + smoke PO
-> - **Wave 4 spawn**: S2.8 (Opus web adopt), S2.9 (Haiku delete obsoletos), S2.10 (Haiku validate:agent)
-> - **Wave 5 inline Opus**: G3 gate check + merge `feat/crud-stock` → `main`
+> - **Wave 1 inline Opus**: S2.0 (migration ajuste negativo §0.8) + handoff pro PO aplicar antes de continuar
+> - **Wave 2 spawn paralelo**: S2.1 (Sonnet StockIndicators KPI grid 2×2), S2.2 (Sonnet StockAdjustment — depende migration aplicada), S2.3/S2.4 (Sonnet factories)
+> - **Wave 3 spawn**: S2.5 (Sonnet parity tests factories), S2.6 (Sonnet mobile adopt) — depende Wave 2
+> - **Wave 4 inline Opus**: G2 gate check + smoke PO
+> - **Wave 5 spawn**: S2.8 (Opus web adopt), S2.9 (Haiku delete obsoletos), S2.10 (Haiku validate:agent)
+> - **Wave 6 inline Opus**: G3 gate check + merge `feat/crud-stock` → `main`
 
 | # | Task | Arquivos | Agente | Complexidade |
 |---|------|----------|--------|-------------|
+| **S2.0** | **NOVA** — Migration desbloqueando ajuste manual negativo (§0.8) + handoff PO aplicar | `docs/migrations/YYYYMMDD_allow_negative_manual_adjustments.sql` | 👤 Opus | ⭐⭐⭐ |
 | S2.1 | Componente `StockIndicators` KPI grid 2×2 (PO-5 — direto v2, sem variant C) | `apps/mobile/src/features/stock/components/StockIndicators.jsx` | 🤖 Sonnet | ⭐⭐⭐ |
-| S2.2 | Tela `StockAdjustmentScreen` modo único "Acertar saldo" (PO-6) + DeltaPreview + motivo | `apps/mobile/src/features/stock/screens/StockAdjustmentScreen.jsx` | 🤖 Sonnet | ⭐⭐ |
+| S2.2 | Tela `StockAdjustmentScreen` modo único "Acertar saldo" (PO-6) + DeltaPreview + motivo · **depende S2.0 migration aplicada** | `apps/mobile/src/features/stock/screens/StockAdjustmentScreen.jsx` | 🤖 Sonnet | ⭐⭐ |
 | S2.3 | Criar `createStockRepository` em `@dosiq/core/repositories/` | `packages/core/src/repositories/createStockRepository.js` | 🤖 Sonnet | ⭐⭐⭐ |
 | S2.4 | Criar `createPurchaseRepository` em `@dosiq/core/repositories/` | `packages/core/src/repositories/createPurchaseRepository.js` | 🤖 Sonnet | ⭐⭐ |
 | S2.5 | Parity tests factories (espelhar pattern `createProtocolRepository.test.js`) | `packages/core/src/repositories/__tests__/` | 🤖 Sonnet | ⭐⭐ |
@@ -337,6 +450,8 @@ function StockIndicators({ medicine, stockSummary, activeProtocols, purchases })
 
 ### S2.2 — Ajuste Manual de Saldo (PO-6 modo único)
 
+**Pré-condição**: migration S2.0 (§0.8) aplicada pelo PO. Sem ela, `adjustToBalance` falha em runtime quando `newBalance < currentStock` (RPC archive original bloqueia delta negativo).
+
 ```jsx
 function StockAdjustmentScreen({ route, navigation }) {
   const { medicineId, currentStock } = route.params
@@ -361,8 +476,9 @@ function StockAdjustmentScreen({ route, navigation }) {
 }
 ```
 
-**ADJUSTMENT_REASONS** (proposta — PO confirma):
-`perda`, `doacao`, `descarte`, `vencimento`, `correcao_erro`, `outro`
+**ADJUSTMENT_REASONS** (§0.8 — alinhado com migration S2.0):
+- delta negativo: `perda`, `doacao`, `descarte`, `vencimento_manual`, `correcao_erro`, `outro`
+- delta positivo: `ajuste_manual_positivo`, `correcao_erro`, `outro` (reusa set existente archive)
 
 ---
 
@@ -457,6 +573,8 @@ packages/core/src/
 | Purchase form (create+edit) cria entrada + atualiza saldo | Demo gravada |
 | FAB ubíquo (Hub + Detail) funciona conforme PO-2/PO-3 | Smoke PO |
 | `StockIndicators` KPI grid 2×2 calcula corretamente | Smoke PO |
+| Regra listagem expandida PO-9 (`hasActiveProtocol \|\| totalStock > 0`) ativa em StockScreen — meds órfãos (sem treatment) aparecem | Smoke PO + grep `getStockData` ausente |
+| Migration S2.0 (`allow_negative_manual_adjustments`) aplicada em produção pelo PO antes de S2.2 | Confirmação PO |
 | Cache invalidation matrix documentada em `useStockMutation` (R-236) | Code review |
 | Bottom sheets com `statusBarTranslucent` (R-233) testado em Android API 24 | Smoke PO Android |
 | **Smoke PO (R-234) concluído antes de `gh pr create`** | Confirmação PO |
@@ -498,7 +616,8 @@ Brief obrigatório R-230 (6 itens) em TODO spawn. Recalibração pós-Fase 2: So
 | S1.1-S1.2 | 👤 Opus | Consolidação 2 services + validar RPCs Hermes |
 | S1.3, S1.5, S1.6, S1.7, S1.8 | 🤖 Sonnet ⭐⭐ | Componentes/hooks complexos (cache matrix, sheet R-233, form mode dual, KPI cross-domain) |
 | S1.4, S1.9, S1.10, S1.11 | 🤖 Haiku ⭐ | Tasks mecânicas (card simples, nav files, tests espelhados) |
-| S2.1, S2.2 | 🤖 Sonnet ⭐⭐ | KPI grid 2×2 + ajuste com DeltaPreview (UX complexa, mas pattern claro) |
+| S2.0 | 👤 Opus | Migration SQL crítica (desbloqueia delta negativo + audit FIFO + grants/RLS) |
+| S2.1, S2.2 | 🤖 Sonnet ⭐⭐ | KPI grid 2×2 + ajuste com DeltaPreview (UX complexa, mas pattern claro). S2.2 depende S2.0 mergeada |
 | S2.3, S2.4, S2.5 | 🤖 Sonnet ⭐⭐ | Factories — espelhar `createProtocolRepository` pattern (validado Fase 2) |
 | S2.6, S2.8 | 👤 Opus | Adopção mobile + web (mudança em arquivos sensíveis cross-feature) |
 | S2.9, S2.10 | 🤖 Haiku ⭐ | Delete obsoletos + validate:agent |
@@ -533,6 +652,15 @@ Brief obrigatório R-230 (6 itens) em TODO spawn. Recalibração pós-Fase 2: So
 ---
 
 ## Changelog
+
+### v2.1 — 2026-05-19 (alignment com archive_old/stock_refactor + bug listagem PO-9 + ajuste negativo)
+- **§0.5 adicionados PO-9 + PO-10**: regra listagem expandida (hasActiveProtocol OR totalStock>0 — corrige bug produção atual via reescrita Wave 4) + regulatory_category fora escopo v1
+- **§0.6.5 NOVO** — Alignment com archive_old/stock_refactor: cataloga modelo canônico (purchases/stock/stock_adjustments/stock_consumptions/medicine_stock_summary view + 4 RPCs + entry_type filter Phantom Stock fix). Define regras read-side (sempre purchases pra histórico, nunca filtro `notes LIKE`) e write-side (nunca insert direto stock, sempre RPC)
+- **§0.7 NOVO** — Detalha regra PO-9 com query refactor pra Wave 4 + lista cenários quebrados em produção (med órfão / treatment finalizado / treatment pausado Fase 2.5)
+- **§0.8 NOVO** — Migration pendente Wave 5: desbloqueia `apply_manual_stock_adjustment` pra delta negativo (PO-6 modo único requer; archive §1.1 regra 6 bloqueava por conservadorismo). Define comportamento novo + reasons aceitos + handoff PO aplica
+- **Sprint Breakdown S3.2** reorganizado: nova S2.0 (migration negativa Opus inline) bloqueia S2.2 (StockAdjustmentScreen) · S1.8 (StockScreen) inclui fix PO-9 substituindo getStockData legacy
+- **Quality Gates G1** + 2 critérios: regra listagem PO-9 + migration S2.0 aplicada
+- **Delegação** atualizada com S2.0 Opus
 
 ### v2 — 2026-05-18 (pós-RETRO_FASE2 + absorção mocks designer)
 - **§0 NOVO** — Cuidados aprendidos pré-Fase 3 (consolidado RETROs Fase 1+2): arquitetura compartilhada, mobile patterns, cache invalidation matrix CRÍTICA, processo SQP §§10-13, decisões PO PO-1..PO-8, helpers canônicos §0.6


### PR DESCRIPTION
## Summary

**Wave 1/5 do Sprint S3.1** (Fase 3 CRUD Estoque). PR sub-sprint → mãe `feat/crud-stock` (não direto pra main — pattern Fase 2 retro).

Foundation backend-only — sem UI nesta PR.

**S1.0 — Helpers canônicos `@dosiq/core/utils/stock.js`** (web↔mobile)
- `STOCK_STATUS` + `STOCK_THRESHOLDS` (constants)
- `resolveStockStatus(qty, dailyConsumption, nearestExpiry, today)` — precedência VENCIDO > CRITICO > BAIXO > NORMAL > ALTO
- `computeAverageUnitPrice(purchases)` — média ponderada por quantity
- `computeExpiryDays(expiry, today)` — aceita `MM/YYYY` e `YYYY-MM-DD`
- `formatBRL(value)` — Intl.NumberFormat pt-BR (canônico)
- **REUSA** `calculateDailyIntake` + `calculateDaysRemaining` (DRY + anti AP-164)
- 20 unit tests vitest

**S1.1 — stockService mobile consolidado**
- 11 métodos · `userId` param explícito · **SEM** `deletePurchase` (PO-1)
- 5 RPCs Supabase · validação Zod via `@dosiq/core`
- `getStockData` legacy preservado (compat `useStock` atual)
- `adjustToBalance` (PO-6 modo único "Acertar saldo")

**S1.2 — Smoke RPCs Hermes** postergado pra Wave 2 (precisa UI pra invocar)

**Bonus** — `vitest.critical.config.js` agora inclui `packages/core/src` tests. 530 → 789 tests no kill switch (+259). Mitiga AP-170 retroativo.

## Test plan

- [x] `rtk lint`: 0 issues
- [x] `rtk npm run validate:agent`: 789/789 green (5.06s)
- [ ] Smoke RPCs no simulador (postergado Wave 2)

## Wave plan S3.1 (PRs sub-sprint → mãe feat/crud-stock)

- [x] **W1** (este PR) — helpers + stockService
- [ ] **W2** spawn paralelo — useStockMutation (R-236) · PurchaseCard · PurchaseMedicineSheet (R-233) · routes/stack
- [ ] **W3** spawn — PurchaseForm (dual mode · med locked PO-3/4) · PurchaseHistory
- [ ] **W4** spawn — StockScreen + StockDetailScreen (FAB ubíquo PO-2 · KPI grid PO-5)
- [ ] **W5** Opus inline — StockAdjustment (PO-6) + smoke local + smoke PO + PR-mãe → main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AI Review Response

| Suggestion | Priority | Decision | Reason |
|------------|----------|----------|--------|
| `adjustToBalance`: `this.*` quebra em destructuring → usar `stockService.*` | Medium | Applied | Commit f9fba2ba |
| `adjustToBalance`: padronizar return decremento pra `{ delta, before, after }` | Medium | Applied | Commit f9fba2ba — return uniforme nos 3 branches |
