### PR TITLE
feat(stock): Wave 4 S3.1 — hub Estoque (PO-9) + Detalhe + Histórico + FAB

### DIFF
--- a/apps/mobile/src/features/stock/components/PurchaseCard.jsx
+++ b/apps/mobile/src/features/stock/components/PurchaseCard.jsx
@@ -42,6 +42,16 @@ export default function PurchaseCard({ purchase, remaining = 0, isLatest = false
     ? colors.status.warning  // <90 dias — amarelo
     : colors.text.secondary  // >=90 dias — neutro
 
+  // Contagem de dias só ajuda para validade próxima (<=60d). Para datas longas,
+  // "vence em 680 dias" não é projetável — mostra a data formatada.
+  const expiryLabel = !purchase.expiration_date
+    ? null
+    : expiryDays === null || expiryDays < 0
+    ? 'Vencido'
+    : expiryDays <= 60
+    ? `Vence em ${expiryDays} ${expiryDays === 1 ? 'dia' : 'dias'}`
+    : `Vence em ${formatDateShortPtBR(purchase.expiration_date)}`
+
   const card = (
     <View
       style={[
@@ -104,12 +114,10 @@ export default function PurchaseCard({ purchase, remaining = 0, isLatest = false
       )}
 
       {/* Validade (se expiration_date) */}
-      {purchase.expiration_date && (
+      {expiryLabel && (
         <View style={styles.expiryChip}>
           <Text style={[styles.expiryText, { color: expiryStatusColor }]}>
-            {expiryDays === null || expiryDays < 0
-              ? 'Vencido'
-              : `Vence em ${expiryDays} dias`}
+            {expiryLabel}
           </Text>
         </View>
       )}

--- a/apps/mobile/src/features/stock/components/PurchaseMedicineSheet.jsx
+++ b/apps/mobile/src/features/stock/components/PurchaseMedicineSheet.jsx
@@ -21,6 +21,8 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { Pill, Search, X } from 'lucide-react-native'
 import { useMedicines } from '../../medications/hooks/useMedicines'
+import { useAuth } from '@platform/auth/hooks/useAuth'
+import { stockService } from '@stock/services/stockService'
 import { selectionTap } from '@shared/utils/haptics'
 import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
 
@@ -74,10 +76,16 @@ function MedicineRow({ item, onPress }) {
 export default function PurchaseMedicineSheet({ visible, onClose, onSelect }) {
   // States (R-010 — States → Memos → Effects → Handlers)
   const [query, setQuery] = useState('')
+  const [stockMap, setStockMap] = useState({})
   const { data, loading, error, refresh } = useMedicines()
+  const { user } = useAuth()
 
-  // Memos
-  const list = useMemo(() => (Array.isArray(data) ? data : []), [data])
+  // Memos — mescla saldo (medicine_stock_summary) em cada medicamento.
+  // useMedicines não traz estoque; sem isso todo saldo aparecia "0 un.".
+  const list = useMemo(() => {
+    const arr = Array.isArray(data) ? data : []
+    return arr.map((m) => ({ ...m, current_stock: stockMap[m.id] ?? 0 }))
+  }, [data, stockMap])
 
   // Pré-computa haystack normalizado para evitar normalize por keystroke (AP-157)
   const indexed = useMemo(
@@ -105,10 +113,19 @@ export default function PurchaseMedicineSheet({ visible, onClose, onSelect }) {
     [filtered]
   )
 
-  // Effects — refresh lista toda vez que sheet abre (captura med recém-criado)
+  // Effects — refresh lista + saldo toda vez que sheet abre (captura med/compra recém-criados)
   useEffect(() => {
-    if (visible) refresh?.()
-  }, [visible, refresh])
+    if (!visible) return
+    refresh?.()
+    const userId = user?.id
+    if (!userId) return
+    let cancelled = false
+    stockService
+      .getStockSummaryMap(userId)
+      .then((map) => { if (!cancelled) setStockMap(map) })
+      .catch(() => { if (!cancelled) setStockMap({}) })
+    return () => { cancelled = true }
+  }, [visible, refresh, user])
 
   // Handlers
   function handleClose() {

--- a/apps/mobile/src/features/stock/components/StockFilterChips.jsx
+++ b/apps/mobile/src/features/stock/components/StockFilterChips.jsx
@@ -1,0 +1,78 @@
+// StockFilterChips.jsx — chips de filtro horizontais para o hub de estoque (S1.8 Wave 4)
+// ADR-028: StyleSheet canônico · ADR-023: fontWeight >= 400 · sem cores hardcoded
+//
+// Contrato: { value, onChange, counts }
+//   value: 'todos' | 'critico' | 'baixo' | 'sem_tratamento'
+//   onChange(nextValue): callback ao tocar num chip
+//   counts: { todos, critico, baixo, sem_tratamento } (números)
+//
+// "vencendo" fora de escopo Wave 4 (exige dado de validade não carregado no hub).
+
+import { ScrollView, Pressable, Text, StyleSheet } from 'react-native'
+import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
+
+const FILTERS = [
+  { key: 'todos', label: 'Todos' },
+  { key: 'critico', label: 'Crítico' },
+  { key: 'baixo', label: 'Baixo' },
+  { key: 'sem_tratamento', label: 'Sem tratamento' },
+]
+
+/**
+ * Chips de filtro do hub de estoque.
+ */
+export default function StockFilterChips({ value, onChange, counts = {} }) {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.container}
+    >
+      {FILTERS.map((f) => {
+        const selected = value === f.key
+        const count = counts[f.key] ?? 0
+        return (
+          <Pressable
+            key={f.key}
+            onPress={() => onChange(f.key)}
+            style={[styles.chip, selected && styles.chipSelected]}
+            accessibilityRole="button"
+            accessibilityState={{ selected }}
+            accessibilityLabel={`Filtrar por ${f.label}`}
+          >
+            <Text style={[styles.chipText, selected && styles.chipTextSelected]}>
+              {f.label} ({count})
+            </Text>
+          </Pressable>
+        )
+      })}
+    </ScrollView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    gap: spacing[2],
+    paddingHorizontal: spacing[5],
+    paddingVertical: spacing[2],
+  },
+  chip: {
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+    borderRadius: borderRadius.full,
+    backgroundColor: colors.neutral[100],
+  },
+  chipSelected: {
+    backgroundColor: colors.primary[500],
+  },
+  chipText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.text.secondary,
+    fontFamily: typography.fontFamily.medium || 'System',
+  },
+  chipTextSelected: {
+    color: colors.text.inverse,
+  },
+})

--- a/apps/mobile/src/features/stock/components/StockItem.jsx
+++ b/apps/mobile/src/features/stock/components/StockItem.jsx
@@ -46,18 +46,12 @@ export default function StockItem({ medicine }) {
           </View>
           
           {hasActiveProtocol && (
-            <StockLevelBadge 
-              status={status} 
-              daysRemaining={daysRemaining} 
+            <StockLevelBadge
+              status={status}
+              daysRemaining={daysRemaining}
             />
           )}
         </View>
-
-        {hasActiveProtocol && daysRemaining !== Infinity && (
-          <Text style={styles.helperText}>
-            Estimativa baseada nos seus protocolos ativos.
-          </Text>
-        )}
       </View>
     </SectionCard>
   )
@@ -111,11 +105,5 @@ const styles = StyleSheet.create({
   bold: {
     fontWeight: '700',
     color: colors.text.primary
-  },
-  helperText: {
-    fontSize: 11,
-    color: colors.neutral[500],
-    marginTop: 12,
-    fontStyle: 'italic'
   }
 })

--- a/apps/mobile/src/features/stock/hooks/_stockDataTransformer.js
+++ b/apps/mobile/src/features/stock/hooks/_stockDataTransformer.js
@@ -59,3 +59,25 @@ export function filterActiveStockItems(processed) {
     .filter(item => item.hasActiveProtocol)
     .sort((a, b) => a.daysRemaining - b.daysRemaining)
 }
+
+/**
+ * Split PO-9 (§0.7): separa itens com protocolo ativo (com previsão de consumo)
+ * dos itens só-estoque (saldo positivo sem treatment ativo — antes invisíveis).
+ *
+ * - active: hasActiveProtocol, ordenado por daysRemaining asc (mais crítico primeiro)
+ * - inactive: !hasActiveProtocol && totalQuantity > 0, ordenado por nome
+ *
+ * O service já filtra `hasActiveProtocol || totalQuantity > 0`, então itens sem
+ * protocolo e sem saldo nem chegam aqui.
+ */
+export function splitStockItems(processed) {
+  const active = processed
+    .filter(item => item.hasActiveProtocol)
+    .sort((a, b) => a.daysRemaining - b.daysRemaining)
+
+  const inactive = processed
+    .filter(item => !item.hasActiveProtocol && item.totalQuantity > 0)
+    .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+
+  return { active, inactive }
+}

--- a/apps/mobile/src/features/stock/hooks/useStock.js
+++ b/apps/mobile/src/features/stock/hooks/useStock.js
@@ -131,11 +131,15 @@ export function useStock() {
     }
   }, [state.data])
 
+  // refresh estável (useCallback) — arrow inline no useMemo recriava a função a
+  // cada setState, causando loop em consumidores com useFocusEffect([refresh]).
+  const refresh = useCallback(() => loadStock(true), [loadStock])
+
   const result = useMemo(() => ({
     ...state,
     data: refinedData,
-    refresh: () => loadStock(true)
-  }), [state, refinedData, loadStock])
+    refresh,
+  }), [state, refinedData, refresh])
 
   return result
 }

--- a/apps/mobile/src/features/stock/hooks/useStock.js
+++ b/apps/mobile/src/features/stock/hooks/useStock.js
@@ -3,9 +3,9 @@ import { AppState } from 'react-native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { getTodayLocal, getNow, parseISO, addDays, isProtocolActiveOnDate } from '@dosiq/core'
 import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
-import { getStockData } from '../services/stockService'
+import { stockService } from '../services/stockService'
 import { debugLog } from '@shared/utils/debugLog'
-import { transformStockData, filterActiveStockItems } from './_stockDataTransformer'
+import { transformStockData, splitStockItems } from './_stockDataTransformer'
 
 const STOCK_CACHE_KEY = '@dosiq/stock-snapshot'
 
@@ -21,12 +21,13 @@ async function _resolveUser() {
 }
 
 async function _fetchAndPersistStock(userId, setState, dataRef) {
-  const result = await getStockData(userId)
+  // PO-9 §0.7: lista meds com protocolo ativo OU saldo positivo (corrige bug de
+  // estoque órfão invisível). Split em active (com previsão) + inactive (só-estoque).
+  const rawData = await stockService.getMedicinesWithStockOrActiveProtocol(userId)
   const today = getTodayLocal()
-  if (!result.success) throw new Error(result.error)
-  const active = filterActiveStockItems(transformStockData(result.data))
-  const newData = { active, inactive: [], localDay: today }
-  const snapshot = { data: newData, capturedAt: getNow().toISOString(), rawData: result.data }
+  const { active, inactive } = splitStockItems(transformStockData(rawData))
+  const newData = { active, inactive, localDay: today }
+  const snapshot = { data: newData, capturedAt: getNow().toISOString(), rawData }
   await AsyncStorage.setItem(STOCK_CACHE_KEY, JSON.stringify(snapshot))
   dataRef.current = newData
   setState({ data: newData, loading: false, error: null, stale: false, refreshing: false })
@@ -103,24 +104,30 @@ export function useStock() {
 
   useEffect(() => _setupMidnightAndAppState(loadStock, dataRef), [loadStock])
 
-  // Resilience layer (Rule R-175): Double-check validity on the active list
-  // Isso protege contra o caso do cache ter sido gerado às 23:59 de ontem e carregado às 00:01 de hoje.
+  // Resilience layer (Rule R-175): re-valida atividade no dia atual.
+  // Protege contra cache gerado às 23:59 e carregado às 00:01 (dia virou).
+  // PO-9: re-split active/inactive a partir da união, mantendo só-estoque visível.
   const refinedData = useMemo(() => {
-    if (!state.data?.active) return state.data
+    if (!state.data?.active && !state.data?.inactive) return state.data
     const today = getTodayLocal()
-    
-    const refinedActive = state.data.active.filter(item => {
-      // Se o item já foi processado e tem activeProtocols salvos:
+
+    const isActiveToday = (item) => {
       if (item.activeProtocols) {
         return item.activeProtocols.some(p => isProtocolActiveOnDate(p, today))
       }
-      // Fallback para protocols originais
       return (item.protocols || []).some(p => p.active && isProtocolActiveOnDate(p, today))
-    })
+    }
 
-    return { 
-      ...state.data, 
-      active: refinedActive 
+    const union = [...(state.data.active || []), ...(state.data.inactive || [])]
+    const refinedActive = union.filter(isActiveToday)
+    const refinedInactive = union.filter(
+      item => !isActiveToday(item) && (item.totalQuantity ?? 0) > 0,
+    )
+
+    return {
+      ...state.data,
+      active: refinedActive,
+      inactive: refinedInactive,
     }
   }, [state.data])
 

--- a/apps/mobile/src/features/stock/screens/PurchaseFormScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/PurchaseFormScreen.jsx
@@ -265,7 +265,7 @@ export default function PurchaseFormScreen() {
                   }
                   error={form.touched.quantity ? form.errors.quantity : undefined}
                   onChange={handleQuantityChange}
-                  onBlur={form.handleBlur}
+                  onBlur={() => form.handleBlur('quantity', coerceDecimal(form.values.quantity))}
                 />
               </View>
               <View style={styles.rowHalf}>
@@ -280,7 +280,7 @@ export default function PurchaseFormScreen() {
                   }
                   error={form.touched.unit_price ? form.errors.unit_price : undefined}
                   onChange={handlePriceChange}
-                  onBlur={form.handleBlur}
+                  onBlur={() => form.handleBlur('unit_price', coerceDecimal(form.values.unit_price))}
                 />
               </View>
             </View>

--- a/apps/mobile/src/features/stock/screens/PurchaseFormScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/PurchaseFormScreen.jsx
@@ -136,9 +136,12 @@ export default function PurchaseFormScreen() {
 
   // States — laboratório travado p/ medicamentos de marca (Novo/Similar)
   const [labLocked, setLabLocked] = useState(false)
+  const { handleChange } = form
 
   // Effects — busca categoria regulatória do medicamento. Se Novo/Similar, o
   // laboratório é marca registrada (não muda por compra): preenche + trava.
+  // setState ocorre dentro do .then (microtask, não sync no corpo do effect),
+  // então não dispara react-hooks/set-state-in-effect.
   useEffect(() => {
     if (!medicineId) return
     let cancelled = false
@@ -147,14 +150,13 @@ export default function PurchaseFormScreen() {
       .then((med) => {
         if (cancelled || !med) return
         if (FIXED_LAB_CATEGORIES.includes(med.regulatory_category) && med.laboratory) {
-          form.handleChange('laboratory', med.laboratory)
+          handleChange('laboratory', med.laboratory)
           setLabLocked(true)
         }
       })
       .catch(() => {})
     return () => { cancelled = true }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [medicineId])
+  }, [medicineId, handleChange])
 
   // Handlers
 

--- a/apps/mobile/src/features/stock/screens/PurchaseFormScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/PurchaseFormScreen.jsx
@@ -104,8 +104,11 @@ export default function PurchaseFormScreen() {
   const initialValues = useMemo(() => {
     if (isEdit && purchase) {
       return {
-        quantity:
-          purchase.quantity != null ? String(purchase.quantity).replace('.', ',') : '',
+        quantity: (() => {
+          // purchase vem da tabela (quantity_bought) ou do demo (quantity)
+          const q = purchase.quantity_bought ?? purchase.quantity
+          return q != null ? String(q).replace('.', ',') : ''
+        })(),
         unit_price:
           purchase.unit_price != null && purchase.unit_price !== 0
             ? String(purchase.unit_price).replace('.', ',')

--- a/apps/mobile/src/features/stock/screens/PurchaseFormScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/PurchaseFormScreen.jsx
@@ -13,7 +13,7 @@
 // ADR-046: unidade sempre presente no label de quantidade.
 // ADR-028: StyleSheet. ADR-023: fontWeights >= 400.
 
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState, useEffect } from 'react'
 import {
   View,
   Text,
@@ -33,7 +33,11 @@ import FormDatePicker from '@shared/components/form/FormDatePicker'
 import FormSection from '@shared/components/form/FormSection'
 import FormActions from '@shared/components/form/FormActions'
 import { useStockMutation } from '@stock/hooks/useStockMutation'
+import { medicineService } from '@medications/services/medicineService'
 import { colors, spacing, typography, borderRadius } from '@shared/styles/tokens'
+
+// Categorias regulatórias com marca registrada → laboratório fixo (não muda por compra).
+const FIXED_LAB_CATEGORIES = ['Novo', 'Similar']
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Helpers de decimal PT-BR (AP-167)
@@ -126,6 +130,28 @@ export default function PurchaseFormScreen() {
 
   const form = useFormState(stockCreateSchema, { initialValues })
   const { createPurchase, updatePurchase, isLoading } = useStockMutation()
+
+  // States — laboratório travado p/ medicamentos de marca (Novo/Similar)
+  const [labLocked, setLabLocked] = useState(false)
+
+  // Effects — busca categoria regulatória do medicamento. Se Novo/Similar, o
+  // laboratório é marca registrada (não muda por compra): preenche + trava.
+  useEffect(() => {
+    if (!medicineId) return
+    let cancelled = false
+    medicineService
+      .getById(medicineId)
+      .then((med) => {
+        if (cancelled || !med) return
+        if (FIXED_LAB_CATEGORIES.includes(med.regulatory_category) && med.laboratory) {
+          form.handleChange('laboratory', med.laboratory)
+          setLabLocked(true)
+        }
+      })
+      .catch(() => {})
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [medicineId])
 
   // Handlers
 
@@ -339,9 +365,10 @@ export default function PurchaseFormScreen() {
               name="laboratory"
               label="Laboratório"
               placeholder="Fabricante"
-              helperText="Opcional"
+              helperText={labLocked ? 'Marca registrada — definida pelo medicamento' : 'Opcional'}
               autoCapitalize="words"
               maxLength={200}
+              disabled={labLocked}
               {...formProps(form, 'laboratory')}
             />
             <FormInput

--- a/apps/mobile/src/features/stock/screens/PurchaseFormScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/PurchaseFormScreen.jsx
@@ -289,6 +289,8 @@ export default function PurchaseFormScreen() {
                   required
                   placeholder="0"
                   keyboardType="decimal-pad"
+                  disabled={isEdit}
+                  helperText={isEdit ? 'Corrija o saldo pelo "Acertar saldo"' : undefined}
                   value={
                     form.values.quantity != null ? String(form.values.quantity) : ''
                   }

--- a/apps/mobile/src/features/stock/screens/PurchaseHistoryScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/PurchaseHistoryScreen.jsx
@@ -13,11 +13,12 @@ import {
   StyleSheet,
 } from 'react-native'
 import { useFocusEffect } from '@react-navigation/native'
-import { ChevronLeft } from 'lucide-react-native'
+import { ChevronLeft, Pill, PillBottle } from 'lucide-react-native'
 import ScreenContainer from '@shared/components/ui/ScreenContainer'
 import EmptyState from '@shared/components/states/EmptyState'
 import PurchaseCard from '@stock/components/PurchaseCard'
 import { stockService } from '@stock/services/stockService'
+import { medicineService } from '@medications/services/medicineService'
 import { useAuth } from '@platform/auth/hooks/useAuth'
 import { computeAverageUnitPrice, formatBRL } from '@dosiq/core'
 import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
@@ -36,6 +37,7 @@ export default function PurchaseHistoryScreen({ route, navigation }) {
 
   // — States (R-010) —
   const [purchases, setPurchases] = useState([])
+  const [medicine, setMedicine] = useState(null)
   const [loading, setLoading] = useState(true)
 
   // — Memos (R-010) —
@@ -58,8 +60,12 @@ export default function PurchaseHistoryScreen({ route, navigation }) {
     if (!medicineId || !userId) return
     setLoading(true)
     try {
-      const data = await stockService.getPurchasesByMedicine(medicineId, userId)
+      const [data, med] = await Promise.all([
+        stockService.getPurchasesByMedicine(medicineId, userId),
+        medicineService.getById(medicineId).catch(() => null),
+      ])
       setPurchases(data ?? [])
+      setMedicine(med ?? null)
     } catch {
       setPurchases([])
     } finally {
@@ -145,12 +151,35 @@ export default function PurchaseHistoryScreen({ route, navigation }) {
         ]}
         ListHeaderComponent={
           <>
-            {/* Título da tela */}
-            <View style={styles.pageHeader}>
-              <Text style={styles.pageTitle} numberOfLines={2}>
-                {medicineName ?? 'Medicamento'}
-              </Text>
-              <Text style={styles.pageSubtitle}>Histórico de compras</Text>
+            {/* Card de contexto do medicamento */}
+            <View style={styles.medicineCard}>
+              <View style={styles.medicineIcon}>
+                {medicine?.type === 'suplemento' ? (
+                  <PillBottle size={22} color={colors.supplement[500]} strokeWidth={2} />
+                ) : (
+                  <Pill size={22} color={colors.primary[500]} strokeWidth={2} />
+                )}
+              </View>
+              <View style={styles.medicineInfo}>
+                <View style={styles.medicineNameRow}>
+                  <Text style={styles.medicineName} numberOfLines={2}>
+                    {medicine?.name ?? medicineName ?? 'Medicamento'}
+                  </Text>
+                  {medicine?.dosage_per_pill ? (
+                    <View style={styles.dosePill}>
+                      <Text style={styles.dosePillText}>
+                        {medicine.dosage_per_pill}{medicine.dosage_unit || ''}
+                      </Text>
+                    </View>
+                  ) : null}
+                </View>
+                {medicine?.active_ingredient ? (
+                  <Text style={styles.medicineSub} numberOfLines={1}>
+                    {medicine.active_ingredient}
+                  </Text>
+                ) : null}
+                <Text style={styles.pageSubtitle}>Histórico de compras</Text>
+              </View>
             </View>
 
             {/* Cards de resumo — visíveis apenas quando há dados */}
@@ -233,19 +262,63 @@ const styles = StyleSheet.create({
     flexGrow: 1,
   },
 
-  // Cabeçalho da página
-  pageHeader: {
-    paddingHorizontal: spacing[5],
-    paddingTop: spacing[4],
-    paddingBottom: spacing[2],
+  // Card de contexto do medicamento
+  medicineCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    marginHorizontal: spacing[5],
+    marginTop: spacing[4],
+    marginBottom: spacing[2],
+    padding: spacing[4],
+    backgroundColor: colors.bg.card,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.border.light,
   },
-
-  pageTitle: {
-    fontSize: 24,
+  medicineIcon: {
+    width: 44,
+    height: 44,
+    borderRadius: 12,
+    backgroundColor: colors.primary[50],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  medicineInfo: {
+    flex: 1,
+    minWidth: 0,
+    gap: 2,
+  },
+  medicineNameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    flexWrap: 'wrap',
+  },
+  medicineName: {
+    flexShrink: 1,
+    fontSize: 18,
     fontWeight: '700',
     color: colors.text.primary,
-    letterSpacing: -0.3,
+    letterSpacing: -0.2,
     fontFamily: typography.fontFamily?.bold ?? 'System',
+  },
+  dosePill: {
+    backgroundColor: colors.neutral[100],
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    borderRadius: 4,
+    borderWidth: 0.5,
+    borderColor: colors.neutral[300],
+  },
+  dosePillText: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: colors.neutral[700],
+  },
+  medicineSub: {
+    fontSize: 13,
+    color: colors.text.secondary,
   },
 
   pageSubtitle: {

--- a/apps/mobile/src/features/stock/screens/PurchaseHistoryScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/PurchaseHistoryScreen.jsx
@@ -9,9 +9,11 @@ import {
   Text,
   FlatList,
   ActivityIndicator,
+  Pressable,
   StyleSheet,
 } from 'react-native'
 import { useFocusEffect } from '@react-navigation/native'
+import { ChevronLeft } from 'lucide-react-native'
 import ScreenContainer from '@shared/components/ui/ScreenContainer'
 import EmptyState from '@shared/components/states/EmptyState'
 import PurchaseCard from '@stock/components/PurchaseCard'
@@ -102,10 +104,26 @@ export default function PurchaseHistoryScreen({ route, navigation }) {
 
   const keyExtractor = useCallback((item) => item.id, [])
 
+  // — Render: barra superior com voltar (sempre visível, inclusive no loading) —
+  const topBar = (
+    <View style={styles.topBar}>
+      <Pressable
+        onPress={() => navigation.goBack()}
+        style={({ pressed }) => [styles.backBtn, pressed && styles.backBtnPressed]}
+        accessibilityRole="button"
+        accessibilityLabel="Voltar"
+        hitSlop={8}
+      >
+        <ChevronLeft size={26} color={colors.text.primary} />
+      </Pressable>
+    </View>
+  )
+
   // — Loading —
   if (loading) {
     return (
       <ScreenContainer>
+        {topBar}
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color={colors.primary[500]} />
           <Text style={styles.loadingText}>Carregando histórico...</Text>
@@ -116,6 +134,7 @@ export default function PurchaseHistoryScreen({ route, navigation }) {
 
   return (
     <ScreenContainer>
+      {topBar}
       <FlatList
         data={purchases}
         keyExtractor={keyExtractor}
@@ -174,6 +193,23 @@ export default function PurchaseHistoryScreen({ route, navigation }) {
 }
 
 const styles = StyleSheet.create({
+  // Barra superior (voltar)
+  topBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing[3],
+    paddingTop: spacing[2],
+  },
+  backBtn: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  backBtnPressed: {
+    opacity: 0.6,
+  },
+
   // Loading
   loadingContainer: {
     flex: 1,

--- a/apps/mobile/src/features/stock/screens/StockDetailScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockDetailScreen.jsx
@@ -1,0 +1,236 @@
+// StockDetailScreen.jsx — detalhe de estoque de UM medicamento (S1.8 Wave 4)
+// R-010: ordem hooks → States → Memos → Effects → Handlers (TDZ crítico)
+// ADR-028: StyleSheet canônico · ADR-023: fontWeight >= 400 · ADR-046: unidade(s)
+// PO-2: FAB ubíquo "Registrar compra" · PO-3: med travado (passamos medicineId)
+//
+// ESCOPO MÍNIMO Wave 4: header + card de saldo + histórico + FAB.
+// KPI grid fica para S2.1 (próximo sprint).
+
+import { useState, useCallback } from 'react'
+import {
+  View,
+  Text,
+  Pressable,
+  ActivityIndicator,
+  StyleSheet,
+} from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useRoute, useFocusEffect } from '@react-navigation/native'
+import { ChevronLeft, Plus, History } from 'lucide-react-native'
+import ScreenContainer from '@shared/components/ui/ScreenContainer'
+import { stockService } from '@stock/services/stockService'
+import { useAuth } from '@platform/auth/hooks/useAuth'
+import { formatDoseUnit } from '@dosiq/core'
+import { colors, spacing, borderRadius, shadows, typography } from '@shared/styles/tokens'
+import { ROUTES } from '@navigation/routes'
+
+/**
+ * Detalhe de estoque de um medicamento.
+ *
+ * route.params:
+ *   medicineId: string    (obrigatório)
+ *   medicineName: string  (display no header)
+ */
+export default function StockDetailScreen({ navigation }) {
+  const route = useRoute()
+  const { medicineId, medicineName } = route.params ?? {}
+  const { user } = useAuth()
+
+  // — States (R-010) —
+  const [totalQuantity, setTotalQuantity] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  // — Effects (R-010) —
+  // SYNC callback obrigatório no useFocusEffect (NUNCA async direto — crash
+  // "An effect function must not return anything besides a function").
+  const fetchSummary = useCallback(async () => {
+    const userId = user?.id
+    if (!medicineId || !userId) return
+    setLoading(true)
+    try {
+      const summary = await stockService.getStockSummary(medicineId, userId)
+      if (summary && typeof summary.total_quantity === 'number') {
+        setTotalQuantity(summary.total_quantity)
+      } else {
+        const fallback = await stockService.getTotalQuantity(medicineId, userId)
+        setTotalQuantity(fallback ?? 0)
+      }
+    } catch {
+      try {
+        const fallback = await stockService.getTotalQuantity(medicineId, userId)
+        setTotalQuantity(fallback ?? 0)
+      } catch {
+        setTotalQuantity(0)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [medicineId, user])
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchSummary()
+    }, [fetchSummary]),
+  )
+
+  // — Handlers (R-010) —
+  const handleBack = useCallback(() => {
+    navigation.goBack()
+  }, [navigation])
+
+  const handleHistory = useCallback(() => {
+    navigation.navigate(ROUTES.PURCHASE_HISTORY, { medicineId, medicineName })
+  }, [navigation, medicineId, medicineName])
+
+  const handleRegisterPurchase = useCallback(() => {
+    navigation.navigate(ROUTES.PURCHASE_FORM, {
+      mode: 'create',
+      medicineId,
+      medicineName,
+    })
+  }, [navigation, medicineId, medicineName])
+
+  return (
+    <ScreenContainer>
+      <SafeAreaView edges={['top']} style={styles.flex}>
+        {/* Header */}
+        <View style={styles.header}>
+          <Pressable
+            onPress={handleBack}
+            style={({ pressed }) => [styles.backBtn, pressed && styles.pressed]}
+            accessibilityRole="button"
+            accessibilityLabel="Voltar"
+            hitSlop={8}
+          >
+            <ChevronLeft size={26} color={colors.text.primary} />
+          </Pressable>
+          <Text style={styles.headerTitle} numberOfLines={1}>
+            {medicineName ?? 'Medicamento'}
+          </Text>
+        </View>
+
+        <View style={styles.content}>
+          {/* Card de saldo */}
+          <View style={styles.balanceCard}>
+            <Text style={styles.balanceLabel}>Saldo atual</Text>
+            {loading ? (
+              <ActivityIndicator size="small" color={colors.primary[500]} />
+            ) : (
+              <Text style={styles.balanceValue}>
+                {formatDoseUnit(totalQuantity ?? 0)}
+              </Text>
+            )}
+          </View>
+
+          {/* Histórico de compras */}
+          <Pressable
+            onPress={handleHistory}
+            style={({ pressed }) => [styles.historyBtn, pressed && styles.pressed]}
+            accessibilityRole="button"
+            accessibilityLabel="Histórico de compras"
+          >
+            <History size={20} color={colors.primary[700]} />
+            <Text style={styles.historyText}>Histórico de compras</Text>
+          </Pressable>
+        </View>
+
+        {/* FAB ubíquo (PO-2) — Registrar compra */}
+        <Pressable
+          onPress={handleRegisterPurchase}
+          style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
+          accessibilityRole="button"
+          accessibilityLabel="Registrar compra"
+        >
+          <Plus size={28} color={colors.text.inverse} />
+        </Pressable>
+      </SafeAreaView>
+    </ScreenContainer>
+  )
+}
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+  },
+  backBtn: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pressed: {
+    opacity: 0.6,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: 22,
+    fontWeight: '700',
+    color: colors.text.primary,
+    letterSpacing: -0.3,
+    fontFamily: typography.fontFamily.bold || 'System',
+  },
+  content: {
+    paddingHorizontal: spacing[5],
+    paddingTop: spacing[2],
+    gap: spacing[4],
+  },
+  balanceCard: {
+    backgroundColor: colors.bg.card,
+    borderRadius: borderRadius.lg,
+    paddingHorizontal: spacing[5],
+    paddingVertical: spacing[5],
+    gap: spacing[2],
+    ...shadows.sm,
+  },
+  balanceLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.text.secondary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  balanceValue: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: colors.text.primary,
+    letterSpacing: -0.5,
+    fontFamily: typography.fontFamily.bold || 'System',
+  },
+  historyBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.primary[50],
+  },
+  historyText: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.primary[700],
+    fontFamily: typography.fontFamily.bold || 'System',
+  },
+  fab: {
+    position: 'absolute',
+    bottom: spacing[6],
+    right: spacing[5],
+    width: 56,
+    height: 56,
+    borderRadius: borderRadius.full,
+    backgroundColor: colors.primary[500],
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...shadows.md,
+  },
+  fabPressed: {
+    opacity: 0.9,
+  },
+})

--- a/apps/mobile/src/features/stock/screens/StockDetailScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockDetailScreen.jsx
@@ -48,20 +48,11 @@ export default function StockDetailScreen({ navigation }) {
     if (!medicineId || !userId) return
     setLoading(true)
     try {
-      const summary = await stockService.getStockSummary(medicineId, userId)
-      if (summary && typeof summary.total_quantity === 'number') {
-        setTotalQuantity(summary.total_quantity)
-      } else {
-        const fallback = await stockService.getTotalQuantity(medicineId, userId)
-        setTotalQuantity(fallback ?? 0)
-      }
+      // getTotalQuantity já resolve view medicine_stock_summary + fallback soma stock.
+      const qty = await stockService.getTotalQuantity(medicineId, userId)
+      setTotalQuantity(qty ?? 0)
     } catch {
-      try {
-        const fallback = await stockService.getTotalQuantity(medicineId, userId)
-        setTotalQuantity(fallback ?? 0)
-      } catch {
-        setTotalQuantity(0)
-      }
+      setTotalQuantity(0)
     } finally {
       setLoading(false)
     }

--- a/apps/mobile/src/features/stock/screens/StockScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockScreen.jsx
@@ -153,9 +153,9 @@ export default function StockScreen() {
         ListHeaderComponent={
           <View>
             <View style={styles.header}>
-              <Text style={styles.title}>Meu Estoque</Text>
+              <Text style={styles.title}>Estoque</Text>
               <Text style={styles.subtitle}>
-                Acompanhe o estoque de seus remédios
+                Acompanhe o estoque dos medicamentos
               </Text>
             </View>
             <StockFilterChips value={filter} onChange={setFilter} counts={counts} />
@@ -163,8 +163,15 @@ export default function StockScreen() {
         }
         ListEmptyComponent={
           <EmptyState
-            message="Você não possui medicamentos cadastrados ou estoque registrado."
+            message="Nenhum medicamento cadastrado ou estoque registrado."
           />
+        }
+        ListFooterComponent={
+          active.length > 0 ? (
+            <Text style={styles.footnote}>
+              * As estimativas desta tela consideram os tratamentos ativos.
+            </Text>
+          ) : null
         }
       />
 
@@ -238,5 +245,13 @@ const styles = StyleSheet.create({
   },
   fabPressed: {
     opacity: 0.9,
+  },
+  footnote: {
+    fontSize: 12,
+    color: colors.text.muted,
+    fontStyle: 'italic',
+    paddingHorizontal: spacing[5],
+    paddingTop: spacing[3],
+    paddingBottom: spacing[6],
   },
 })

--- a/apps/mobile/src/features/stock/screens/StockScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockScreen.jsx
@@ -2,9 +2,9 @@
 // R-010: ordem hooks → States → Memos → Effects → Handlers
 // PO-2: FAB ubíquo "Registrar compra" via PurchaseMedicineSheet
 
-import React, { useState, useMemo, useCallback } from 'react'
+import React, { useState, useMemo, useCallback, useRef } from 'react'
 import { SectionList, RefreshControl, StyleSheet, Text, View, Pressable } from 'react-native'
-import { useNavigation } from '@react-navigation/native'
+import { useNavigation, useFocusEffect } from '@react-navigation/native'
 import { Plus } from 'lucide-react-native'
 import { useStock } from '@stock/hooks/useStock'
 import ScreenContainer from '@shared/components/ui/ScreenContainer'
@@ -36,6 +36,7 @@ export default function StockScreen() {
   // — States (R-010) —
   const [filter, setFilter] = useState('todos')
   const [sheetVisible, setSheetVisible] = useState(false)
+  const isFirstFocus = useRef(true)
 
   // — Memos (R-010) —
   const active = useMemo(() => data?.active ?? [], [data])
@@ -81,6 +82,19 @@ export default function StockScreen() {
     }
     return list
   }, [data, filter, active, inactive])
+
+  // — Effects (R-010) —
+  // Refresh ao re-focar (volta de PurchaseForm/Detail) pra refletir nova compra
+  // sem exigir pull-to-refresh. Pula o 1º foco — useStock já carrega no mount.
+  useFocusEffect(
+    useCallback(() => {
+      if (isFirstFocus.current) {
+        isFirstFocus.current = false
+        return
+      }
+      refresh()
+    }, [refresh]),
+  )
 
   // — Handlers (R-010) —
   const handleOpenItem = useCallback(

--- a/apps/mobile/src/features/stock/screens/StockScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockScreen.jsx
@@ -1,41 +1,115 @@
-import React, { useMemo } from 'react'
-import { SectionList, RefreshControl, StyleSheet, Text, View } from 'react-native'
+// StockScreen.jsx — hub principal de Gerenciamento de Estoque (S1.8 Wave 4)
+// R-010: ordem hooks → States → Memos → Effects → Handlers
+// PO-2: FAB ubíquo "Registrar compra" via PurchaseMedicineSheet
+
+import React, { useState, useMemo, useCallback } from 'react'
+import { SectionList, RefreshControl, StyleSheet, Text, View, Pressable } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
+import { Plus } from 'lucide-react-native'
 import { useStock } from '@stock/hooks/useStock'
 import ScreenContainer from '@shared/components/ui/ScreenContainer'
 import LoadingState from '@shared/components/states/LoadingState'
 import EmptyState from '@shared/components/states/EmptyState'
 import ErrorState from '@shared/components/states/ErrorState'
 import StockItem from '@stock/components/StockItem'
+import StockFilterChips from '@stock/components/StockFilterChips'
+import PurchaseMedicineSheet from '@stock/components/PurchaseMedicineSheet'
 import StaleBanner from '@shared/components/feedback/StaleBanner'
-import { colors, typography } from '@shared/styles/tokens'
+import { colors, spacing, borderRadius, shadows, typography } from '@shared/styles/tokens'
+import { ROUTES } from '@navigation/routes'
 
 /**
  * Tela principal de Gerenciamento de Estoque (H5.5).
  */
 export default function StockScreen() {
+  const navigation = useNavigation()
   const { data, loading, error, stale, refreshing, refresh } = useStock()
 
-  // Formata os dados no formato esperado pelo SectionList
+  // — States (R-010) —
+  const [filter, setFilter] = useState('todos')
+  const [sheetVisible, setSheetVisible] = useState(false)
+
+  // — Memos (R-010) —
+  const active = useMemo(() => data?.active ?? [], [data])
+  const inactive = useMemo(() => data?.inactive ?? [], [data])
+
+  const counts = useMemo(
+    () => ({
+      todos: active.length + inactive.length,
+      critico: active.filter((m) => m.status === 'CRITICAL').length,
+      baixo: active.filter((m) => m.status === 'LOW').length,
+      sem_tratamento: inactive.length,
+    }),
+    [active, inactive],
+  )
+
+  // Aplica o filtro às seções do SectionList.
   const sections = useMemo(() => {
     if (!data) return []
     const list = []
-    
-    if (data?.active?.length > 0) {
-      list.push({
-        title: 'Estoque em Uso',
-        data: data.active
-      })
+
+    if (filter === 'sem_tratamento') {
+      if (inactive.length > 0) {
+        list.push({ title: 'Sem tratamento ativo', data: inactive })
+      }
+      return list
     }
-    
-    if (data?.inactive?.length > 0) {
-      list.push({
-        title: 'Sem tratamento ativo',
-        data: data.inactive
-      })
+
+    if (filter === 'critico' || filter === 'baixo') {
+      const status = filter === 'critico' ? 'CRITICAL' : 'LOW'
+      const filtered = active.filter((m) => m.status === status)
+      if (filtered.length > 0) {
+        list.push({ title: 'Estoque em Uso', data: filtered })
+      }
+      return list
     }
-    
+
+    // 'todos' — ambas as seções
+    if (active.length > 0) {
+      list.push({ title: 'Estoque em Uso', data: active })
+    }
+    if (inactive.length > 0) {
+      list.push({ title: 'Sem tratamento ativo', data: inactive })
+    }
     return list
-  }, [data])
+  }, [data, filter, active, inactive])
+
+  // — Handlers (R-010) —
+  const handleOpenItem = useCallback(
+    (item) => {
+      navigation.navigate(ROUTES.STOCK_DETAIL, {
+        medicineId: item.id,
+        medicineName: item.name,
+      })
+    },
+    [navigation],
+  )
+
+  const handleSelectMedicine = useCallback(
+    (medicineId, medicineName) => {
+      setSheetVisible(false)
+      navigation.navigate(ROUTES.PURCHASE_FORM, {
+        mode: 'create',
+        medicineId,
+        medicineName,
+      })
+    },
+    [navigation],
+  )
+
+  const renderItem = useCallback(
+    ({ item }) => (
+      <Pressable
+        onPress={() => handleOpenItem(item)}
+        style={({ pressed }) => pressed && styles.itemPressed}
+        accessibilityRole="button"
+        accessibilityLabel={`Detalhes do estoque de ${item.name}`}
+      >
+        <StockItem medicine={item} />
+      </Pressable>
+    ),
+    [handleOpenItem],
+  )
 
   if (loading && !refreshing) {
     return (
@@ -48,9 +122,9 @@ export default function StockScreen() {
   if (error && !data) {
     return (
       <ScreenContainer>
-        <ErrorState 
-          message="Não foi possível carregar seu estoque." 
-          onRetry={refresh} 
+        <ErrorState
+          message="Não foi possível carregar seu estoque."
+          onRetry={refresh}
         />
       </ScreenContainer>
     )
@@ -62,7 +136,7 @@ export default function StockScreen() {
       <SectionList
         sections={sections}
         keyExtractor={(item) => item.id}
-        renderItem={({ item }) => <StockItem medicine={item} />}
+        renderItem={renderItem}
         renderSectionHeader={({ section: { title } }) => (
           <View style={styles.sectionHeader}>
             <Text style={styles.sectionTitle}>{title}</Text>
@@ -70,25 +144,44 @@ export default function StockScreen() {
         )}
         contentContainerStyle={styles.listContent}
         refreshControl={
-          <RefreshControl 
-            refreshing={refreshing} 
-            onRefresh={refresh} 
-            tintColor="#6366f1"
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={refresh}
+            tintColor={colors.primary[500]}
           />
         }
         ListHeaderComponent={
-          <View style={styles.header}>
-            <Text style={styles.title}>Meu Estoque</Text>
-            <Text style={styles.subtitle}>
-              Acompanhe o estoque de seus remédios
-            </Text>
+          <View>
+            <View style={styles.header}>
+              <Text style={styles.title}>Meu Estoque</Text>
+              <Text style={styles.subtitle}>
+                Acompanhe o estoque de seus remédios
+              </Text>
+            </View>
+            <StockFilterChips value={filter} onChange={setFilter} counts={counts} />
           </View>
         }
         ListEmptyComponent={
-          <EmptyState 
-            message="Você não possui medicamentos cadastrados ou estoque registrado." 
+          <EmptyState
+            message="Você não possui medicamentos cadastrados ou estoque registrado."
           />
         }
+      />
+
+      {/* FAB ubíquo (PO-2) — abre seletor de medicamento p/ registrar compra */}
+      <Pressable
+        onPress={() => setSheetVisible(true)}
+        style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
+        accessibilityRole="button"
+        accessibilityLabel="Registrar compra"
+      >
+        <Plus size={28} color={colors.text.inverse} />
+      </Pressable>
+
+      <PurchaseMedicineSheet
+        visible={sheetVisible}
+        onClose={() => setSheetVisible(false)}
+        onSelect={handleSelectMedicine}
       />
     </ScreenContainer>
   )
@@ -96,12 +189,12 @@ export default function StockScreen() {
 
 const styles = StyleSheet.create({
   listContent: {
-    paddingBottom: 40
+    paddingBottom: spacing[12],
   },
   header: {
-    paddingHorizontal: 20,
-    paddingVertical: 16,
-    marginBottom: 8,
+    paddingHorizontal: spacing[5],
+    paddingVertical: spacing[4],
+    marginBottom: spacing[2],
   },
   title: {
     fontSize: 28,
@@ -113,19 +206,37 @@ const styles = StyleSheet.create({
   subtitle: {
     fontSize: 16,
     color: colors.text.secondary,
-    marginTop: 4,
+    marginTop: spacing[1],
     fontFamily: typography.fontFamily.medium || 'System',
   },
+  itemPressed: {
+    opacity: 0.7,
+  },
   sectionHeader: {
-    paddingHorizontal: 20,
-    paddingVertical: 12,
-    backgroundColor: '#f9fafb'
+    paddingHorizontal: spacing[5],
+    paddingVertical: spacing[3],
+    backgroundColor: colors.neutral[50],
   },
   sectionTitle: {
     fontSize: 13,
     fontWeight: '700',
-    color: '#6b7280',
+    color: colors.text.secondary,
     textTransform: 'uppercase',
-    letterSpacing: 0.5
-  }
+    letterSpacing: 0.5,
+  },
+  fab: {
+    position: 'absolute',
+    bottom: spacing[6],
+    right: spacing[5],
+    width: 56,
+    height: 56,
+    borderRadius: borderRadius.full,
+    backgroundColor: colors.primary[500],
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...shadows.md,
+  },
+  fabPressed: {
+    opacity: 0.9,
+  },
 })

--- a/apps/mobile/src/features/stock/screens/StockScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockScreen.jsx
@@ -18,6 +18,14 @@ import StaleBanner from '@shared/components/feedback/StaleBanner'
 import { colors, spacing, borderRadius, shadows, typography } from '@shared/styles/tokens'
 import { ROUTES } from '@navigation/routes'
 
+// Mensagem contextual do empty state por filtro (evita "nenhum cadastrado"
+// quando na verdade há meds, mas nenhum bate o filtro aplicado).
+const FILTER_EMPTY_LABEL = {
+  critico: 'em estado crítico',
+  baixo: 'com estoque baixo',
+  sem_tratamento: 'sem tratamento ativo',
+}
+
 /**
  * Tela principal de Gerenciamento de Estoque (H5.5).
  */
@@ -162,9 +170,17 @@ export default function StockScreen() {
           </View>
         }
         ListEmptyComponent={
-          <EmptyState
-            message="Nenhum medicamento cadastrado ou estoque registrado."
-          />
+          filter === 'todos' ? (
+            <EmptyState
+              icon="💊"
+              message="Nenhum medicamento cadastrado ou estoque registrado."
+            />
+          ) : (
+            <EmptyState
+              icon="🔍"
+              message={`Nenhum medicamento ${FILTER_EMPTY_LABEL[filter]}.`}
+            />
+          )
         }
         ListFooterComponent={
           active.length > 0 ? (

--- a/apps/mobile/src/features/stock/services/stockService.js
+++ b/apps/mobile/src/features/stock/services/stockService.js
@@ -185,6 +185,25 @@ export const stockService = {
   },
 
   /**
+   * Mapa medicineId → total_quantity de todos os meds do usuário (bulk).
+   * Usado pelo PurchaseMedicineSheet pra exibir saldo sem N queries.
+   * @returns {Promise<Record<string, number>>}
+   */
+  async getStockSummaryMap(userId) {
+    z.string().uuid().parse(userId)
+    const { data, error } = await nativeSupabaseClient
+      .from('medicine_stock_summary')
+      .select('medicine_id, total_quantity')
+      .eq('user_id', userId)
+
+    if (error) throw error
+    return (data || []).reduce((map, row) => {
+      map[row.medicine_id] = row.total_quantity ?? 0
+      return map
+    }, {})
+  },
+
+  /**
    * Total quantity (com fallback manual caso view não retorne).
    */
   async getTotalQuantity(medicineId, userId) {

--- a/apps/mobile/src/features/stock/services/stockService.js
+++ b/apps/mobile/src/features/stock/services/stockService.js
@@ -28,6 +28,11 @@ import { debugLog, errorLog } from '@shared/utils/debugLog'
 // ───────────────────────────────────────────────────────────────────────────
 
 /**
+ * @deprecated PO-9 §0.7 — filtra `protocols.active=true` no servidor e esconde
+ * meds com estoque órfão. Substituído por
+ * `stockService.getMedicinesWithStockOrActiveProtocol`. Remover em fix-pack
+ * pós-Fase 3 (sem callers após Wave 4).
+ *
  * Busca medicamentos com estoque + protocolos ativos pra cálculo de consumo.
  * @param {string} userId
  * @returns {Promise<{success: boolean, data?: Array, error?: string}>}
@@ -89,6 +94,55 @@ function fmtZodErr(errors) {
 
 export const stockService = {
   // === READS ===
+
+  /**
+   * Medicamentos do hub de estoque (PO-9 §0.7): lista quem tem protocolo ativo
+   * HOJE OU saldo positivo. Corrige bug de produção do getStockData legacy, que
+   * filtrava `protocols.active=true` no servidor e escondia meds com estoque
+   * órfão (sem treatment / treatment finalizado / treatment pausado).
+   *
+   * NÃO filtra protocols.active no servidor — atividade é avaliada no client
+   * via isProtocolActiveOnDate, e a inclusão considera também totalStock > 0.
+   *
+   * @returns {Promise<Array>} medicines crus (medicine_stock_summary + protocols)
+   */
+  async getMedicinesWithStockOrActiveProtocol(userId) {
+    z.string().uuid().parse(userId)
+    const { data, error } = await nativeSupabaseClient
+      .from('medicines')
+      .select(`
+        id,
+        name,
+        laboratory,
+        dosage_unit,
+        dosage_per_pill,
+        medicine_stock_summary!left (
+          total_quantity
+        ),
+        protocols (
+          id,
+          dosage_per_intake,
+          time_schedule,
+          frequency,
+          active,
+          start_date,
+          end_date
+        )
+      `)
+      .eq('user_id', userId)
+      .order('name')
+
+    if (error) throw error
+
+    const today = getTodayLocal()
+    return (data || []).filter((m) => {
+      const hasActiveProtocol = (m.protocols || []).some(
+        (p) => p.active && isProtocolActiveOnDate(p, today),
+      )
+      const totalStock = m.medicine_stock_summary?.[0]?.total_quantity ?? 0
+      return hasActiveProtocol || totalStock > 0
+    })
+  },
 
   /**
    * Stock entries de um medicamento (FIFO order).

--- a/apps/mobile/src/features/stock/services/stockService.js
+++ b/apps/mobile/src/features/stock/services/stockService.js
@@ -321,8 +321,11 @@ export const stockService = {
   },
 
   /**
-   * Edita uma purchase existente. Sem RPC dedicada na web — update direto na
-   * tabela purchases. NÃO mexe em stock (saldo é decremento via consume_stock).
+   * Edita uma purchase existente — APENAS metadados (preço, datas, farmácia,
+   * lab, notas). NÃO altera `quantity_bought`: a quantidade está amarrada ao
+   * lote em `stock` (saldo + FIFO) e qualquer correção de saldo passa pelo
+   * fluxo dedicado "Acertar saldo" (PO-6). Editar quantidade aqui causaria
+   * desync silencioso (sem trigger no DB que propague).
    */
   async updatePurchase(id, input, userId) {
     const validation = validateStockCreate(input)
@@ -332,7 +335,6 @@ export const stockService = {
     const { data, error } = await nativeSupabaseClient
       .from('purchases')
       .update({
-        quantity_bought: p.quantity,
         unit_price: p.unit_price ?? 0,
         purchase_date: p.purchase_date,
         expiration_date: p.expiration_date,

--- a/apps/mobile/src/features/stock/services/stockService.js
+++ b/apps/mobile/src/features/stock/services/stockService.js
@@ -255,16 +255,22 @@ export const stockService = {
    * Histórico de compras de um medicamento.
    */
   async getPurchasesByMedicine(medicineId, userId) {
+    // Embed do lote em `stock` (FK stock.purchase_id → purchases.id) pra expor o
+    // saldo restante de cada compra. `remaining` = soma das entries do lote
+    // (normalmente 1). Sem isso o PurchaseCard mostrava sempre "0 restantes".
     const { data, error } = await nativeSupabaseClient
       .from('purchases')
-      .select('*')
+      .select('*, stock(quantity)')
       .eq('medicine_id', medicineId)
       .eq('user_id', userId)
       .order('purchase_date', { ascending: false })
       .order('created_at', { ascending: false })
 
     if (error) throw error
-    return data || []
+    return (data || []).map((p) => ({
+      ...p,
+      remaining: (p.stock || []).reduce((acc, s) => acc + (Number(s.quantity) || 0), 0),
+    }))
   },
 
   /**
@@ -326,7 +332,7 @@ export const stockService = {
     const { data, error } = await nativeSupabaseClient
       .from('purchases')
       .update({
-        quantity: p.quantity,
+        quantity_bought: p.quantity,
         unit_price: p.unit_price ?? 0,
         purchase_date: p.purchase_date,
         expiration_date: p.expiration_date,

--- a/apps/mobile/src/features/treatments/hooks/useTreatments.js
+++ b/apps/mobile/src/features/treatments/hooks/useTreatments.js
@@ -20,6 +20,7 @@ export function useTreatments() {
   // States (R-010: states first)
   const [data, setData] = useState(null)
   const [loading, setLoading] = useState(true)
+  const [hasLoaded, setHasLoaded] = useState(false)
   const [error, setError] = useState(null)
   const [stale, setStale] = useState(false)
   const [activeTab, setActiveTab] = useState('ativos')
@@ -79,6 +80,10 @@ export function useTreatments() {
       }
     } finally {
       setLoading(false)
+      // Marca que a 1ª resolução terminou (sucesso/cache/erro). Gate de UI usa
+      // isto pra evitar flash do empty state antes dos dados chegarem (groups
+      // é sempre array, então `!groups` nunca pegava o load inicial).
+      setHasLoaded(true)
     }
   }, [])
 
@@ -138,6 +143,7 @@ export function useTreatments() {
     // shape legado — compat com callsites existentes
     data: transformed.data,
     loading,
+    hasLoaded,
     error,
     stale,
     refresh: load,
@@ -150,7 +156,7 @@ export function useTreatments() {
     finalizados: transformed.finalizados ?? [],
     groups: transformed.groups ?? [],
     currentItems,
-  }), [transformed, loading, error, stale, load, activeTab, currentItems])
+  }), [transformed, loading, hasLoaded, error, stale, load, activeTab, currentItems])
 
   return result
 }

--- a/apps/mobile/src/features/treatments/screens/TreatmentsScreen.jsx
+++ b/apps/mobile/src/features/treatments/screens/TreatmentsScreen.jsx
@@ -27,6 +27,7 @@ export default function TreatmentsScreen() {
   const {
     groups,
     loading,
+    hasLoaded,
     error,
     stale,
     refresh,
@@ -90,10 +91,10 @@ export default function TreatmentsScreen() {
     })
   }, [])
 
-  if (loading && !groups) {
+  if (!hasLoaded) {
     return (
       <ScreenContainer>
-        <LoadingState message="Carregando seus tratamentos..." />
+        <LoadingState message="Carregando tratamentos..." />
       </ScreenContainer>
     )
   }

--- a/apps/mobile/src/features/treatments/screens/__tests__/TreatmentsScreen.test.jsx
+++ b/apps/mobile/src/features/treatments/screens/__tests__/TreatmentsScreen.test.jsx
@@ -16,6 +16,7 @@ describe('TreatmentsScreen', () => {
   // Helper: shape Fase 2.5 do useTreatments (activeTab + counts + grupos + listas per-tab)
   const mockUseTreatments = (overrides = {}) => ({
     loading: false,
+    hasLoaded: true,
     error: null,
     stale: false,
     refresh: jest.fn(),
@@ -32,9 +33,9 @@ describe('TreatmentsScreen', () => {
   })
 
   it('renders loading state', () => {
-    useTreatments.mockReturnValue(mockUseTreatments({ loading: true, groups: null, data: null }));
+    useTreatments.mockReturnValue(mockUseTreatments({ loading: true, hasLoaded: false, groups: null, data: null }));
     const { getByText } = render(<TreatmentsScreen />);
-    expect(getByText(/Carregando seus tratamentos/i)).toBeTruthy();
+    expect(getByText(/Carregando tratamentos/i)).toBeTruthy();
   });
 
   it('renders list of treatments when data exists', () => {

--- a/apps/mobile/src/navigation/StockStack.jsx
+++ b/apps/mobile/src/navigation/StockStack.jsx
@@ -8,6 +8,7 @@
 import { createStackNavigator } from '@react-navigation/stack'
 import { ROUTES } from './routes'
 import StockScreen from '../features/stock/screens/StockScreen'
+import StockDetailScreen from '../features/stock/screens/StockDetailScreen'
 import PurchaseFormScreen from '../features/stock/screens/PurchaseFormScreen'
 import PurchaseHistoryScreen from '../features/stock/screens/PurchaseHistoryScreen'
 
@@ -17,6 +18,7 @@ export default function StockStack() {
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
       <Stack.Screen name={ROUTES.STOCK_MAIN} component={StockScreen} />
+      <Stack.Screen name={ROUTES.STOCK_DETAIL} component={StockDetailScreen} />
       <Stack.Screen name={ROUTES.PURCHASE_FORM} component={PurchaseFormScreen} />
       <Stack.Screen name={ROUTES.PURCHASE_HISTORY} component={PurchaseHistoryScreen} />
     </Stack.Navigator>

--- a/apps/mobile/src/shared/hooks/useFormState.js
+++ b/apps/mobile/src/shared/hooks/useFormState.js
@@ -10,6 +10,9 @@ import { useCallback, useMemo, useState } from 'react'
 
 const EMPTY = Object.freeze({})
 
+// Sentinel para distinguir "sem override" de "override undefined" no handleBlur.
+const NO_OVERRIDE = Symbol('no-override')
+
 const deepEqual = (a, b) => {
   if (a === b) return true
   // Date precisa de comparação por valor (getTime) — Object.keys(Date) retorna []
@@ -58,10 +61,14 @@ export function useFormState(schema, { initialValues = EMPTY } = {}) {
     })
   }, [])
 
+  // valueOverride (opcional): valor coercido pra validar no lugar do raw em
+  // values[field]. Necessário p/ campos decimais PT-BR que guardam string até o
+  // submit (ex: "0,437") mas precisam validar como number no blur (AP-167).
   const handleBlur = useCallback(
-    (field) => {
+    (field, valueOverride = NO_OVERRIDE) => {
       setTouched((prev) => (prev[field] ? prev : { ...prev, [field]: true }))
-      const msg = validateField(schema, field, values[field], values)
+      const value = valueOverride === NO_OVERRIDE ? values[field] : valueOverride
+      const msg = validateField(schema, field, value, { ...values, [field]: value })
       setErrors((prev) => {
         if (msg) return { ...prev, [field]: msg }
         if (!prev[field]) return prev

--- a/packages/core/src/utils/stock.js
+++ b/packages/core/src/utils/stock.js
@@ -63,9 +63,11 @@ export function resolveStockStatus(qty, dailyConsumption, nearestExpiryYYYYMM = 
 /**
  * computeAverageUnitPrice — preco medio ponderado pela quantidade comprada.
  *
- * Ignora compras com `quantity <= 0` ou `unit_price` ausente/nulo.
+ * Ignora compras com quantidade <= 0 ou `unit_price` ausente/nulo.
+ * Aceita `quantity_bought` (coluna canônica da tabela purchases) ou `quantity`
+ * (contrato de input do form/schema) — o que estiver presente.
  *
- * @param {Array<{quantity: number, unit_price: number}>} purchases
+ * @param {Array<{quantity_bought?: number, quantity?: number, unit_price: number}>} purchases
  * @returns {number} preco medio (0 se nao houver compras validas)
  */
 export function computeAverageUnitPrice(purchases) {
@@ -74,7 +76,7 @@ export function computeAverageUnitPrice(purchases) {
   let totalCost = 0
   let totalQty = 0
   for (const p of purchases) {
-    const qty = Number(p?.quantity) || 0
+    const qty = Number(p?.quantity_bought ?? p?.quantity) || 0
     // Rejeitar explicitamente null/undefined ANTES de Number() —
     // Number(null) === 0 (finito) escaparia o filtro de isFinite.
     if (p?.unit_price == null || qty <= 0) continue


### PR DESCRIPTION
## Summary

Wave 4 do Sprint S3.1 — UI do hub de estoque + correção do bug de listagem em produção (PO-9), mais um ciclo extenso de fixes de smoke do PO.

**Data-layer (PO-9 §0.7):** hub agora lista medicamentos com `hasActiveProtocol || totalStock > 0` — corrige bug de produção onde meds com estoque órfão (sem treatment / finalizado / pausado) ficavam invisíveis. `getStockData` legacy marcado `@deprecated`.

**Telas/componentes:**
- **StockScreen** (hub): listagem PO-9, chips de filtro (Todos/Crítico/Baixo/Sem tratamento + counts), FAB ubíquo → PurchaseMedicineSheet → form, footer de estimativa, empty state contextual por filtro, refresh on focus.
- **StockDetailScreen** (NOVO): header + saldo + histórico + FAB registrar compra (KPI grid fica p/ S2.1).
- **StockFilterChips** (NOVO).
- **StockStack**: registra STOCK_DETAIL.

**Fixes de smoke (PO):**
- PurchaseMedicineSheet exibia saldo 0 pra todos → bulk `getStockSummaryMap`.
- Blur de quantity/unit_price acusava "Use apenas números" indevido (decimal PT-BR string vs z.number) → handleBlur com coerção opcional.
- Laboratório travado p/ marca (Novo/Similar).
- Terminologia UI: removido "protocolo" + pronomes possessivos (regra PO 2026-05-15).
- Flash do empty state na aba Tratamentos (gate hasLoaded).
- Histórico/detalhe: saldo restante (embed lote), custo médio (quantity_bought), qty no edit, botão voltar, card de contexto do medicamento.
- Validade legível (data p/ >60d em vez de "vence em 680 dias").
- Loop "Maximum update depth" (refresh estável no useStock).
- Edição de compra não altera quantidade (evita desync de saldo — correção via Acertar saldo PO-6).

Schema validado em produção via Supabase MCP (purchases.quantity_bought, stock.quantity/purchase_id, FK).

## Test plan

- [ ] Smoke PO em device físico (validado ✅ pelo PO antes do PR)
- [ ] Hub lista meds com estoque órfão (sem treatment / pausado / finalizado)
- [ ] Chips filtram + counts corretos + empty state contextual
- [ ] FAB → sheet (saldos reais) → form create → volta → lista atualiza sozinha
- [ ] Detalhe: saldo + histórico + FAB
- [ ] Histórico: card de contexto + saldo restante + custo médio + voltar + editar
- [ ] Form: decimal PT-BR, lab travado p/ marca, qty travada no edit
- [ ] Reload Expo sem loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## AI Review Response

| Sugestxc3xa3o | Prioridade | Decisxc3xa3o | Motivo |
|----------|-----------|---------|--------|
| Simplificar fetchSummary p/ getTotalQuantity (StockDetail) | Medium | Applied | bdc227a2 xe2x80x94 getTotalQuantity jxc3xa1 tem fallback interno |
| Ordem hooks + setTimeout(0) + handleChange dep (PurchaseForm) | Medium | Partial | bdc227a2 xe2x80x94 aplicado handleChange nas deps (remove eslint-disable); setTimeout(0) desnecessxc3xa1rio (setState async no .then); reorder declinado (R-010 = Effects antes de Handlers) |
