### PR TITLE
feat(stock): S3.2 parte 1 — Indicadores (KPI) + Ajuste de saldo (PO-6) + migration

### DIFF
--- a/apps/mobile/src/features/stock/components/StockIndicators.jsx
+++ b/apps/mobile/src/features/stock/components/StockIndicators.jsx
@@ -1,0 +1,131 @@
+// StockIndicators.jsx — KPI grid 2×2 do detalhe de estoque (S2.1 Fase 3)
+// R-010: sem hooks complexos (componente de apresentação puro)
+// ADR-028: StyleSheet canônico · ADR-023: fontWeight >= 400
+//
+// Layout: 2 colunas (flexWrap), cada card flexBasis ~48%.
+//   [ Saldo          | Consumo / dia ]
+//   [ Dias restantes | Custo médio   ]
+
+import { View, Text, StyleSheet } from 'react-native'
+import { Package, TrendingDown, Clock, Tag } from 'lucide-react-native'
+import { formatBRL } from '@dosiq/core'
+import { colors, spacing, borderRadius, shadows } from '@shared/styles/tokens'
+
+/**
+ * Grid de indicadores (KPIs) do estoque de um medicamento.
+ *
+ * @param {{
+ *   saldo: number,                 // saldo total em unidades
+ *   dailyConsumption: number,      // consumo diário (un./dia)
+ *   daysRemaining: number|null,    // dias restantes (null = sem consumo)
+ *   avgUnitPrice: number,          // custo médio ponderado por unidade
+ * }} props
+ */
+export default function StockIndicators({
+  saldo = 0,
+  dailyConsumption = 0,
+  daysRemaining = null,
+  avgUnitPrice = 0,
+}) {
+  // Cor de alerta para "Dias restantes": <7 vermelho · <14 amarelo · senão neutro.
+  const daysColor =
+    daysRemaining == null
+      ? colors.text.primary
+      : daysRemaining < 7
+        ? colors.status.error
+        : daysRemaining < 14
+          ? colors.status.warning
+          : colors.text.primary
+
+  return (
+    <View style={styles.grid}>
+      <Kpi
+        icon={<Package size={18} color={colors.primary[700]} />}
+        label="Saldo"
+        value={String(saldo)}
+        suffix="un."
+      />
+      <Kpi
+        icon={<TrendingDown size={18} color={colors.primary[700]} />}
+        label="Consumo / dia"
+        value={String(dailyConsumption)}
+        suffix="un."
+      />
+      <Kpi
+        icon={<Clock size={18} color={colors.primary[700]} />}
+        label="Dias restantes"
+        value={daysRemaining == null ? '—' : String(daysRemaining)}
+        suffix={daysRemaining == null ? null : 'dias'}
+        valueColor={daysColor}
+      />
+      <Kpi
+        icon={<Tag size={18} color={colors.primary[700]} />}
+        label="Custo médio"
+        value={formatBRL(avgUnitPrice)}
+        suffix="/ un."
+      />
+    </View>
+  )
+}
+
+function Kpi({ icon, label, value, suffix, valueColor }) {
+  return (
+    <View style={styles.card}>
+      <View style={styles.iconWrap}>{icon}</View>
+      <Text style={styles.label}>{label}</Text>
+      <View style={styles.valueRow}>
+        <Text style={[styles.value, valueColor && { color: valueColor }]}>
+          {value}
+        </Text>
+        {suffix ? <Text style={styles.suffix}>{suffix}</Text> : null}
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing[3],
+  },
+  card: {
+    flexGrow: 1,
+    flexBasis: '47%',
+    backgroundColor: colors.bg.card,
+    borderRadius: borderRadius.lg,
+    padding: spacing[4],
+    gap: spacing[2],
+    ...shadows.sm,
+  },
+  iconWrap: {
+    width: 32,
+    height: 32,
+    borderRadius: borderRadius.sm,
+    backgroundColor: colors.primary[50],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: colors.text.secondary,
+  },
+  valueRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: spacing[1],
+    flexWrap: 'wrap',
+  },
+  value: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: colors.text.primary,
+    letterSpacing: -0.3,
+  },
+  suffix: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: colors.text.muted,
+  },
+})

--- a/apps/mobile/src/features/stock/screens/StockAdjustmentScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockAdjustmentScreen.jsx
@@ -1,0 +1,383 @@
+// StockAdjustmentScreen.jsx — tela "Acertar saldo" (PO-6, S2.2 Fase 3).
+//
+// Modo ÚNICO "Acertar saldo": usuário digita o saldo final desejado (newBalance,
+// inteiro >= 0, un.). O delta (newBalance - currentBalance) é calculado e mostrado
+// no preview "APÓS AJUSTE". NÃO há segmented control +/− (PO-6).
+//
+// route.params: { medicineId, medicineName, currentBalance }
+//   currentBalance pode vir do StockDetail; se ausente, busca via getTotalQuantity.
+//
+// Contratos:
+//   useStockMutation().adjustBalance(medicineId, newBalance, reason, notes)
+//     → Promise<{delta, before, after}>; já dá toast e lança em erro.
+//   stockService.getTotalQuantity(medicineId, userId) → number.
+//   useAuth() → user?.id.
+//
+// R-010: States → Memos → Effects → Handlers
+// ADR-028: StyleSheet. ADR-023: fontWeights >= 400. ADR-046: unidade(s) no texto.
+
+import { useCallback, useMemo, useState } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+  KeyboardAvoidingView,
+  Platform,
+  StyleSheet,
+} from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useNavigation, useRoute, useFocusEffect } from '@react-navigation/native'
+import { ChevronLeft, Package } from 'lucide-react-native'
+import FormInput from '@shared/components/form/FormInput'
+import FormSelect from '@shared/components/form/FormSelect'
+import FormSection from '@shared/components/form/FormSection'
+import FormActions from '@shared/components/form/FormActions'
+import { useStockMutation } from '@stock/hooks/useStockMutation'
+import { stockService } from '@stock/services/stockService'
+import { useAuth } from '@platform/auth/hooks/useAuth'
+import { colors, spacing, typography, borderRadius } from '@shared/styles/tokens'
+
+// Motivos de ajuste — value enviado ao service, label exibido no dropdown.
+const REASON_OPTIONS = [
+  { value: 'perda', label: 'Perda' },
+  { value: 'doacao', label: 'Doação a terceiros' },
+  { value: 'descarte', label: 'Descarte' },
+  { value: 'vencimento_manual', label: 'Vencimento' },
+  { value: 'correcao_erro', label: 'Correção de erro' },
+  { value: 'outro', label: 'Outro' },
+]
+
+// Aceita apenas dígitos (saldo é inteiro de unidades).
+function sanitizeInt(raw) {
+  return String(raw ?? '').replace(/[^0-9]/g, '')
+}
+
+export default function StockAdjustmentScreen() {
+  // States (R-010 — States → Memos → Effects → Handlers)
+  const navigation = useNavigation()
+  const route = useRoute()
+  const { user } = useAuth()
+  const { adjustBalance } = useStockMutation()
+
+  const { medicineId, medicineName, currentBalance: paramBalance } = route.params ?? {}
+
+  const [currentBalance, setCurrentBalance] = useState(
+    typeof paramBalance === 'number' ? paramBalance : null,
+  )
+  const [newBalance, setNewBalance] = useState('')
+  const [reason, setReason] = useState('')
+  const [notes, setNotes] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  // Memos
+  const parsedNew = useMemo(() => {
+    if (newBalance === '') return null
+    const n = Number(newBalance)
+    return Number.isFinite(n) ? n : null
+  }, [newBalance])
+
+  const delta = useMemo(() => {
+    if (parsedNew == null || currentBalance == null) return null
+    return parsedNew - currentBalance
+  }, [parsedNew, currentBalance])
+
+  const canConfirm = useMemo(
+    () =>
+      !submitting &&
+      currentBalance != null &&
+      parsedNew != null &&
+      parsedNew >= 0 &&
+      delta !== 0 &&
+      reason !== '',
+    [submitting, currentBalance, parsedNew, delta, reason],
+  )
+
+  // Effects — busca saldo atual se não veio por param (callback sync; setState
+  // dentro do .then = microtask, não dispara set-state-in-effect).
+  useFocusEffect(
+    useCallback(() => {
+      if (currentBalance != null || !medicineId || !user?.id) return
+      let cancelled = false
+      stockService
+        .getTotalQuantity(medicineId, user.id)
+        .then((total) => {
+          if (!cancelled && typeof total === 'number') setCurrentBalance(total)
+        })
+        .catch(() => {})
+      return () => {
+        cancelled = true
+      }
+    }, [currentBalance, medicineId, user]),
+  )
+
+  // Handlers
+  const handleNewBalanceChange = useCallback((_name, raw) => {
+    setNewBalance(sanitizeInt(raw))
+  }, [])
+
+  const handleReasonChange = useCallback((_name, value) => {
+    setReason(value)
+  }, [])
+
+  const handleNotesChange = useCallback((_name, value) => {
+    setNotes(value)
+  }, [])
+
+  const goBack = useCallback(() => navigation.goBack(), [navigation])
+
+  const handleConfirm = useCallback(async () => {
+    if (parsedNew == null || parsedNew < 0 || delta === 0 || reason === '') return
+    setSubmitting(true)
+    try {
+      await adjustBalance(medicineId, Number(parsedNew), reason, notes || null)
+      navigation.goBack()
+    } catch {
+      // Hook já mostrou toast de erro; mantém usuário na tela para corrigir.
+    } finally {
+      setSubmitting(false)
+    }
+  }, [parsedNew, delta, reason, notes, adjustBalance, medicineId, navigation])
+
+  // Preview "APÓS AJUSTE" — cor do delta: verde se positivo, vermelho se negativo.
+  const deltaPositive = delta != null && delta > 0
+  const deltaLabel =
+    delta != null ? `(${delta > 0 ? '+' : ''}${delta})` : ''
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top']}>
+      {/* Header */}
+      <View style={styles.header}>
+        <Pressable
+          onPress={goBack}
+          style={styles.headerBtn}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel="Voltar"
+        >
+          <ChevronLeft size={24} color={colors.text.primary} />
+        </Pressable>
+        <Text style={styles.title}>Ajustar saldo</Text>
+        <View style={styles.headerSpacer} />
+      </View>
+
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 60 : 0}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Card de contexto — medicamento + saldo atual */}
+          <View style={styles.contextCard}>
+            <View style={styles.contextIcon}>
+              <Package size={18} color={colors.primary[700]} strokeWidth={2} />
+            </View>
+            <View style={styles.contextInfo}>
+              <Text style={styles.contextName} numberOfLines={2}>
+                {medicineName ?? '—'}
+              </Text>
+              <Text style={styles.contextBalance}>
+                {currentBalance != null
+                  ? `Saldo atual: ${currentBalance} ${currentBalance === 1 ? 'unidade' : 'unidades'}`
+                  : 'Calculando saldo…'}
+              </Text>
+            </View>
+          </View>
+
+          {/* Novo saldo */}
+          <FormSection title="Ajuste">
+            <FormInput
+              name="newBalance"
+              label="Novo saldo (un.)"
+              required
+              placeholder="0"
+              keyboardType="number-pad"
+              maxLength={6}
+              value={newBalance}
+              onChange={handleNewBalanceChange}
+              helperText="Informe o saldo final desejado em unidades"
+            />
+
+            {/* Preview APÓS AJUSTE */}
+            {delta != null && (
+              <View style={styles.previewBox}>
+                <Text style={styles.previewLabel}>APÓS AJUSTE</Text>
+                <View style={styles.previewRow}>
+                  <Text style={styles.previewFrom}>{currentBalance}</Text>
+                  <Text style={styles.previewArrow}> → </Text>
+                  <Text style={styles.previewTo}>{parsedNew} un.</Text>
+                  {delta !== 0 && (
+                    <Text
+                      style={[
+                        styles.previewDelta,
+                        {
+                          color: deltaPositive
+                            ? colors.status.success
+                            : colors.status.error,
+                        },
+                      ]}
+                    >
+                      {' '}
+                      {deltaLabel}
+                    </Text>
+                  )}
+                </View>
+              </View>
+            )}
+
+            {/* Motivo (obrigatório) */}
+            <FormSelect
+              name="reason"
+              label="Motivo"
+              required
+              placeholder="Selecionar motivo"
+              options={REASON_OPTIONS}
+              value={reason}
+              onChange={handleReasonChange}
+            />
+
+            {/* Observações (opcional) */}
+            <FormInput
+              name="notes"
+              label="Observações"
+              placeholder="Detalhes do ajuste…"
+              helperText="Opcional"
+              multiline
+              numberOfLines={3}
+              maxLength={500}
+              value={notes}
+              onChange={handleNotesChange}
+            />
+          </FormSection>
+        </ScrollView>
+
+        {/* Sticky footer */}
+        <FormActions
+          primaryLabel="Confirmar ajuste"
+          onPrimary={handleConfirm}
+          primaryDisabled={!canConfirm}
+          primaryLoading={submitting}
+          secondaryLabel="Cancelar"
+          onSecondary={goBack}
+        />
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: colors.bg.screen,
+  },
+  flex: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[3],
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border.light,
+    backgroundColor: colors.bg.card,
+  },
+  headerBtn: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    flex: 1,
+    fontSize: 17,
+    fontWeight: '700',
+    color: colors.text.primary,
+    textAlign: 'center',
+    fontFamily: typography.fontFamily.bold,
+  },
+  headerSpacer: {
+    width: 40,
+  },
+  scroll: {
+    paddingHorizontal: spacing[5],
+    paddingTop: spacing[4],
+    paddingBottom: spacing[12],
+  },
+  // Card de contexto
+  contextCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    backgroundColor: colors.primary[50] ?? colors.bg.card,
+    borderWidth: 1.5,
+    borderColor: colors.border.light,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    marginBottom: spacing[6],
+  },
+  contextIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: borderRadius.full ?? 99,
+    backgroundColor: colors.bg.card,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  contextInfo: {
+    flex: 1,
+  },
+  contextName: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.text.primary,
+  },
+  contextBalance: {
+    fontSize: 13,
+    fontWeight: '400',
+    color: colors.text.secondary,
+    marginTop: 2,
+  },
+  // Preview APÓS AJUSTE
+  previewBox: {
+    backgroundColor: colors.primary[50] ?? colors.bg.card,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+  },
+  previewLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1,
+    color: colors.text.muted,
+    marginBottom: spacing[1],
+  },
+  previewRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+  },
+  previewFrom: {
+    fontSize: 15,
+    fontWeight: '400',
+    color: colors.text.muted,
+    textDecorationLine: 'line-through',
+  },
+  previewArrow: {
+    fontSize: 15,
+    fontWeight: '400',
+    color: colors.text.secondary,
+  },
+  previewTo: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.text.primary,
+  },
+  previewDelta: {
+    fontSize: 14,
+    fontWeight: '700',
+  },
+})

--- a/apps/mobile/src/features/stock/screens/StockAdjustmentScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockAdjustmentScreen.jsx
@@ -35,6 +35,7 @@ import FormSection from '@shared/components/form/FormSection'
 import FormActions from '@shared/components/form/FormActions'
 import { useStockMutation } from '@stock/hooks/useStockMutation'
 import { stockService } from '@stock/services/stockService'
+import { medicineService } from '@medications/services/medicineService'
 import { useAuth } from '@platform/auth/hooks/useAuth'
 import { colors, spacing, typography, borderRadius } from '@shared/styles/tokens'
 
@@ -65,6 +66,7 @@ export default function StockAdjustmentScreen() {
   const [currentBalance, setCurrentBalance] = useState(
     typeof paramBalance === 'number' ? paramBalance : null,
   )
+  const [medicine, setMedicine] = useState(null)
   const [newBalance, setNewBalance] = useState('')
   const [reason, setReason] = useState('')
   const [notes, setNotes] = useState('')
@@ -93,18 +95,26 @@ export default function StockAdjustmentScreen() {
     [submitting, currentBalance, parsedNew, delta, reason],
   )
 
-  // Effects — busca saldo atual se não veio por param (callback sync; setState
-  // dentro do .then = microtask, não dispara set-state-in-effect).
+  // Effects — busca medicine (dose pill da ficha) sempre + saldo atual se não
+  // veio por param. Callback sync; setState no .then = microtask (não dispara
+  // set-state-in-effect).
   useFocusEffect(
     useCallback(() => {
-      if (currentBalance != null || !medicineId || !user?.id) return
+      const userId = user?.id
+      if (!medicineId || !userId) return
       let cancelled = false
-      stockService
-        .getTotalQuantity(medicineId, user.id)
-        .then((total) => {
-          if (!cancelled && typeof total === 'number') setCurrentBalance(total)
-        })
+      medicineService
+        .getById(medicineId)
+        .then((med) => { if (!cancelled && med) setMedicine(med) })
         .catch(() => {})
+      if (currentBalance == null) {
+        stockService
+          .getTotalQuantity(medicineId, userId)
+          .then((total) => {
+            if (!cancelled && typeof total === 'number') setCurrentBalance(total)
+          })
+          .catch(() => {})
+      }
       return () => {
         cancelled = true
       }
@@ -138,6 +148,12 @@ export default function StockAdjustmentScreen() {
       setSubmitting(false)
     }
   }, [parsedNew, delta, reason, notes, adjustBalance, medicineId, navigation])
+
+  // Dose pill da ficha (sempre que houver medicine com dosagem).
+  const dosePill =
+    medicine?.dosage_per_pill != null
+      ? `${medicine.dosage_per_pill}${medicine.dosage_unit ?? ''}`
+      : null
 
   // Preview "APÓS AJUSTE" — cor do delta: verde se positivo, vermelho se negativo.
   const deltaPositive = delta != null && delta > 0
@@ -176,9 +192,16 @@ export default function StockAdjustmentScreen() {
               <Package size={18} color={colors.primary[700]} strokeWidth={2} />
             </View>
             <View style={styles.contextInfo}>
-              <Text style={styles.contextName} numberOfLines={2}>
-                {medicineName ?? '—'}
-              </Text>
+              <View style={styles.contextNameRow}>
+                <Text style={styles.contextName} numberOfLines={2}>
+                  {medicine?.name ?? medicineName ?? '—'}
+                </Text>
+                {dosePill ? (
+                  <View style={styles.dosePill}>
+                    <Text style={styles.dosePillText}>{dosePill}</Text>
+                  </View>
+                ) : null}
+              </View>
               <Text style={styles.contextBalance}>
                 {currentBalance != null
                   ? `Saldo atual: ${currentBalance} ${currentBalance === 1 ? 'unidade' : 'unidades'}`
@@ -193,7 +216,7 @@ export default function StockAdjustmentScreen() {
               name="newBalance"
               label="Novo saldo (un.)"
               required
-              placeholder="0"
+              placeholder={currentBalance != null ? String(currentBalance) : '0'}
               keyboardType="number-pad"
               maxLength={6}
               value={newBalance}
@@ -331,10 +354,30 @@ const styles = StyleSheet.create({
   contextInfo: {
     flex: 1,
   },
+  contextNameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    flexWrap: 'wrap',
+  },
   contextName: {
+    flexShrink: 1,
     fontSize: 15,
     fontWeight: '600',
     color: colors.text.primary,
+  },
+  dosePill: {
+    backgroundColor: colors.neutral[100],
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    borderRadius: 4,
+    borderWidth: 0.5,
+    borderColor: colors.neutral[300],
+  },
+  dosePillText: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: colors.text.secondary,
   },
   contextBalance: {
     fontSize: 13,

--- a/apps/mobile/src/features/stock/screens/StockAdjustmentScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockAdjustmentScreen.jsx
@@ -96,8 +96,10 @@ export default function StockAdjustmentScreen() {
   )
 
   // Effects — busca medicine (dose pill da ficha) sempre + saldo atual se não
-  // veio por param. Callback sync; setState no .then = microtask (não dispara
-  // set-state-in-effect).
+  // veio por param. NÃO depende de `currentBalance` (evita re-execução quando o
+  // saldo é setado); `needsBalance` deriva do param (estável). Callback sync;
+  // setState no .then = microtask (não dispara set-state-in-effect).
+  const needsBalance = typeof paramBalance !== 'number'
   useFocusEffect(
     useCallback(() => {
       const userId = user?.id
@@ -107,7 +109,7 @@ export default function StockAdjustmentScreen() {
         .getById(medicineId)
         .then((med) => { if (!cancelled && med) setMedicine(med) })
         .catch(() => {})
-      if (currentBalance == null) {
+      if (needsBalance) {
         stockService
           .getTotalQuantity(medicineId, userId)
           .then((total) => {
@@ -118,7 +120,7 @@ export default function StockAdjustmentScreen() {
       return () => {
         cancelled = true
       }
-    }, [currentBalance, medicineId, user]),
+    }, [medicineId, user, needsBalance]),
   )
 
   // Handlers

--- a/apps/mobile/src/features/stock/screens/StockDetailScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockDetailScreen.jsx
@@ -30,24 +30,11 @@ import { stockService } from '@stock/services/stockService'
 import { medicineService } from '@medications/services/medicineService'
 import PurchaseCard from '@stock/components/PurchaseCard'
 import StockIndicators from '@stock/components/StockIndicators'
+import StockLevelBadge from '@stock/components/StockLevelBadge'
 import { useAuth } from '@platform/auth/hooks/useAuth'
-import {
-  formatDoseUnit,
-  computeAverageUnitPrice,
-  resolveStockStatus,
-  STOCK_STATUS,
-} from '@dosiq/core'
+import { computeAverageUnitPrice } from '@dosiq/core'
 import { colors, spacing, borderRadius, shadows, typography } from '@shared/styles/tokens'
 import { ROUTES } from '@navigation/routes'
-
-// Label PT-BR + cor do chip por status (resolveStockStatus retorna lowercase).
-const STATUS_META = {
-  [STOCK_STATUS.CRITICO]: { label: 'CRÍTICO', color: colors.status.error, bg: '#fde8e8' },
-  [STOCK_STATUS.BAIXO]: { label: 'BAIXO', color: colors.supplement[700], bg: colors.supplement[50] },
-  [STOCK_STATUS.NORMAL]: { label: 'NORMAL', color: colors.primary[700], bg: colors.primary[50] },
-  [STOCK_STATUS.ALTO]: { label: 'ALTO', color: colors.status.success, bg: '#e6f6f3' },
-  [STOCK_STATUS.VENCIDO]: { label: 'VENCIDO', color: colors.status.error, bg: '#fde8e8' },
-}
 
 // Suplemento usa paridade visual laranja (igual web). Demais tipos = medicamento.
 const SUPPLEMENT_TYPES = new Set(['suplemento', 'supplement'])
@@ -82,10 +69,18 @@ export default function StockDetailScreen({ navigation }) {
     [saldo, dailyConsumption],
   )
 
-  const status = useMemo(
-    () => resolveStockStatus(saldo, dailyConsumption),
+  // Badge "saldo em dias" (mesmo da listagem — StockLevelBadge usa enum UPPERCASE
+  // + daysRemaining numérico; Infinity = sem consumo → "-- dias").
+  const badgeDays = useMemo(
+    () => (dailyConsumption > 0 ? saldo / dailyConsumption : Infinity),
     [saldo, dailyConsumption],
   )
+  const badgeStatus = useMemo(() => {
+    if (badgeDays < 7) return 'CRITICAL'
+    if (badgeDays < 14) return 'LOW'
+    if (badgeDays < 30) return 'NORMAL'
+    return 'HIGH'
+  }, [badgeDays])
 
   const isSupplement = useMemo(
     () => SUPPLEMENT_TYPES.has(medicine?.type),
@@ -167,7 +162,6 @@ export default function StockDetailScreen({ navigation }) {
     medicine?.dosage_per_pill != null
       ? `${medicine.dosage_per_pill}${medicine.dosage_unit ?? ''}`
       : null
-  const statusMeta = STATUS_META[status] ?? STATUS_META[STOCK_STATUS.NORMAL]
   const heroColor = isSupplement ? colors.supplement[500] : colors.primary[500]
   const heroBg = isSupplement ? colors.supplement[50] : colors.primary[50]
   const HeroIcon = isSupplement ? PillBottle : Pill
@@ -225,26 +219,16 @@ export default function StockDetailScreen({ navigation }) {
                     </View>
                   ) : null}
                 </View>
-                {medicine?.laboratory ? (
+                {medicine?.active_ingredient ? (
                   <Text style={styles.heroLab} numberOfLines={1}>
-                    {medicine.laboratory}
+                    {medicine.active_ingredient}
                   </Text>
                 ) : null}
-              </View>
-            </View>
-
-            {/* Card saldo total */}
-            <View style={styles.balanceCard}>
-              <Text style={styles.balanceLabel}>Saldo total</Text>
-              <View style={styles.balanceRow}>
-                <Text style={styles.balanceValue}>{formatDoseUnit(saldo)}</Text>
-                <View style={[styles.statusChip, { backgroundColor: statusMeta.bg }]}>
-                  <Text style={[styles.statusChipText, { color: statusMeta.color }]}>
-                    {daysRemaining != null
-                      ? `${statusMeta.label} · ${daysRemaining} dias`
-                      : statusMeta.label}
-                  </Text>
-                </View>
+                {dailyConsumption > 0 ? (
+                  <View style={styles.heroBadge}>
+                    <StockLevelBadge status={badgeStatus} daysRemaining={badgeDays} />
+                  </View>
+                ) : null}
               </View>
             </View>
 
@@ -395,45 +379,8 @@ const styles = StyleSheet.create({
     fontWeight: '400',
     color: colors.text.secondary,
   },
-  // Card saldo total
-  balanceCard: {
-    backgroundColor: colors.bg.card,
-    borderRadius: borderRadius.lg,
-    paddingHorizontal: spacing[5],
-    paddingVertical: spacing[5],
-    gap: spacing[3],
-    ...shadows.sm,
-  },
-  balanceLabel: {
-    fontSize: 13,
-    fontWeight: '600',
-    color: colors.text.secondary,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-  },
-  balanceRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: spacing[3],
-    flexWrap: 'wrap',
-  },
-  balanceValue: {
-    fontSize: 28,
-    fontWeight: '800',
-    color: colors.text.primary,
-    letterSpacing: -0.5,
-    fontFamily: typography.fontFamily.bold || 'System',
-  },
-  statusChip: {
-    paddingHorizontal: spacing[3],
-    paddingVertical: spacing[1],
-    borderRadius: borderRadius.full,
-  },
-  statusChipText: {
-    fontSize: 12,
-    fontWeight: '700',
-    letterSpacing: 0.5,
+  heroBadge: {
+    marginTop: spacing[1],
   },
   // Seções
   section: {

--- a/apps/mobile/src/features/stock/screens/StockDetailScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockDetailScreen.jsx
@@ -1,58 +1,119 @@
-// StockDetailScreen.jsx — detalhe de estoque de UM medicamento (S1.8 Wave 4)
+// StockDetailScreen.jsx — detalhe de estoque de UM medicamento (S2.1 Fase 3)
 // R-010: ordem hooks → States → Memos → Effects → Handlers (TDZ crítico)
 // ADR-028: StyleSheet canônico · ADR-023: fontWeight >= 400 · ADR-046: unidade(s)
 // PO-2: FAB ubíquo "Registrar compra" · PO-3: med travado (passamos medicineId)
 //
-// ESCOPO MÍNIMO Wave 4: header + card de saldo + histórico + FAB.
-// KPI grid fica para S2.1 (próximo sprint).
+// Estrutura (mock mock-estoque-detalhes):
+//   Header (voltar + nome + acertar saldo) → Card hero → Card saldo total
+//   → Indicadores (KPI grid 2×2) → Histórico (preview última compra) → FAB.
 
-import { useState, useCallback } from 'react'
+import { useState, useMemo, useCallback } from 'react'
 import {
   View,
   Text,
   Pressable,
   ActivityIndicator,
+  ScrollView,
   StyleSheet,
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useRoute, useFocusEffect } from '@react-navigation/native'
-import { ChevronLeft, Plus, History } from 'lucide-react-native'
+import {
+  ChevronLeft,
+  Plus,
+  Pill,
+  PillBottle,
+  SlidersHorizontal,
+} from 'lucide-react-native'
 import ScreenContainer from '@shared/components/ui/ScreenContainer'
 import { stockService } from '@stock/services/stockService'
+import { medicineService } from '@medications/services/medicineService'
+import PurchaseCard from '@stock/components/PurchaseCard'
+import StockIndicators from '@stock/components/StockIndicators'
 import { useAuth } from '@platform/auth/hooks/useAuth'
-import { formatDoseUnit } from '@dosiq/core'
+import {
+  formatDoseUnit,
+  computeAverageUnitPrice,
+  resolveStockStatus,
+  STOCK_STATUS,
+} from '@dosiq/core'
 import { colors, spacing, borderRadius, shadows, typography } from '@shared/styles/tokens'
 import { ROUTES } from '@navigation/routes'
+
+// Label PT-BR + cor do chip por status (resolveStockStatus retorna lowercase).
+const STATUS_META = {
+  [STOCK_STATUS.CRITICO]: { label: 'CRÍTICO', color: colors.status.error, bg: '#fde8e8' },
+  [STOCK_STATUS.BAIXO]: { label: 'BAIXO', color: colors.supplement[700], bg: colors.supplement[50] },
+  [STOCK_STATUS.NORMAL]: { label: 'NORMAL', color: colors.primary[700], bg: colors.primary[50] },
+  [STOCK_STATUS.ALTO]: { label: 'ALTO', color: colors.status.success, bg: '#e6f6f3' },
+  [STOCK_STATUS.VENCIDO]: { label: 'VENCIDO', color: colors.status.error, bg: '#fde8e8' },
+}
+
+// Suplemento usa paridade visual laranja (igual web). Demais tipos = medicamento.
+const SUPPLEMENT_TYPES = new Set(['suplemento', 'supplement'])
 
 /**
  * Detalhe de estoque de um medicamento.
  *
  * route.params:
- *   medicineId: string    (obrigatório)
- *   medicineName: string  (display no header)
+ *   medicineId: string         (obrigatório)
+ *   medicineName: string       (display imediato no header)
+ *   dailyConsumption: number   (consumo diário derivado do tratamento ativo)
  */
 export default function StockDetailScreen({ navigation }) {
   const route = useRoute()
-  const { medicineId, medicineName } = route.params ?? {}
+  const { medicineId, medicineName, dailyConsumption = 0 } = route.params ?? {}
   const { user } = useAuth()
 
   // — States (R-010) —
-  const [totalQuantity, setTotalQuantity] = useState(null)
+  const [saldo, setSaldo] = useState(0)
+  const [purchases, setPurchases] = useState([])
+  const [medicine, setMedicine] = useState(null)
   const [loading, setLoading] = useState(true)
+
+  // — Memos (R-010) —
+  const avgUnitPrice = useMemo(
+    () => computeAverageUnitPrice(purchases),
+    [purchases],
+  )
+
+  const daysRemaining = useMemo(
+    () => (dailyConsumption > 0 ? Math.ceil(saldo / dailyConsumption) : null),
+    [saldo, dailyConsumption],
+  )
+
+  const status = useMemo(
+    () => resolveStockStatus(saldo, dailyConsumption),
+    [saldo, dailyConsumption],
+  )
+
+  const isSupplement = useMemo(
+    () => SUPPLEMENT_TYPES.has(medicine?.type),
+    [medicine],
+  )
+
+  const latestPurchase = useMemo(() => purchases[0] ?? null, [purchases])
 
   // — Effects (R-010) —
   // SYNC callback obrigatório no useFocusEffect (NUNCA async direto — crash
   // "An effect function must not return anything besides a function").
-  const fetchSummary = useCallback(async () => {
+  const fetchDetail = useCallback(async () => {
     const userId = user?.id
     if (!medicineId || !userId) return
     setLoading(true)
     try {
-      // getTotalQuantity já resolve view medicine_stock_summary + fallback soma stock.
-      const qty = await stockService.getTotalQuantity(medicineId, userId)
-      setTotalQuantity(qty ?? 0)
+      const [qty, purchaseList, med] = await Promise.all([
+        stockService.getTotalQuantity(medicineId, userId),
+        stockService.getPurchasesByMedicine(medicineId, userId),
+        medicineService.getById(medicineId),
+      ])
+      setSaldo(qty ?? 0)
+      setPurchases(Array.isArray(purchaseList) ? purchaseList : [])
+      setMedicine(med ?? null)
     } catch {
-      setTotalQuantity(0)
+      setSaldo(0)
+      setPurchases([])
+      setMedicine(null)
     } finally {
       setLoading(false)
     }
@@ -60,8 +121,8 @@ export default function StockDetailScreen({ navigation }) {
 
   useFocusEffect(
     useCallback(() => {
-      fetchSummary()
-    }, [fetchSummary]),
+      fetchDetail()
+    }, [fetchDetail]),
   )
 
   // — Handlers (R-010) —
@@ -69,9 +130,29 @@ export default function StockDetailScreen({ navigation }) {
     navigation.goBack()
   }, [navigation])
 
+  const handleAdjust = useCallback(() => {
+    navigation.navigate(ROUTES.STOCK_ADJUSTMENT, {
+      medicineId,
+      medicineName,
+      currentBalance: saldo,
+    })
+  }, [navigation, medicineId, medicineName, saldo])
+
   const handleHistory = useCallback(() => {
     navigation.navigate(ROUTES.PURCHASE_HISTORY, { medicineId, medicineName })
   }, [navigation, medicineId, medicineName])
+
+  const handleEditPurchase = useCallback(
+    (purchaseId) => {
+      navigation.navigate(ROUTES.PURCHASE_FORM, {
+        mode: 'edit',
+        purchaseId,
+        medicineId,
+        medicineName,
+      })
+    },
+    [navigation, medicineId, medicineName],
+  )
 
   const handleRegisterPurchase = useCallback(() => {
     navigation.navigate(ROUTES.PURCHASE_FORM, {
@@ -81,6 +162,16 @@ export default function StockDetailScreen({ navigation }) {
     })
   }, [navigation, medicineId, medicineName])
 
+  const name = medicine?.name ?? medicineName ?? 'Medicamento'
+  const dosePill =
+    medicine?.dosage_per_pill != null
+      ? `${medicine.dosage_per_pill}${medicine.dosage_unit ?? ''}`
+      : null
+  const statusMeta = STATUS_META[status] ?? STATUS_META[STOCK_STATUS.NORMAL]
+  const heroColor = isSupplement ? colors.supplement[500] : colors.primary[500]
+  const heroBg = isSupplement ? colors.supplement[50] : colors.primary[50]
+  const HeroIcon = isSupplement ? PillBottle : Pill
+
   return (
     <ScreenContainer>
       <SafeAreaView edges={['top']} style={styles.flex}>
@@ -88,7 +179,7 @@ export default function StockDetailScreen({ navigation }) {
         <View style={styles.header}>
           <Pressable
             onPress={handleBack}
-            style={({ pressed }) => [styles.backBtn, pressed && styles.pressed]}
+            style={({ pressed }) => [styles.iconBtn, pressed && styles.pressed]}
             accessibilityRole="button"
             accessibilityLabel="Voltar"
             hitSlop={8}
@@ -96,34 +187,109 @@ export default function StockDetailScreen({ navigation }) {
             <ChevronLeft size={26} color={colors.text.primary} />
           </Pressable>
           <Text style={styles.headerTitle} numberOfLines={1}>
-            {medicineName ?? 'Medicamento'}
+            {name}
           </Text>
-        </View>
-
-        <View style={styles.content}>
-          {/* Card de saldo */}
-          <View style={styles.balanceCard}>
-            <Text style={styles.balanceLabel}>Saldo atual</Text>
-            {loading ? (
-              <ActivityIndicator size="small" color={colors.primary[500]} />
-            ) : (
-              <Text style={styles.balanceValue}>
-                {formatDoseUnit(totalQuantity ?? 0)}
-              </Text>
-            )}
-          </View>
-
-          {/* Histórico de compras */}
           <Pressable
-            onPress={handleHistory}
-            style={({ pressed }) => [styles.historyBtn, pressed && styles.pressed]}
+            onPress={handleAdjust}
+            style={({ pressed }) => [styles.iconBtn, pressed && styles.pressed]}
             accessibilityRole="button"
-            accessibilityLabel="Histórico de compras"
+            accessibilityLabel="Acertar saldo"
+            hitSlop={8}
           >
-            <History size={20} color={colors.primary[700]} />
-            <Text style={styles.historyText}>Histórico de compras</Text>
+            <SlidersHorizontal size={22} color={colors.text.primary} />
           </Pressable>
         </View>
+
+        {loading ? (
+          <View style={styles.loadingWrap}>
+            <ActivityIndicator size="large" color={colors.primary[500]} />
+          </View>
+        ) : (
+          <ScrollView
+            contentContainerStyle={styles.content}
+            showsVerticalScrollIndicator={false}
+          >
+            {/* Card hero */}
+            <View style={styles.heroCard}>
+              <View style={[styles.heroIcon, { backgroundColor: heroBg }]}>
+                <HeroIcon size={24} color={heroColor} />
+              </View>
+              <View style={styles.heroInfo}>
+                <View style={styles.heroNameRow}>
+                  <Text style={styles.heroName} numberOfLines={2}>
+                    {name}
+                  </Text>
+                  {dosePill ? (
+                    <View style={styles.dosePill}>
+                      <Text style={styles.dosePillText}>{dosePill}</Text>
+                    </View>
+                  ) : null}
+                </View>
+                {medicine?.laboratory ? (
+                  <Text style={styles.heroLab} numberOfLines={1}>
+                    {medicine.laboratory}
+                  </Text>
+                ) : null}
+              </View>
+            </View>
+
+            {/* Card saldo total */}
+            <View style={styles.balanceCard}>
+              <Text style={styles.balanceLabel}>Saldo total</Text>
+              <View style={styles.balanceRow}>
+                <Text style={styles.balanceValue}>{formatDoseUnit(saldo)}</Text>
+                <View style={[styles.statusChip, { backgroundColor: statusMeta.bg }]}>
+                  <Text style={[styles.statusChipText, { color: statusMeta.color }]}>
+                    {daysRemaining != null
+                      ? `${statusMeta.label} · ${daysRemaining} dias`
+                      : statusMeta.label}
+                  </Text>
+                </View>
+              </View>
+            </View>
+
+            {/* Indicadores */}
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>Indicadores</Text>
+              <StockIndicators
+                saldo={saldo}
+                dailyConsumption={dailyConsumption}
+                daysRemaining={daysRemaining}
+                avgUnitPrice={avgUnitPrice}
+              />
+            </View>
+
+            {/* Histórico de compras */}
+            <View style={styles.section}>
+              <View style={styles.sectionHeaderRow}>
+                <Text style={styles.sectionTitle}>Histórico de compras</Text>
+                {purchases.length > 0 ? (
+                  <Pressable
+                    onPress={handleHistory}
+                    style={({ pressed }) => pressed && styles.pressed}
+                    accessibilityRole="button"
+                    accessibilityLabel="Ver todas as compras"
+                    hitSlop={8}
+                  >
+                    <Text style={styles.linkText}>VER TODAS</Text>
+                  </Pressable>
+                ) : null}
+              </View>
+              {latestPurchase ? (
+                <PurchaseCard
+                  purchase={latestPurchase}
+                  remaining={latestPurchase.remaining ?? 0}
+                  isLatest
+                  onPress={() => handleEditPurchase(latestPurchase.id)}
+                />
+              ) : (
+                <Text style={styles.emptyText}>
+                  Nenhuma compra registrada ainda.
+                </Text>
+              )}
+            </View>
+          </ScrollView>
+        )}
 
         {/* FAB ubíquo (PO-2) — Registrar compra */}
         <Pressable
@@ -150,7 +316,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[4],
     paddingVertical: spacing[3],
   },
-  backBtn: {
+  iconBtn: {
     width: 36,
     height: 36,
     alignItems: 'center',
@@ -167,17 +333,75 @@ const styles = StyleSheet.create({
     letterSpacing: -0.3,
     fontFamily: typography.fontFamily.bold || 'System',
   },
+  loadingWrap: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   content: {
     paddingHorizontal: spacing[5],
     paddingTop: spacing[2],
+    paddingBottom: spacing[12],
     gap: spacing[4],
   },
+  // Card hero
+  heroCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    backgroundColor: colors.bg.card,
+    borderRadius: borderRadius.lg,
+    padding: spacing[4],
+    ...shadows.sm,
+  },
+  heroIcon: {
+    width: 48,
+    height: 48,
+    borderRadius: borderRadius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  heroInfo: {
+    flex: 1,
+    gap: spacing[1],
+  },
+  heroNameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    flexWrap: 'wrap',
+  },
+  heroName: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: colors.text.primary,
+    fontFamily: typography.fontFamily.bold || 'System',
+  },
+  dosePill: {
+    backgroundColor: colors.neutral[100],
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    borderRadius: 4,
+    borderWidth: 0.5,
+    borderColor: colors.neutral[300],
+  },
+  dosePillText: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: colors.text.secondary,
+  },
+  heroLab: {
+    fontSize: 14,
+    fontWeight: '400',
+    color: colors.text.secondary,
+  },
+  // Card saldo total
   balanceCard: {
     backgroundColor: colors.bg.card,
     borderRadius: borderRadius.lg,
     paddingHorizontal: spacing[5],
     paddingVertical: spacing[5],
-    gap: spacing[2],
+    gap: spacing[3],
     ...shadows.sm,
   },
   balanceLabel: {
@@ -187,6 +411,13 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     letterSpacing: 0.5,
   },
+  balanceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing[3],
+    flexWrap: 'wrap',
+  },
   balanceValue: {
     fontSize: 28,
     fontWeight: '800',
@@ -194,20 +425,42 @@ const styles = StyleSheet.create({
     letterSpacing: -0.5,
     fontFamily: typography.fontFamily.bold || 'System',
   },
-  historyBtn: {
+  statusChip: {
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[1],
+    borderRadius: borderRadius.full,
+  },
+  statusChipText: {
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+  },
+  // Seções
+  section: {
+    gap: spacing[3],
+  },
+  sectionHeaderRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: spacing[2],
-    paddingHorizontal: spacing[4],
-    paddingVertical: spacing[3],
-    borderRadius: borderRadius.md,
-    backgroundColor: colors.primary[50],
+    justifyContent: 'space-between',
   },
-  historyText: {
-    fontSize: 15,
+  sectionTitle: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: colors.text.primary,
+    fontFamily: typography.fontFamily.bold || 'System',
+  },
+  linkText: {
+    fontSize: 13,
     fontWeight: '700',
     color: colors.primary[700],
-    fontFamily: typography.fontFamily.bold || 'System',
+    letterSpacing: 0.5,
+  },
+  emptyText: {
+    fontSize: 14,
+    fontWeight: '400',
+    color: colors.text.muted,
+    fontStyle: 'italic',
   },
   fab: {
     position: 'absolute',

--- a/apps/mobile/src/features/stock/screens/StockScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockScreen.jsx
@@ -102,6 +102,7 @@ export default function StockScreen() {
       navigation.navigate(ROUTES.STOCK_DETAIL, {
         medicineId: item.id,
         medicineName: item.name,
+        dailyConsumption: item.dailyConsumption,
       })
     },
     [navigation],

--- a/apps/mobile/src/navigation/StockStack.jsx
+++ b/apps/mobile/src/navigation/StockStack.jsx
@@ -11,6 +11,7 @@ import StockScreen from '../features/stock/screens/StockScreen'
 import StockDetailScreen from '../features/stock/screens/StockDetailScreen'
 import PurchaseFormScreen from '../features/stock/screens/PurchaseFormScreen'
 import PurchaseHistoryScreen from '../features/stock/screens/PurchaseHistoryScreen'
+import StockAdjustmentScreen from '../features/stock/screens/StockAdjustmentScreen'
 
 const Stack = createStackNavigator()
 
@@ -21,6 +22,7 @@ export default function StockStack() {
       <Stack.Screen name={ROUTES.STOCK_DETAIL} component={StockDetailScreen} />
       <Stack.Screen name={ROUTES.PURCHASE_FORM} component={PurchaseFormScreen} />
       <Stack.Screen name={ROUTES.PURCHASE_HISTORY} component={PurchaseHistoryScreen} />
+      <Stack.Screen name={ROUTES.STOCK_ADJUSTMENT} component={StockAdjustmentScreen} />
     </Stack.Navigator>
   )
 }

--- a/docs/migrations/20260522_allow_negative_manual_adjustments.sql
+++ b/docs/migrations/20260522_allow_negative_manual_adjustments.sql
@@ -1,0 +1,151 @@
+-- 20260522_allow_negative_manual_adjustments.sql
+--
+-- S2.0 (Fase 3 §0.8) — desbloqueia ajuste manual NEGATIVO em
+-- apply_manual_stock_adjustment, habilitando o fluxo "Acertar saldo" (PO-6)
+-- para correções de perda/doação/descarte/vencimento manual.
+--
+-- Antes: delta < 0 lançava exceção (decisão conservadora 2026-04-02).
+-- Agora:
+--   • delta > 0  → comportamento original (insere lote entry_type='adjustment')
+--   • delta < 0  → consome FIFO dos lotes existentes (entry_type != 'legacy_
+--                  unrecoverable', quantity > 0), SEM criar stock_consumptions
+--                  (não é dose), e registra UM stock_adjustments negativo
+--                  (stock_id = NULL — consumo distribuído entre lotes).
+--   • saldo nunca fica negativo: valida total disponível >= abs(delta).
+--
+-- SECURITY DEFINER + search_path fixo (consistente com a função atual).
+-- Aplicação manual pelo PO (agente não aplica migration).
+
+CREATE OR REPLACE FUNCTION public.apply_manual_stock_adjustment(
+  p_medicine_id uuid,
+  p_quantity_delta numeric,
+  p_reason text,
+  p_notes text DEFAULT NULL::text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_stock public.stock%ROWTYPE;
+  v_adjustment public.stock_adjustments%ROWTYPE;
+  v_total_available NUMERIC := 0;
+  v_remaining NUMERIC;
+  v_to_consume NUMERIC;
+  v_stock_row public.stock%ROWTYPE;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Usuário não autenticado';
+  END IF;
+
+  IF p_quantity_delta IS NULL OR p_quantity_delta = 0 THEN
+    RAISE EXCEPTION 'Quantidade do ajuste deve ser diferente de zero';
+  END IF;
+
+  IF NULLIF(TRIM(COALESCE(p_reason, '')), '') IS NULL THEN
+    RAISE EXCEPTION 'Motivo do ajuste é obrigatório';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.medicines
+    WHERE id = p_medicine_id
+      AND user_id = v_user_id
+  ) THEN
+    RAISE EXCEPTION 'Medicamento não encontrado para o usuário autenticado';
+  END IF;
+
+  -- ── Delta POSITIVO: insere lote de ajuste (comportamento original) ──────────
+  IF p_quantity_delta > 0 THEN
+    INSERT INTO public.stock (
+      medicine_id, quantity, purchase_date, expiration_date, unit_price,
+      notes, user_id, purchase_id, original_quantity, entry_type
+    )
+    VALUES (
+      p_medicine_id, p_quantity_delta, CURRENT_DATE, NULL, 0,
+      NULLIF(TRIM(p_notes), ''), v_user_id, NULL, p_quantity_delta, 'adjustment'
+    )
+    RETURNING * INTO v_stock;
+
+    INSERT INTO public.stock_adjustments (
+      user_id, medicine_id, stock_id, quantity_delta, reason, reference_id, notes
+    )
+    VALUES (
+      v_user_id, p_medicine_id, v_stock.id, p_quantity_delta,
+      NULLIF(TRIM(p_reason), ''), NULL, NULLIF(TRIM(p_notes), '')
+    )
+    RETURNING * INTO v_adjustment;
+
+    RETURN jsonb_build_object(
+      'stock', to_jsonb(v_stock),
+      'adjustment', to_jsonb(v_adjustment)
+    );
+  END IF;
+
+  -- ── Delta NEGATIVO: consome FIFO sem criar stock_consumptions ───────────────
+  -- Valida saldo suficiente (não permite saldo negativo).
+  SELECT COALESCE(SUM(quantity), 0)
+  INTO v_total_available
+  FROM public.stock
+  WHERE medicine_id = p_medicine_id
+    AND user_id = v_user_id
+    AND quantity > 0
+    AND entry_type != 'legacy_unrecoverable';
+
+  IF v_total_available < ABS(p_quantity_delta) THEN
+    RAISE EXCEPTION 'Saldo insuficiente para o ajuste (disponível: %, solicitado: %)',
+      v_total_available, ABS(p_quantity_delta);
+  END IF;
+
+  v_remaining := ABS(p_quantity_delta);
+
+  FOR v_stock_row IN
+    SELECT *
+    FROM public.stock
+    WHERE medicine_id = p_medicine_id
+      AND user_id = v_user_id
+      AND quantity > 0
+      AND entry_type != 'legacy_unrecoverable'
+    ORDER BY purchase_date ASC, created_at ASC, id ASC
+    FOR UPDATE
+  LOOP
+    EXIT WHEN v_remaining <= 0;
+
+    v_to_consume := LEAST(v_stock_row.quantity, v_remaining);
+
+    UPDATE public.stock
+    SET quantity = quantity - v_to_consume
+    WHERE id = v_stock_row.id;
+
+    v_remaining := v_remaining - v_to_consume;
+  END LOOP;
+
+  IF v_remaining > 0 THEN
+    RAISE EXCEPTION 'Falha de consistência: ajuste negativo FIFO incompleto';
+  END IF;
+
+  -- Um único registro de auditoria (delta negativo). stock_id NULL pois o
+  -- consumo foi distribuído entre múltiplos lotes.
+  INSERT INTO public.stock_adjustments (
+    user_id, medicine_id, stock_id, quantity_delta, reason, reference_id, notes
+  )
+  VALUES (
+    v_user_id, p_medicine_id, NULL, p_quantity_delta,
+    NULLIF(TRIM(p_reason), ''), NULL, NULLIF(TRIM(p_notes), '')
+  )
+  RETURNING * INTO v_adjustment;
+
+  RETURN jsonb_build_object(
+    'stock', NULL,
+    'adjustment', to_jsonb(v_adjustment)
+  );
+END;
+$function$;
+
+-- Grants (idempotente — CREATE OR REPLACE preserva, mas reforçamos o template).
+REVOKE EXECUTE ON FUNCTION public.apply_manual_stock_adjustment(uuid, numeric, text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.apply_manual_stock_adjustment(uuid, numeric, text, text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.apply_manual_stock_adjustment(uuid, numeric, text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.apply_manual_stock_adjustment(uuid, numeric, text, text) TO service_role;


### PR DESCRIPTION
## Summary

Parte 1 do Sprint S3.2 — completa o Detalhe de estoque (KPI grid) e entrega o fluxo de Ajuste de saldo (PO-6). Migrations já aplicadas em produção via MCP (validadas com rollback).

**Migration S2.0 (§0.8):** `apply_manual_stock_adjustment` agora aceita delta negativo (consome FIFO, sem saldo negativo, sem stock_consumptions, 1 registro de auditoria). Habilita "Acertar saldo". Já aplicada + validada (61→58 rollback, guarda de saldo insuficiente, grants). Migration §0.9 (precisão unit_price NUMERIC(12,4)) também aplicada.

**S2.1 — StockIndicators + StockDetailScreen** (mock `mock-estoque-detalhes`):
- KPI grid 2×2: Saldo / Consumo-dia / Dias restantes (alerta de cor) / Custo médio
- Ficha hero: ícone por tipo + nome + dose pill + composto ativo + badge "saldo em dias"
- Histórico preview (última compra) + "Ver todas"; FAB registrar compra; "Acertar saldo" no header
- Removido card "Saldo total" redundante

**S2.2 — StockAdjustmentScreen** (mock `mock-estoque-ajuste-saldo`, PO-6 modo único):
- Digita saldo final → preview delta (+/−) → motivo + observações → `adjustBalance`
- Placeholder = saldo atual; ficha com dose pill
- Rota STOCK_ADJUSTMENT registrada no StockStack

## Test plan

- [x] Smoke PO em device (validado e aprovado antes do PR)
- [x] Migrations aplicadas + validadas via MCP (rollback)
- [ ] Detalhe: KPI grid, ficha (composto + badge), histórico, FAB, acertar saldo
- [ ] Ajuste: acertar saldo +/− (inclusive negativo real), preview delta, motivos
- [ ] Saldo recalcula após ajuste (volta ao detalhe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## AI Review Response

| Sugestxc3xa3o | Prioridade | Decisxc3xa3o | Motivo |
|----------|-----------|---------|--------|
| currentBalance na dep do useFocusEffect (re-exec) | Medium | Applied | 34aea8bf xe2x80x94 dep estxc3xa1vel needsBalance; getTotalQuantity jxc3xa1 usado |
