### PR TITLE
feat(stock): Wave 2 S3.1 — useStockMutation + PurchaseCard + Sheet + nav

### DIFF
--- a/apps/mobile/src/features/stock/components/PurchaseCard.jsx
+++ b/apps/mobile/src/features/stock/components/PurchaseCard.jsx
@@ -1,0 +1,312 @@
+// PurchaseCard.jsx — card de exibição de uma compra (histórico de estoque)
+// Parte do fluxo S1.4 Wave 2 — visão detalhada de cada compra com barra de consumo
+
+import { View, Text, StyleSheet, Pressable } from 'react-native'
+import { colors, spacing, borderRadius } from '@shared/styles/tokens'
+import { formatDatePtBR, computeExpiryDays, formatBRL, formatDoseUnit } from '@dosiq/core'
+
+/**
+ * @param {{
+ *   purchase: {
+ *     id: string,
+ *     medicine_id: string,
+ *     quantity_bought: number,
+ *     unit_price: number,
+ *     purchase_date: string,        // 'YYYY-MM-DD'
+ *     expiration_date: string|null, // 'YYYY-MM-DD' ou null
+ *     pharmacy: string|null,
+ *     laboratory: string|null,
+ *     notes: string|null,
+ *   },
+ *   remaining: number,              // saldo restante da entry do stock
+ *   isLatest?: boolean,             // true se é a mais recente (badge "ÚLTIMA")
+ *   onPress?: () => void            // tap leva pra editar compra
+ * }} props
+ */
+export default function PurchaseCard({ purchase, remaining = 0, isLatest = false, onPress }) {
+  // States (R-010 — ordem critica antes de derivações)
+  // Nenhum hook complexo — apenas useMemo se houver heavy computation
+
+  // Derivações
+  const consumed = purchase.quantity_bought - remaining
+  const percentConsumed = purchase.quantity_bought > 0 ? (consumed / purchase.quantity_bought) * 100 : 0
+  const isInUse = remaining > 0
+  const expiryDays = purchase.expiration_date ? computeExpiryDays(purchase.expiration_date) : null
+  const purchaseDateFormatted = formatDatePtBR(purchase.purchase_date)
+  const totalCost = purchase.unit_price * purchase.quantity_bought
+  const expiryStatusColor = expiryDays === null
+    ? colors.neutral[400] // sem data
+    : expiryDays < 30
+    ? colors.status.error    // <30 dias — vermelho
+    : expiryDays < 90
+    ? colors.status.warning  // <90 dias — amarelo
+    : colors.text.secondary  // >=90 dias — neutro
+
+  const card = (
+    <View
+      style={[
+        styles.card,
+        isLatest && styles.cardLatest,
+      ]}
+    >
+      {/* Header: data + badge de status */}
+      <View style={styles.header}>
+        <View style={styles.headerLeft}>
+          <Text style={styles.purchaseDate}>{purchaseDateFormatted}</Text>
+          {isLatest && (
+            <View style={styles.badgeLatest}>
+              <Text style={styles.badgeLatestText}>ÚLTIMA</Text>
+            </View>
+          )}
+        </View>
+      </View>
+
+      {/* Quantidades: "30 un. compradas · 16 restantes" */}
+      <View style={styles.quantityRow}>
+        <Text style={styles.quantityText}>
+          {purchase.quantity_bought} {formatDoseUnit(purchase.quantity_bought, 'un')} compradas
+        </Text>
+        <Text style={styles.quantityDot}> · </Text>
+        <Text style={[styles.quantityText, { color: isInUse ? colors.status.success : colors.text.muted }]}>
+          {remaining} restantes
+        </Text>
+      </View>
+
+      {/* Barra de consumo (se em uso) */}
+      {isInUse && (
+        <View style={styles.progressSection}>
+          <View style={styles.progressLabelRow}>
+            <Text style={styles.progressLabel}>
+              Consumida {consumed} / {purchase.quantity_bought}
+            </Text>
+          </View>
+          <View style={styles.progressBar}>
+            <View
+              style={[
+                styles.progressFill,
+                { width: `${percentConsumed}%` },
+              ]}
+            />
+          </View>
+        </View>
+      )}
+
+      {/* Custo: "R$ 0,89 por un. · Total R$ 26,70" */}
+      <View style={styles.costRow}>
+        <Text style={styles.costLabel}>Custo: </Text>
+        <Text style={styles.costValue}>
+          {formatBRL(purchase.unit_price)} por un.
+        </Text>
+        <Text style={styles.costDot}> · </Text>
+        <Text style={styles.costValue}>Total {formatBRL(totalCost)}</Text>
+      </View>
+
+      {/* Farmácia + Laboratório (se presentes) */}
+      {(purchase.pharmacy || purchase.laboratory) && (
+        <View style={styles.bottomInfo}>
+          {purchase.pharmacy && (
+            <Text style={styles.bottomInfoText}>{purchase.pharmacy}</Text>
+          )}
+          {purchase.pharmacy && purchase.laboratory && (
+            <Text style={styles.bottomInfoDot}> · </Text>
+          )}
+          {purchase.laboratory && (
+            <Text style={styles.bottomInfoText}>{purchase.laboratory}</Text>
+          )}
+        </View>
+      )}
+
+      {/* Validade (se expiration_date) */}
+      {purchase.expiration_date && (
+        <View style={styles.expiryChip}>
+          <Text style={[styles.expiryText, { color: expiryStatusColor }]}>
+            {expiryDays === null || expiryDays < 0
+              ? 'Vencido'
+              : `Vence em ${expiryDays} dias`}
+          </Text>
+        </View>
+      )}
+    </View>
+  )
+
+  if (!onPress) return card
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => pressed && styles.pressed}
+      accessibilityRole="button"
+      accessibilityLabel={`Editar compra de ${purchase.quantity_bought} unidades do ${purchaseDateFormatted}`}
+    >
+      {card}
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  // Card base com borda sutil
+  card: {
+    backgroundColor: colors.bg.card,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colors.border.light,
+    padding: spacing[3],
+    gap: spacing[2],
+  },
+
+  // Destaque para última compra
+  cardLatest: {
+    borderColor: colors.primary[200],
+    borderWidth: 1.5,
+  },
+
+  // Header com data + badge
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+
+  headerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    flex: 1,
+    flexWrap: 'wrap',
+  },
+
+  purchaseDate: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.text.primary,
+  },
+
+  // Badge "ÚLTIMA"
+  badgeLatest: {
+    backgroundColor: colors.primary[50],
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    borderRadius: 4,
+    borderWidth: 0.5,
+    borderColor: colors.primary[200],
+  },
+
+  badgeLatestText: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: colors.primary[700],
+    letterSpacing: 0.5,
+  },
+
+  // Linha de quantidades
+  quantityRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  },
+
+  quantityText: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: colors.text.secondary,
+  },
+
+  quantityDot: {
+    fontSize: 13,
+    color: colors.text.muted,
+    marginHorizontal: 2,
+  },
+
+  // Seção de barra de consumo
+  progressSection: {
+    gap: spacing[1],
+  },
+
+  progressLabelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+
+  progressLabel: {
+    fontSize: 12,
+    fontWeight: '500',
+    color: colors.text.secondary,
+  },
+
+  progressBar: {
+    height: 6,
+    backgroundColor: colors.neutral[200],
+    borderRadius: 3,
+    overflow: 'hidden',
+  },
+
+  progressFill: {
+    height: '100%',
+    backgroundColor: colors.primary[500],
+    borderRadius: 3,
+  },
+
+  // Linha de custo
+  costRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    paddingTop: spacing[1],
+    borderTopWidth: 1,
+    borderTopColor: colors.border.light,
+  },
+
+  costLabel: {
+    fontSize: 12,
+    fontWeight: '500',
+    color: colors.text.secondary,
+  },
+
+  costValue: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.text.primary,
+  },
+
+  costDot: {
+    fontSize: 12,
+    color: colors.text.muted,
+    marginHorizontal: 2,
+  },
+
+  // Informações inferiores (farmácia, laboratório)
+  bottomInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  },
+
+  bottomInfoText: {
+    fontSize: 12,
+    fontWeight: '400',
+    color: colors.text.muted,
+  },
+
+  bottomInfoDot: {
+    fontSize: 12,
+    color: colors.text.muted,
+    marginHorizontal: 2,
+  },
+
+  // Chip de validade
+  expiryChip: {
+    marginTop: spacing[1],
+  },
+
+  expiryText: {
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 0.3,
+  },
+
+  // Feedback de tap
+  pressed: {
+    opacity: 0.7,
+  },
+})

--- a/apps/mobile/src/features/stock/components/PurchaseMedicineSheet.jsx
+++ b/apps/mobile/src/features/stock/components/PurchaseMedicineSheet.jsx
@@ -1,0 +1,395 @@
+// PurchaseMedicineSheet.jsx — bottom sheet para selecionar medicamento ao registrar compra.
+// Sprint P.1 S1.7. Especificação R-230.
+//
+// Contrato: visible + onClose + onSelect(medicineId, medicineName).
+// Tap em row → onSelect(id, name) + fecha sheet. Parent navega para o form de compra.
+// R-233: statusBarTranslucent + spacer Android + SafeAreaView edges=['bottom'].
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  ActivityIndicator,
+  FlatList,
+  Modal,
+  Platform,
+  Pressable,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { Pill, Search, X } from 'lucide-react-native'
+import { useMedicines } from '../../medications/hooks/useMedicines'
+import { selectionTap } from '@shared/utils/haptics'
+import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
+
+// Cor literal extraída para evitar react-native/no-color-literals em StyleSheet
+const SHADOW_COLOR = '#000'
+
+// NFD normalize para busca case-/diacríticos-insensível (AP-157 — pré-computado).
+function normalize(s) {
+  return String(s || '')
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+}
+
+// MedicineRow extraído como componente próprio para manter PurchaseMedicineSheet
+// dentro do limite max-lines-per-function.
+function MedicineRow({ item, onPress }) {
+  const dosageLabel = item.dosage_per_pill
+    ? `${item.dosage_per_pill}${item.dosage_unit || ''}`
+    : null
+
+  return (
+    <Pressable
+      style={({ pressed }) => [styles.item, pressed && styles.itemPressed]}
+      onPress={() => onPress(item)}
+      accessibilityRole="button"
+      accessibilityLabel={`Selecionar ${item.name} para registrar compra`}
+    >
+      <View style={styles.itemIcon}>
+        <Pill size={20} color={colors.primary[500]} strokeWidth={2} />
+      </View>
+      <View style={styles.itemText}>
+        <View style={styles.itemHeader}>
+          <Text style={styles.itemName} numberOfLines={1}>
+            {item.name}
+          </Text>
+          {dosageLabel ? (
+            <View style={styles.dosagePill}>
+              <Text style={styles.dosagePillText}>{dosageLabel}</Text>
+            </View>
+          ) : null}
+        </View>
+        <Text style={styles.itemSub} numberOfLines={1}>
+          Saldo: {item.current_stock ?? 0} un.
+        </Text>
+      </View>
+    </Pressable>
+  )
+}
+
+export default function PurchaseMedicineSheet({ visible, onClose, onSelect }) {
+  // States (R-010 — States → Memos → Effects → Handlers)
+  const [query, setQuery] = useState('')
+  const { data, loading, error, refresh } = useMedicines()
+
+  // Memos
+  const list = useMemo(() => (Array.isArray(data) ? data : []), [data])
+
+  // Pré-computa haystack normalizado para evitar normalize por keystroke (AP-157)
+  const indexed = useMemo(
+    () =>
+      list.map((m) => ({
+        item: m,
+        haystack: normalize(`${m.name || ''} ${m.active_ingredient || ''}`),
+      })),
+    [list]
+  )
+
+  const trimmed = query.trim()
+  const filtered = useMemo(() => {
+    if (!trimmed) return indexed.map((x) => x.item)
+    const q = normalize(trimmed)
+    return indexed.filter((x) => x.haystack.includes(q)).map((x) => x.item)
+  }, [indexed, trimmed])
+
+  // Ordena: estoque baixo primeiro (menor current_stock no topo) — alinha com mock do designer
+  const sorted = useMemo(
+    () =>
+      [...filtered].sort(
+        (a, b) => (a.current_stock ?? Infinity) - (b.current_stock ?? Infinity)
+      ),
+    [filtered]
+  )
+
+  // Effects — refresh lista toda vez que sheet abre (captura med recém-criado)
+  useEffect(() => {
+    if (visible) refresh?.()
+  }, [visible, refresh])
+
+  // Handlers
+  function handleClose() {
+    setQuery('')
+    onClose?.()
+  }
+
+  function handleSelect(item) {
+    selectionTap()
+    setQuery('')
+    onSelect?.(item.id, item.name)
+    onClose?.()
+  }
+
+  return (
+    <Modal
+      visible={!!visible}
+      transparent
+      animationType="slide"
+      onRequestClose={handleClose}
+      // Android: statusBarTranslucent faz o Modal cobrir o status bar e ignorar
+      // o bottom tabs do parent navigator (sem isso o sheet só ocupa a área do
+      // screen atual, truncando em Android 7+ / API 24 — AP-165 / R-233).
+      statusBarTranslucent
+    >
+      <View style={styles.root}>
+        {/* Spacer Android: empurra o sheet abaixo da status bar translúcida (R-233) */}
+        {Platform.OS === 'android' ? (
+          <View style={{ height: StatusBar.currentHeight ?? 0 }} />
+        ) : null}
+
+        <Pressable
+          style={styles.backdrop}
+          onPress={handleClose}
+          accessibilityLabel="Fechar"
+        />
+
+        <SafeAreaView edges={['bottom']} style={styles.sheet}>
+          {/* Handle visual */}
+          <View style={styles.handle} />
+
+          {/* Header */}
+          <View style={styles.header}>
+            <Text style={styles.title}>Para qual medicamento?</Text>
+            <Pressable
+              onPress={handleClose}
+              hitSlop={8}
+              style={styles.closeBtn}
+              accessibilityRole="button"
+              accessibilityLabel="Fechar"
+            >
+              <X size={22} color={colors.text.secondary} strokeWidth={2} />
+            </Pressable>
+          </View>
+
+          {/* Campo de busca */}
+          <View style={styles.searchBox}>
+            <Search size={18} color={colors.text.muted} strokeWidth={2} />
+            <TextInput
+              style={styles.searchInput}
+              value={query}
+              onChangeText={setQuery}
+              placeholder="Buscar medicamento…"
+              placeholderTextColor={colors.text.muted}
+              autoCorrect={false}
+              autoCapitalize="none"
+              returnKeyType="search"
+              accessibilityLabel="Buscar medicamento"
+              maxLength={100}
+            />
+            {query ? (
+              <Pressable
+                onPress={() => setQuery('')}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel="Limpar busca"
+              >
+                <X size={18} color={colors.text.muted} strokeWidth={2} />
+              </Pressable>
+            ) : null}
+          </View>
+
+          {/* Rótulo da lista */}
+          {!loading && !error && list.length > 0 ? (
+            <Text style={styles.listLabel}>
+              {trimmed
+                ? `${sorted.length} de ${list.length} medicamentos`
+                : 'Sugestões · estoque baixo primeiro'}
+            </Text>
+          ) : null}
+
+          {/* Loading */}
+          {loading ? (
+            <View style={styles.centerWrap}>
+              <ActivityIndicator color={colors.primary[500]} />
+              <Text style={styles.centerText}>Carregando medicamentos…</Text>
+            </View>
+          ) : error ? (
+            /* Erro de carregamento */
+            <View style={styles.centerWrap}>
+              <Text style={styles.errorText}>{error}</Text>
+            </View>
+          ) : (
+            /* Lista */
+            <FlatList
+              data={sorted}
+              keyExtractor={(item) => item.id}
+              renderItem={({ item }) => (
+                <MedicineRow item={item} onPress={handleSelect} />
+              )}
+              keyboardShouldPersistTaps="handled"
+              keyboardDismissMode="on-drag"
+              contentContainerStyle={styles.listContent}
+              ListEmptyComponent={
+                <View style={styles.centerWrap}>
+                  {list.length === 0 ? (
+                    <Text style={styles.emptyText}>
+                      Cadastre primeiro um medicamento para registrar uma compra.
+                    </Text>
+                  ) : (
+                    <Text style={styles.emptyText}>
+                      Nenhum medicamento encontrado para "{trimmed}".
+                    </Text>
+                  )}
+                </View>
+              }
+            />
+          )}
+        </SafeAreaView>
+      </View>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: colors.bg.overlay,
+  },
+  sheet: {
+    backgroundColor: colors.bg.card,
+    borderTopLeftRadius: borderRadius.xl,
+    borderTopRightRadius: borderRadius.xl,
+    padding: spacing[5],
+    maxHeight: '70%',
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 40,
+    height: 4,
+    borderRadius: borderRadius.full,
+    backgroundColor: colors.neutral[300],
+    marginBottom: spacing[4],
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing[4],
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.text.primary,
+    fontFamily: typography.fontFamily.bold,
+    flex: 1,
+  },
+  closeBtn: {
+    marginLeft: spacing[2],
+  },
+  searchBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    height: 44,
+    paddingHorizontal: spacing[3],
+    backgroundColor: colors.neutral[100],
+    borderRadius: borderRadius.full,
+    marginBottom: spacing[1],
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 15,
+    color: colors.text.primary,
+    fontWeight: '500',
+    padding: 0,
+  },
+  listLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: colors.text.muted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+    paddingVertical: spacing[3],
+  },
+  listContent: {
+    paddingBottom: spacing[4],
+    gap: spacing[2],
+  },
+  centerWrap: {
+    paddingVertical: spacing[8],
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  centerText: {
+    fontSize: 13,
+    color: colors.text.secondary,
+    marginTop: spacing[2],
+  },
+  errorText: {
+    fontSize: 13,
+    color: colors.status.error,
+    textAlign: 'center',
+  },
+  emptyText: {
+    fontSize: 13,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    lineHeight: 20,
+    paddingHorizontal: spacing[4],
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    backgroundColor: colors.bg.card,
+    borderRadius: borderRadius.lg,
+    padding: spacing[3],
+    // Sombra leve conforme mock do designer
+    shadowColor: SHADOW_COLOR,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.06,
+    shadowRadius: 3,
+    elevation: 2,
+  },
+  itemPressed: {
+    opacity: 0.7,
+  },
+  itemIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 10,
+    backgroundColor: colors.primary[50],
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  itemText: {
+    flex: 1,
+    minWidth: 0,
+    gap: 2,
+  },
+  itemHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  itemName: {
+    flexShrink: 1,
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.text.primary,
+    fontFamily: typography.fontFamily.bold,
+  },
+  dosagePill: {
+    backgroundColor: colors.neutral[100],
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    borderRadius: 4,
+  },
+  dosagePillText: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: colors.neutral[700],
+  },
+  itemSub: {
+    fontSize: 13,
+    color: colors.text.secondary,
+  },
+})

--- a/apps/mobile/src/features/stock/hooks/useStockMutation.js
+++ b/apps/mobile/src/features/stock/hooks/useStockMutation.js
@@ -1,0 +1,141 @@
+// useStockMutation.js — wrappers createPurchase/updatePurchase/adjustBalance sobre useMutation
+//
+// Encapsula:
+// - Toast feedback (success/error em PT-BR)
+// - Cache invalidation (matrix R-236 — ver bloco por método abaixo)
+// - Navegação opcional pós-sucesso (goBack)
+//
+// Uso:
+//   const { createPurchase, updatePurchase, adjustBalance, isLoading } = useStockMutation()
+//   createPurchase(input, { goBack: true })
+//
+// ────────────────────────────────────────────────────────────────────────────
+// CACHE INVALIDATION MATRIX (R-236) — todo mutation deve listar TODOS
+// snapshots afetados. Esquecer um cache adjacente = bug latente (D11 Fase 2.5).
+// ────────────────────────────────────────────────────────────────────────────
+
+import { useCallback } from 'react'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { useNavigation } from '@react-navigation/native'
+import { useMutation } from '@shared/hooks/useMutation'
+import { useToast } from '@shared/components/feedback/Toast'
+import { useAuth } from '@platform/auth/hooks/useAuth'
+import { stockService } from '../services/stockService'
+
+const STOCK_CACHE_KEY = '@dosiq/stock-snapshot'
+const PURCHASES_CACHE_KEY = '@dosiq/purchases-snapshot'
+const TREATMENTS_CACHE_KEY = '@dosiq/treatments-snapshot'
+const TODAY_CACHE_KEY = '@dosiq/today-snapshot'
+
+export function useStockMutation() {
+  // States (R-010 — States → Memos → Effects → Handlers)
+  const navigation = useNavigation()
+  const { show } = useToast()
+  const { user } = useAuth()
+
+  /**
+   * createPurchase — registra compra + atualiza saldo via RPC.
+   * Caches invalidados:
+   *   - @dosiq/stock-snapshot (saldo, status, listagem hub)
+   *   - @dosiq/purchases-snapshot (histórico do medicamento)
+   *   - @dosiq/treatments-snapshot (daysRemaining recalculado — cross-domain)
+   *   - @dosiq/today-snapshot (dashboard pode mostrar status atualizado)
+   */
+  const mutationCreate = useMutation({
+    invalidateKeys: [
+      STOCK_CACHE_KEY,
+      PURCHASES_CACHE_KEY,
+      TREATMENTS_CACHE_KEY,
+      TODAY_CACHE_KEY,
+    ],
+    onSuccess: () => show('Compra registrada', { variant: 'success' }),
+    onError: (err) => show(err?.message ?? 'Erro ao registrar compra', { variant: 'error' }),
+  })
+
+  /**
+   * updatePurchase — edita compra existente (quantidade, preço, datas, etc).
+   * Caches invalidados:
+   *   - @dosiq/stock-snapshot (quantidade editada afeta saldo/status)
+   *   - @dosiq/purchases-snapshot (histórico precisa refletir edição)
+   *   - @dosiq/treatments-snapshot (daysRemaining recalculado — cross-domain)
+   *   - @dosiq/today-snapshot (dashboard pode mostrar status atualizado)
+   */
+  const mutationUpdate = useMutation({
+    invalidateKeys: [
+      STOCK_CACHE_KEY,
+      PURCHASES_CACHE_KEY,
+      TREATMENTS_CACHE_KEY,
+      TODAY_CACHE_KEY,
+    ],
+    onSuccess: () => show('Compra atualizada', { variant: 'success' }),
+    onError: (err) => show(err?.message ?? 'Erro ao atualizar compra', { variant: 'error' }),
+  })
+
+  const createPurchase = useCallback(
+    async (input, { goBack = false } = {}) => {
+      const result = await mutationCreate.mutate(() =>
+        stockService.createPurchase(input, user.id),
+      )
+      if (result && goBack) navigation.goBack()
+      return result
+    },
+    [mutationCreate, navigation, user],
+  )
+
+  const updatePurchase = useCallback(
+    async (id, input, { goBack = false } = {}) => {
+      const result = await mutationUpdate.mutate(() =>
+        stockService.updatePurchase(id, input, user.id),
+      )
+      if (result && goBack) navigation.goBack()
+      return result
+    },
+    [mutationUpdate, navigation, user],
+  )
+
+  /**
+   * adjustBalance — acerta saldo para um valor desejado (PO-6).
+   * Caches invalidados:
+   *   - @dosiq/stock-snapshot (saldo, status, listagem hub)
+   *   - @dosiq/treatments-snapshot (daysRemaining recalculado — cross-domain)
+   *   - @dosiq/today-snapshot (dashboard pode mostrar status atualizado)
+   *
+   * NÃO invalida @dosiq/purchases-snapshot — ajuste de saldo não cria/edita
+   * registro de compra; é operação de correção independente do histórico.
+   *
+   * Não usa wrapper useMutation pois tem fluxo de retorno custom (delta, before, after)
+   * e validações internas no service (adjustToBalance calcula delta → increase/decrease).
+   */
+  const adjustBalance = useCallback(
+    async (medicineId, newBalance, reason, notes) => {
+      try {
+        const result = await stockService.adjustToBalance(
+          medicineId,
+          newBalance,
+          reason,
+          notes,
+          user.id,
+        )
+        // multiRemove = 1 chamada à ponte nativa (vs N concorrentes) — atômico.
+        await AsyncStorage.multiRemove([
+          STOCK_CACHE_KEY,
+          TREATMENTS_CACHE_KEY,
+          TODAY_CACHE_KEY,
+        ]).catch(() => {})
+        show('Saldo ajustado', { variant: 'success' })
+        return result
+      } catch (err) {
+        show(err?.message ?? 'Erro ao ajustar saldo', { variant: 'error' })
+        throw err
+      }
+    },
+    [show, user],
+  )
+
+  return {
+    createPurchase,
+    updatePurchase,
+    adjustBalance,
+    isLoading: mutationCreate.isLoading || mutationUpdate.isLoading,
+  }
+}

--- a/apps/mobile/src/features/stock/hooks/useStockMutation.js
+++ b/apps/mobile/src/features/stock/hooks/useStockMutation.js
@@ -73,8 +73,11 @@ export function useStockMutation() {
 
   const createPurchase = useCallback(
     async (input, { goBack = false } = {}) => {
+      // Guard early: hook pode renderizar com auth ainda carregando.
+      // Optional chaining no service call defende contra user null adicional.
+      if (!user?.id) throw new Error('Usuário não autenticado')
       const result = await mutationCreate.mutate(() =>
-        stockService.createPurchase(input, user.id),
+        stockService.createPurchase(input, user?.id),
       )
       if (result && goBack) navigation.goBack()
       return result
@@ -84,8 +87,9 @@ export function useStockMutation() {
 
   const updatePurchase = useCallback(
     async (id, input, { goBack = false } = {}) => {
+      if (!user?.id) throw new Error('Usuário não autenticado')
       const result = await mutationUpdate.mutate(() =>
-        stockService.updatePurchase(id, input, user.id),
+        stockService.updatePurchase(id, input, user?.id),
       )
       if (result && goBack) navigation.goBack()
       return result
@@ -108,20 +112,24 @@ export function useStockMutation() {
    */
   const adjustBalance = useCallback(
     async (medicineId, newBalance, reason, notes) => {
+      if (!user?.id) throw new Error('Usuário não autenticado')
       try {
         const result = await stockService.adjustToBalance(
           medicineId,
           newBalance,
           reason,
           notes,
-          user.id,
+          user?.id,
         )
         // multiRemove = 1 chamada à ponte nativa (vs N concorrentes) — atômico.
+        // Log falha em __DEV__ pra diagnóstico (cache stale survives next refresh).
         await AsyncStorage.multiRemove([
           STOCK_CACHE_KEY,
           TREATMENTS_CACHE_KEY,
           TODAY_CACHE_KEY,
-        ]).catch(() => {})
+        ]).catch((err) => {
+          if (__DEV__) console.warn('[useStockMutation] multiRemove failed:', err)
+        })
         show('Saldo ajustado', { variant: 'success' })
         return result
       } catch (err) {

--- a/apps/mobile/src/navigation/RootTabs.jsx
+++ b/apps/mobile/src/navigation/RootTabs.jsx
@@ -11,7 +11,7 @@ import { Calendar, Pill, Package, User } from 'lucide-react-native'
 import { ROUTES } from './routes'
 import TodayScreen from '../features/dashboard/screens/TodayScreen'
 import TreatmentsStack from './TreatmentsStack'
-import StockScreen from '../features/stock/screens/StockScreen'
+import StockStack from './StockStack'
 import ProfileStack from './ProfileStack'
 import { colors } from '../shared/styles/tokens'
 
@@ -82,8 +82,21 @@ export default function RootTabs() {
       />
       <Tab.Screen
         name={ROUTES.STOCK}
-        component={StockScreen}
+        component={StockStack}
         options={{ title: 'Estoque' }}
+        listeners={({ navigation, route }) => ({
+          tabPress: (e) => {
+            // Re-tap na tab ativa enquanto em sub-tela → volta para a raiz do stack.
+            // Necessário em createStackNavigator (JS) — native-stack faria por padrão.
+            const isFocused = navigation.isFocused()
+            const tabState = route.state
+            const isOnSubScreen = tabState && tabState.index > 0
+            if (isFocused && isOnSubScreen) {
+              e.preventDefault()
+              navigation.navigate(ROUTES.STOCK, { screen: ROUTES.STOCK_MAIN })
+            }
+          },
+        })}
       />
       <Tab.Screen
         name={ROUTES.PROFILE}

--- a/apps/mobile/src/navigation/StockStack.jsx
+++ b/apps/mobile/src/navigation/StockStack.jsx
@@ -1,0 +1,20 @@
+// StockStack.jsx — stack aninhado dentro da tab Estoque
+// Fase 3: inclui StockScreen como raiz (STOCK_MAIN)
+// Sub-telas (StockDetail, PurchaseForm, PurchaseHistory, StockAdjustment) adicionadas nas Waves 3/4/5
+//
+// ADR-036: usa `@react-navigation/stack` (JS) em vez de native-stack
+// — evita crash em Android API 24 (rn-screens IndexOutOfBoundsException)
+
+import { createStackNavigator } from '@react-navigation/stack'
+import { ROUTES } from './routes'
+import StockScreen from '../features/stock/screens/StockScreen'
+
+const Stack = createStackNavigator()
+
+export default function StockStack() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name={ROUTES.STOCK_MAIN} component={StockScreen} />
+    </Stack.Navigator>
+  )
+}

--- a/apps/mobile/src/navigation/routes.js
+++ b/apps/mobile/src/navigation/routes.js
@@ -40,6 +40,14 @@ export const ROUTES = {
   MEDICINE_EDIT: 'MedicineEdit',
   MEDICINE_DETAIL: 'MedicineDetail',
 
+  // Sub-rotas de Estoque (Fase 3)
+  STOCK_MAIN: 'StockMain',                 // renomeada de STOCK pra hub
+  STOCK_DETAIL: 'StockDetail',
+  PURCHASE_FORM: 'PurchaseForm',           // mode prop: 'create' | 'edit'
+  PURCHASE_HISTORY: 'PurchaseHistory',
+  STOCK_ADJUSTMENT: 'StockAdjustment',
+  // ❌ PURCHASE_DELETE removido (PO-1 — Fase 3 não tem exclusão de compra)
+
   // Dev-only (apenas __DEV__)
   MEDICINE_DEMO: 'MedicineDemo',
   TREATMENT_PRIMITIVES_DEMO: 'TreatmentPrimitivesDemo',


### PR DESCRIPTION
## Summary

**Wave 2/5 do Sprint S3.1** (Fase 3 CRUD Estoque). PR sub-sprint → mãe \`feat/crud-stock\`.

4 spawns paralelos cavecrew (2 Sonnet + 2 Sonnet pra escopos mais complexos):

### S1.3 — useStockMutation (Sonnet) · cache invalidation matrix R-236
- API: \`createPurchase / updatePurchase / adjustBalance / isLoading\`
- Matrix completa documentada JSDoc:
  - \`createPurchase + updatePurchase\` invalidam **stock + purchases + treatments + today** (cross-domain — daysRemaining recalcula)
  - \`adjustBalance\` invalida **stock + treatments + today** (sem purchases pq ajuste não cria/edita compra)
- \`userId\` via \`useAuth()\` (padrão apps/mobile)

### S1.4 — PurchaseCard (Haiku-style mecânico — Sonnet executou)
- Props: \`purchase + remaining + isLatest + onPress\`
- Barra de consumo + custo unit/total (\`formatBRL\` canônico) + chip validade dinâmico (red <30d / yellow <90d / neutro via \`computeExpiryDays\`)
- Tokens canônicos · ADR-023 + ADR-028 + ADR-046

### S1.7 — PurchaseMedicineSheet (Sonnet) · R-233 obrigatório
- Modal bottom sheet listando medicamentos do user
- \`statusBarTranslucent\` + spacer \`StatusBar.currentHeight\` + \`SafeAreaView edges=['bottom']\` (R-233 — anti AP-165 Android API 24)
- Header + busca + ordem por estoque baixo + loading/empty/backdrop tap

### S1.9 + S1.10 — Navigation (Sonnet — 3 arquivos, cap=4)
- \`StockStack.jsx\` NOVO — \`createStackNavigator\` JS (ADR-036 evita crash Android API 24)
- \`routes.js\` +5 rotas: \`STOCK_MAIN, STOCK_DETAIL, PURCHASE_FORM, PURCHASE_HISTORY, STOCK_ADJUSTMENT\` · **SEM** \`PURCHASE_DELETE\` (PO-1)
- \`RootTabs.jsx\` troca StockScreen por StockStack + listener tabPress (re-tap volta pra raiz, espelha pattern TREATMENTS)

## Test plan

- [x] \`rtk lint\`: 0 errors (1 complexity warning baseline PurchaseCard — não bloqueia)
- [x] \`rtk npm run validate:agent\`: 789/789 green
- [ ] Smoke local: Wave 2 não tem UI screens consumindo ainda (Wave 3+4 instalam). Smoke acumula pra fim do Sprint S3.1.

## Wave plan S3.1

- [x] **W1** mergeada — helpers + stockService (#574)
- [x] **W2** (este PR) — useStockMutation + PurchaseCard + PurchaseMedicineSheet + nav
- [ ] **W3** spawn — PurchaseFormScreen (mode dual create/edit · med locked PO-3/4) + PurchaseHistoryScreen
- [ ] **W4** spawn — StockScreen + StockDetailScreen (FAB ubíquo PO-2 · KPI grid PO-5 · fix listagem PO-9)
- [ ] **W5** Opus inline — migration S2.0 + StockAdjustment (PO-6) + smoke local + smoke PO + PR-mãe → main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AI Review Response

| Suggestion | Priority | Decision | Reason |
|------------|----------|----------|--------|
| useStockMutation:77 createPurchase `user.id` → `user?.id` | High | Applied | Commit e7b6f5d0 — + guard early `if (!user?.id) throw` |
| useStockMutation:88 updatePurchase `user.id` → `user?.id` | High | Applied | Commit e7b6f5d0 |
| useStockMutation:117 adjustBalance `user.id` → `user?.id` | High | Applied | Commit e7b6f5d0 |
| useStockMutation:124 log multiRemove failure em `__DEV__` | Medium | Applied | Commit e7b6f5d0 — console.warn pra dev visibility, mantém non-blocking |
