### PR TITLE
refactor(stock): S3.2 G2+G3 — factories canônicas @dosiq/core (web+mobile)

### DIFF
--- a/apps/mobile/src/features/stock/components/PurchaseMedicineSheet.jsx
+++ b/apps/mobile/src/features/stock/components/PurchaseMedicineSheet.jsx
@@ -121,7 +121,7 @@ export default function PurchaseMedicineSheet({ visible, onClose, onSelect }) {
     if (!userId) return
     let cancelled = false
     stockService
-      .getStockSummaryMap(userId)
+      .getStockSummaryMap()
       .then((map) => { if (!cancelled) setStockMap(map) })
       .catch(() => { if (!cancelled) setStockMap({}) })
     return () => { cancelled = true }

--- a/apps/mobile/src/features/stock/hooks/useStock.js
+++ b/apps/mobile/src/features/stock/hooks/useStock.js
@@ -20,10 +20,11 @@ async function _resolveUser() {
   return user
 }
 
-async function _fetchAndPersistStock(userId, setState, dataRef) {
+async function _fetchAndPersistStock(setState, dataRef) {
   // PO-9 §0.7: lista meds com protocolo ativo OU saldo positivo (corrige bug de
   // estoque órfão invisível). Split em active (com previsão) + inactive (só-estoque).
-  const rawData = await stockService.getMedicinesWithStockOrActiveProtocol(userId)
+  // userId é resolvido internamente pela factory (G2) — não passamos mais aqui.
+  const rawData = await stockService.getMedicinesWithStockOrActiveProtocol()
   const today = getTodayLocal()
   const { active, inactive } = splitStockItems(transformStockData(rawData))
   const newData = { active, inactive, localDay: today }
@@ -88,8 +89,9 @@ export function useStock() {
     if (isRefreshing) setState(prev => ({ ...prev, refreshing: true, error: null }))
     else setState(prev => ({ ...prev, loading: true, error: null }))
     try {
-      const user = await _resolveUser()
-      await _fetchAndPersistStock(user.id, setState, dataRef)
+      // Guard: garante sessão antes de buscar (lança "Sessão expirada" se deslogado).
+      await _resolveUser()
+      await _fetchAndPersistStock(setState, dataRef)
     } catch (err) {
       if (__DEV__) console.warn('[useStock] Fetch failed, checking cache:', err.message)
       try {

--- a/apps/mobile/src/features/stock/hooks/useStockMutation.js
+++ b/apps/mobile/src/features/stock/hooks/useStockMutation.js
@@ -77,7 +77,7 @@ export function useStockMutation() {
       // Optional chaining no service call defende contra user null adicional.
       if (!user?.id) throw new Error('Usuário não autenticado')
       const result = await mutationCreate.mutate(() =>
-        stockService.createPurchase(input, user?.id),
+        stockService.createPurchase(input),
       )
       if (result && goBack) navigation.goBack()
       return result
@@ -89,7 +89,7 @@ export function useStockMutation() {
     async (id, input, { goBack = false } = {}) => {
       if (!user?.id) throw new Error('Usuário não autenticado')
       const result = await mutationUpdate.mutate(() =>
-        stockService.updatePurchase(id, input, user?.id),
+        stockService.updatePurchase(id, input),
       )
       if (result && goBack) navigation.goBack()
       return result
@@ -119,7 +119,6 @@ export function useStockMutation() {
           newBalance,
           reason,
           notes,
-          user?.id,
         )
         // multiRemove = 1 chamada à ponte nativa (vs N concorrentes) — atômico.
         // Log falha em __DEV__ pra diagnóstico (cache stale survives next refresh).

--- a/apps/mobile/src/features/stock/screens/PurchaseHistoryScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/PurchaseHistoryScreen.jsx
@@ -61,7 +61,7 @@ export default function PurchaseHistoryScreen({ route, navigation }) {
     setLoading(true)
     try {
       const [data, med] = await Promise.all([
-        stockService.getPurchasesByMedicine(medicineId, userId),
+        stockService.getPurchasesByMedicine(medicineId),
         medicineService.getById(medicineId).catch(() => null),
       ])
       setPurchases(data ?? [])

--- a/apps/mobile/src/features/stock/screens/StockAdjustmentScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockAdjustmentScreen.jsx
@@ -10,7 +10,7 @@
 // Contratos:
 //   useStockMutation().adjustBalance(medicineId, newBalance, reason, notes)
 //     → Promise<{delta, before, after}>; já dá toast e lança em erro.
-//   stockService.getTotalQuantity(medicineId, userId) → number.
+//   stockService.getTotalQuantity(medicineId) → number (userId resolvido na factory G2).
 //   useAuth() → user?.id.
 //
 // R-010: States → Memos → Effects → Handlers

--- a/apps/mobile/src/features/stock/screens/StockDetailScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockDetailScreen.jsx
@@ -98,8 +98,8 @@ export default function StockDetailScreen({ navigation }) {
     setLoading(true)
     try {
       const [qty, purchaseList, med] = await Promise.all([
-        stockService.getTotalQuantity(medicineId, userId),
-        stockService.getPurchasesByMedicine(medicineId, userId),
+        stockService.getTotalQuantity(medicineId),
+        stockService.getPurchasesByMedicine(medicineId),
         medicineService.getById(medicineId),
       ])
       setSaldo(qty ?? 0)

--- a/apps/mobile/src/features/stock/services/stockService.js
+++ b/apps/mobile/src/features/stock/services/stockService.js
@@ -1,30 +1,35 @@
-// stockService.js — Fase 3 CRUD Estoque mobile.
+// stockService.js — Fase 3 CRUD Estoque mobile (S3.2 G2: adopt factories).
 //
-// Consolidação dos 2 services web (`stockService` + `purchaseService`) num
-// único módulo mobile. Pattern thin local (ADR-029) — chama Supabase direto
-// via nativeSupabaseClient. Validação Zod via @dosiq/core (R-125 + R-232).
+// G2: thin wrapper sobre createStockRepository + createPurchaseRepository de
+// @dosiq/core/repositories. O `stockService` exportado é a COMPOSIÇÃO das duas
+// instâncias (callers continuam usando stockService.createPurchase/etc num único
+// objeto). DI mobile: nativeSupabaseClient + getUserId via supabase.auth.
 //
-// Diferenças vs web:
-// - userId é param explícito (consistente com treatmentsService.js mobile)
-// - Sem `delete` de purchase (PO-1 — escopo cortado; correção via Ajuste)
-// - getStockData (legacy MVP read-only) preservado pra não quebrar useStock atual
+// Mudança vs S3.1: userId NÃO é mais param explícito — a factory resolve via
+// getUserId injetado. Call sites mobile (hooks/screens) dropam o arg userId.
 //
-// Refactor pra factory createStockRepository + createPurchaseRepository em S2
-// (G2/G3). Por enquanto este service é a fonte mobile.
+// getStockData (legacy MVP read-only) preservado sem callers reais (apenas refs
+// em comentários) — mantido pra não introduzir risco; remover em fix-pack pós-Fase 3.
 
 import { z } from 'zod'
 import {
+  createStockRepository,
+  createPurchaseRepository,
   getTodayLocal,
   isProtocolActiveOnDate,
-  validateStockCreate,
-  validateStockDecrease,
-  validateStockIncrease,
 } from '@dosiq/core'
 import { supabase as nativeSupabaseClient } from '../../../platform/supabase/nativeSupabaseClient'
 import { debugLog, errorLog } from '@shared/utils/debugLog'
 
+async function getUserId() {
+  const { data, error } = await nativeSupabaseClient.auth.getUser()
+  const user = data?.user
+  if (error || !user) throw new Error('Sessão expirada. Faça login novamente.')
+  return user.id
+}
+
 // ───────────────────────────────────────────────────────────────────────────
-// LEGACY — getStockData (MVP read-only, mantido pra useStock atual)
+// LEGACY — getStockData (MVP read-only, mantido por segurança; sem callers)
 // ───────────────────────────────────────────────────────────────────────────
 
 /**
@@ -85,376 +90,10 @@ export async function getStockData(userId) {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// FASE 3 — stockService object (CRUD completo)
+// FASE 3 S3.2 G2 — composição das factories de @dosiq/core
 // ───────────────────────────────────────────────────────────────────────────
 
-function fmtZodErr(errors) {
-  return errors.map((e) => `${e.field}: ${e.message}`).join('; ')
-}
+const stockRepo = createStockRepository({ client: nativeSupabaseClient, getUserId })
+const purchaseRepo = createPurchaseRepository({ client: nativeSupabaseClient, getUserId })
 
-export const stockService = {
-  // === READS ===
-
-  /**
-   * Medicamentos do hub de estoque (PO-9 §0.7): lista quem tem protocolo ativo
-   * HOJE OU saldo positivo. Corrige bug de produção do getStockData legacy, que
-   * filtrava `protocols.active=true` no servidor e escondia meds com estoque
-   * órfão (sem treatment / treatment finalizado / treatment pausado).
-   *
-   * NÃO filtra protocols.active no servidor — atividade é avaliada no client
-   * via isProtocolActiveOnDate, e a inclusão considera também totalStock > 0.
-   *
-   * @returns {Promise<Array>} medicines crus (medicine_stock_summary + protocols)
-   */
-  async getMedicinesWithStockOrActiveProtocol(userId) {
-    z.string().uuid().parse(userId)
-    const { data, error } = await nativeSupabaseClient
-      .from('medicines')
-      .select(`
-        id,
-        name,
-        laboratory,
-        dosage_unit,
-        dosage_per_pill,
-        medicine_stock_summary!left (
-          total_quantity
-        ),
-        protocols (
-          id,
-          dosage_per_intake,
-          time_schedule,
-          frequency,
-          active,
-          start_date,
-          end_date
-        )
-      `)
-      .eq('user_id', userId)
-      .order('name')
-
-    if (error) throw error
-
-    const today = getTodayLocal()
-    return (data || []).filter((m) => {
-      const hasActiveProtocol = (m.protocols || []).some(
-        (p) => p.active && isProtocolActiveOnDate(p, today),
-      )
-      const totalStock = m.medicine_stock_summary?.[0]?.total_quantity ?? 0
-      return hasActiveProtocol || totalStock > 0
-    })
-  },
-
-  /**
-   * Stock entries de um medicamento (FIFO order).
-   */
-  async getByMedicine(medicineId, userId) {
-    const { data, error } = await nativeSupabaseClient
-      .from('stock')
-      .select('*')
-      .eq('medicine_id', medicineId)
-      .eq('user_id', userId)
-      .order('created_at', { ascending: false })
-
-    if (error) throw error
-    return data || []
-  },
-
-  /**
-   * Summary agregado (total_quantity, entries_count, datas).
-   * Usa view medicine_stock_summary.
-   */
-  async getStockSummary(medicineId, userId) {
-    const { data, error } = await nativeSupabaseClient
-      .from('medicine_stock_summary')
-      .select('*')
-      .eq('medicine_id', medicineId)
-      .eq('user_id', userId)
-      .maybeSingle()
-
-    if (error) throw error
-    return (
-      data ?? {
-        medicine_id: medicineId,
-        user_id: userId,
-        total_quantity: 0,
-        stock_entries_count: 0,
-        oldest_entry_date: null,
-        newest_entry_date: null,
-      }
-    )
-  },
-
-  /**
-   * Mapa medicineId → total_quantity de todos os meds do usuário (bulk).
-   * Usado pelo PurchaseMedicineSheet pra exibir saldo sem N queries.
-   * @returns {Promise<Record<string, number>>}
-   */
-  async getStockSummaryMap(userId) {
-    z.string().uuid().parse(userId)
-    const { data, error } = await nativeSupabaseClient
-      .from('medicine_stock_summary')
-      .select('medicine_id, total_quantity')
-      .eq('user_id', userId)
-
-    if (error) throw error
-    return (data || []).reduce((map, row) => {
-      map[row.medicine_id] = row.total_quantity ?? 0
-      return map
-    }, {})
-  },
-
-  /**
-   * Total quantity (com fallback manual caso view não retorne).
-   */
-  async getTotalQuantity(medicineId, userId) {
-    const { data: summary, error: summaryError } = await nativeSupabaseClient
-      .from('medicine_stock_summary')
-      .select('total_quantity')
-      .eq('medicine_id', medicineId)
-      .eq('user_id', userId)
-      .maybeSingle()
-
-    if (!summaryError && summary) return summary.total_quantity
-
-    const { data, error } = await nativeSupabaseClient
-      .from('stock')
-      .select('quantity')
-      .eq('medicine_id', medicineId)
-      .eq('user_id', userId)
-
-    if (error) throw error
-    return (data || []).reduce((acc, e) => acc + (e.quantity || 0), 0)
-  },
-
-  /**
-   * Medicamentos com stock baixo. Usa RPC; fallback view direto.
-   */
-  async getLowStockMedicines(userId, threshold = 10) {
-    const { data, error } = await nativeSupabaseClient.rpc('get_low_stock_medicines', {
-      p_user_id: userId,
-      p_threshold: threshold,
-    })
-
-    if (error) {
-      const { data: fallback, error: fbErr } = await nativeSupabaseClient
-        .from('medicine_stock_summary')
-        .select('*')
-        .eq('user_id', userId)
-        .lte('total_quantity', threshold)
-        .order('total_quantity', { ascending: true })
-
-      if (fbErr) throw fbErr
-      return fallback || []
-    }
-    return data || []
-  },
-
-  // === PURCHASES (read) ===
-
-  /**
-   * Histórico de compras de um medicamento.
-   */
-  async getPurchasesByMedicine(medicineId, userId) {
-    // Embed do lote em `stock` (FK stock.purchase_id → purchases.id) pra expor o
-    // saldo restante de cada compra. `remaining` = soma das entries do lote
-    // (normalmente 1). Sem isso o PurchaseCard mostrava sempre "0 restantes".
-    const { data, error } = await nativeSupabaseClient
-      .from('purchases')
-      .select('*, stock(quantity)')
-      .eq('medicine_id', medicineId)
-      .eq('user_id', userId)
-      .order('purchase_date', { ascending: false })
-      .order('created_at', { ascending: false })
-
-    if (error) throw error
-    return (data || []).map((p) => ({
-      ...p,
-      remaining: (p.stock || []).reduce((acc, s) => acc + (Number(s.quantity) || 0), 0),
-    }))
-  },
-
-  /**
-   * Última compra de cada medicineId (mapa medicineId → purchase).
-   */
-  async getLatestPurchasesByMedicineIds(medicineIds, userId) {
-    if (!medicineIds || medicineIds.length === 0) return {}
-    const { data, error } = await nativeSupabaseClient
-      .from('purchases')
-      .select('*')
-      .eq('user_id', userId)
-      .in('medicine_id', medicineIds)
-      .order('purchase_date', { ascending: false })
-      .order('created_at', { ascending: false })
-
-    if (error) throw error
-    return (data || []).reduce((map, p) => {
-      if (!map[p.medicine_id]) map[p.medicine_id] = p
-      return map
-    }, {})
-  },
-
-  // === WRITES ===
-
-  /**
-   * Cria compra + atualiza saldo (atômico via RPC).
-   * @throws {Error} se validation Zod falhar
-   */
-  async createPurchase(input, userId) {
-    const validation = validateStockCreate(input)
-    if (!validation.success) throw new Error(`Erro de validação: ${fmtZodErr(validation.errors)}`)
-    const p = validation.data
-
-    const { data, error } = await nativeSupabaseClient.rpc('create_purchase_with_stock', {
-      p_medicine_id: p.medicine_id,
-      p_quantity: p.quantity,
-      p_unit_price: p.unit_price ?? 0,
-      p_purchase_date: p.purchase_date,
-      p_expiration_date: p.expiration_date,
-      p_pharmacy: p.pharmacy,
-      p_laboratory: p.laboratory,
-      p_notes: p.notes,
-    })
-
-    if (error) throw error
-    debugLog('stockService', `createPurchase OK medicineId=${p.medicine_id} userId=${userId}`)
-    return data
-  },
-
-  /**
-   * Edita uma purchase existente — APENAS metadados (preço, datas, farmácia,
-   * lab, notas). NÃO altera `quantity_bought`: a quantidade está amarrada ao
-   * lote em `stock` (saldo + FIFO) e qualquer correção de saldo passa pelo
-   * fluxo dedicado "Acertar saldo" (PO-6). Editar quantidade aqui causaria
-   * desync silencioso (sem trigger no DB que propague).
-   */
-  async updatePurchase(id, input, userId) {
-    const validation = validateStockCreate(input)
-    if (!validation.success) throw new Error(`Erro de validação: ${fmtZodErr(validation.errors)}`)
-    const p = validation.data
-
-    const { data, error } = await nativeSupabaseClient
-      .from('purchases')
-      .update({
-        unit_price: p.unit_price ?? 0,
-        purchase_date: p.purchase_date,
-        expiration_date: p.expiration_date,
-        pharmacy: p.pharmacy,
-        laboratory: p.laboratory,
-        notes: p.notes,
-      })
-      .eq('id', id)
-      .eq('user_id', userId)
-      .select()
-      .single()
-
-    if (error) throw error
-    return data
-  },
-
-  /**
-   * Consumo FIFO (chamado quando dose é registrada).
-   * @throws {Error} se medicineLogId ausente ou validation falhar
-   */
-  async decreaseStock(medicineId, quantity, medicineLogId, userId) {
-    const validation = validateStockDecrease({ medicine_id: medicineId, quantity })
-    if (!validation.success) throw new Error(`Erro de validação: ${fmtZodErr(validation.errors)}`)
-    if (!medicineLogId) throw new Error('medicineLogId é obrigatório para consumo FIFO rastreável')
-
-    const { data, error } = await nativeSupabaseClient.rpc('consume_stock_fifo', {
-      p_medicine_id: medicineId,
-      p_quantity: quantity,
-      p_medicine_log_id: medicineLogId,
-    })
-
-    if (error) throw error
-    debugLog('stockService', `decreaseStock OK medicineId=${medicineId} userId=${userId}`)
-    return data
-  },
-
-  /**
-   * Estorna stock (delete de log) OU ajuste manual positivo.
-   * Se `options.medicine_log_id` presente → restore_stock_for_log RPC.
-   * Senão → apply_manual_stock_adjustment RPC.
-   */
-  async increaseStock(medicineId, quantity, options = {}, userId) {
-    const normalized =
-      typeof options === 'string'
-        ? { reason: options, quantity }
-        : { ...options, quantity }
-
-    const validation = validateStockIncrease({
-      medicine_id: medicineId,
-      quantity,
-      medicine_log_id: normalized.medicine_log_id ?? null,
-      reason: normalized.reason ?? 'Ajuste de estoque',
-      notes: normalized.notes ?? null,
-    })
-
-    if (!validation.success) throw new Error(`Erro de validação: ${fmtZodErr(validation.errors)}`)
-    const payload = validation.data
-
-    if (payload.medicine_log_id) {
-      const { data, error } = await nativeSupabaseClient.rpc('restore_stock_for_log', {
-        p_medicine_log_id: payload.medicine_log_id,
-        p_reason: payload.reason,
-      })
-      if (error) throw error
-      return data
-    }
-
-    const { data, error } = await nativeSupabaseClient.rpc('apply_manual_stock_adjustment', {
-      p_medicine_id: medicineId,
-      p_quantity_delta: quantity,
-      p_reason: payload.reason,
-      p_notes: payload.notes,
-    })
-
-    if (error) throw error
-    debugLog('stockService', `increaseStock OK medicineId=${medicineId} userId=${userId}`)
-    return data
-  },
-
-  /**
-   * Ajuste manual — modo único "Acertar saldo" (PO-6).
-   * Calcula delta = newBalance - currentTotal e dispara increase/decrease.
-   *
-   * @param {string} medicineId
-   * @param {number} newBalance - saldo final desejado (>=0)
-   * @param {string} reason - motivo (obrigatório PO-6)
-   * @param {string|null} notes
-   * @param {string} userId
-   */
-  async adjustToBalance(medicineId, newBalance, reason, notes, userId) {
-    if (!reason) throw new Error('Motivo é obrigatório para ajuste manual')
-    if (newBalance < 0) throw new Error('Saldo final não pode ser negativo')
-
-    // Usar stockService.* (não this.*) — adjustToBalance pode ser destructurado
-    // em hooks (ex: const { adjustToBalance } = useStockMutation()), perdendo
-    // referência a `this`.
-    const current = await stockService.getTotalQuantity(medicineId, userId)
-    const delta = newBalance - current
-
-    if (delta === 0) {
-      debugLog('stockService', `adjustToBalance: delta=0, no-op medicineId=${medicineId}`)
-      return { delta: 0, before: current, after: newBalance }
-    }
-
-    if (delta > 0) {
-      await stockService.increaseStock(medicineId, delta, { reason, notes }, userId)
-    } else {
-      // delta negativo — ajuste manual decrementa via RPC com quantity_delta negativo
-      // (depende de migration S2.0 pendente — ver EXEC_SPEC_FASE3 §0.8)
-      const { error } = await nativeSupabaseClient.rpc('apply_manual_stock_adjustment', {
-        p_medicine_id: medicineId,
-        p_quantity_delta: delta,
-        p_reason: reason,
-        p_notes: notes ?? null,
-      })
-      if (error) throw error
-      debugLog('stockService', `adjustToBalance decrement OK medicineId=${medicineId} delta=${delta}`)
-    }
-
-    // Return padronizado nos 3 branches — API previsível
-    return { delta, before: current, after: newBalance }
-  },
-}
+export const stockService = { ...stockRepo, ...purchaseRepo }

--- a/apps/web/src/features/stock/services/purchaseService.js
+++ b/apps/web/src/features/stock/services/purchaseService.js
@@ -1,118 +1,26 @@
+// purchaseService.js — Adapter web sobre createPurchaseRepository (S3.2 G3).
+//
+// G3: a lógica de compras (queries + média ponderada) foi extraída para
+// createPurchaseRepository em @dosiq/core. Este adapter injeta client/getUserId
+// da sessão web e expõe a API histórica do web delegando à factory.
+//
+// Nota: getByMedicine agora embute o lote (`stock(quantity)`) e calcula
+// `remaining` por compra (igual mobile) — campo aditivo, consumidores antigos
+// seguem funcionando. A média ponderada usa computeAverageUnitPrice canônico
+// de @dosiq/core (lê quantity_bought ?? quantity).
+
 import { supabase, getUserId } from '@shared/utils/supabase'
-import { validateStockCreate } from '@schemas/stockSchema'
+import { createPurchaseRepository } from '@dosiq/core'
 
-function calculateWeightedAverage(entries = []) {
-  const validEntries = entries.filter(
-    (entry) => (entry.quantity_bought ?? 0) > 0 && (entry.unit_price ?? 0) > 0
-  )
-
-  if (validEntries.length === 0) return 0
-
-  const totalValue = validEntries.reduce(
-    (sum, entry) => sum + entry.unit_price * entry.quantity_bought,
-    0
-  )
-  const totalQuantity = validEntries.reduce((sum, entry) => sum + entry.quantity_bought, 0)
-
-  return totalQuantity > 0 ? totalValue / totalQuantity : 0
-}
-
-function groupLatestByMedicine(entries = []) {
-  return entries.reduce((map, entry) => {
-    if (!map[entry.medicine_id]) {
-      map[entry.medicine_id] = entry
-    }
-    return map
-  }, {})
-}
-
-function groupHistoryByMedicine(entries = []) {
-  return entries.reduce((map, entry) => {
-    if (!map[entry.medicine_id]) {
-      map[entry.medicine_id] = []
-    }
-    map[entry.medicine_id].push(entry)
-    return map
-  }, {})
-}
+const purchaseRepo = createPurchaseRepository({ client: supabase, getUserId })
 
 export const purchaseService = {
-  async getByMedicine(medicineId) {
-    const { data, error } = await supabase
-      .from('purchases')
-      .select('*')
-      .eq('medicine_id', medicineId)
-      .eq('user_id', await getUserId())
-      .order('purchase_date', { ascending: false })
-      .order('created_at', { ascending: false })
-
-    if (error) throw error
-    return data || []
-  },
-
-  async getLatestByMedicineIds(medicineIds = []) {
-    if (!medicineIds.length) return {}
-
-    const { data, error } = await supabase
-      .from('purchases')
-      .select('*')
-      .eq('user_id', await getUserId())
-      .in('medicine_id', medicineIds)
-      .order('purchase_date', { ascending: false })
-      .order('created_at', { ascending: false })
-
-    if (error) throw error
-    return groupLatestByMedicine(data || [])
-  },
-
-  async getHistoryByMedicineIds(medicineIds = []) {
-    if (!medicineIds.length) return {}
-
-    const { data, error } = await supabase
-      .from('purchases')
-      .select('*')
-      .eq('user_id', await getUserId())
-      .in('medicine_id', medicineIds)
-      .order('purchase_date', { ascending: false })
-      .order('created_at', { ascending: false })
-
-    if (error) throw error
-    return groupHistoryByMedicine(data || [])
-  },
-
-  async getAverageUnitPriceByMedicineIds(medicineIds = []) {
-    if (!medicineIds.length) return {}
-
-    const historyByMedicine = await this.getHistoryByMedicineIds(medicineIds)
-
-    return Object.fromEntries(
-      Object.entries(historyByMedicine).map(([medicineId, entries]) => [
-        medicineId,
-        calculateWeightedAverage(entries),
-      ])
-    )
-  },
-
-  async create(input) {
-    const validation = validateStockCreate(input)
-    if (!validation.success) {
-      const errorMessages = validation.errors.map((e) => `${e.field}: ${e.message}`).join('; ')
-      throw new Error(`Erro de validação: ${errorMessages}`)
-    }
-
-    const payload = validation.data
-    const { data, error } = await supabase.rpc('create_purchase_with_stock', {
-      p_medicine_id: payload.medicine_id,
-      p_quantity: payload.quantity,
-      p_unit_price: payload.unit_price ?? 0,
-      p_purchase_date: payload.purchase_date,
-      p_expiration_date: payload.expiration_date,
-      p_pharmacy: payload.pharmacy,
-      p_laboratory: payload.laboratory,
-      p_notes: payload.notes,
-    })
-
-    if (error) throw error
-    return data
-  },
+  getByMedicine: (medicineId) => purchaseRepo.getPurchasesByMedicine(medicineId),
+  getLatestByMedicineIds: (medicineIds) =>
+    purchaseRepo.getLatestPurchasesByMedicineIds(medicineIds),
+  getHistoryByMedicineIds: (medicineIds) =>
+    purchaseRepo.getHistoryByMedicineIds(medicineIds),
+  getAverageUnitPriceByMedicineIds: (medicineIds) =>
+    purchaseRepo.getAverageUnitPriceByMedicineIds(medicineIds),
+  create: (input) => purchaseRepo.createPurchase(input),
 }

--- a/apps/web/src/features/stock/services/stockService.js
+++ b/apps/web/src/features/stock/services/stockService.js
@@ -1,246 +1,30 @@
+// stockService.js — Adapter web sobre as factories de @dosiq/core (S3.2 G3).
+//
+// G3: a lógica CRUD de estoque foi extraída para createStockRepository /
+// createPurchaseRepository em @dosiq/core (fonte única web↔mobile). Este módulo
+// é um adapter fino que injeta o client/getUserId da sessão web e expõe a API
+// histórica do web (add/decrease/increase/...) delegando aos métodos da factory
+// (nomes canônicos mobile: createPurchase/decreaseStock/increaseStock).
+//
+// Mantido como adapter (e não removido) pra preservar todos os callers web +
+// cachedServices + testes sem churn. Validação Zod é canônica via @dosiq/core.
+
 import { supabase, getUserId } from '@shared/utils/supabase'
-import { validateStockDecrease, validateStockIncrease } from '@schemas/stockSchema'
-import { purchaseService } from './purchaseService'
+import { createStockRepository, createPurchaseRepository } from '@dosiq/core'
 
-/**
- * Stock Service - Manage medicine stock
- *
- * PERFORMANCE OPTIMIZATION (v1.6):
- * - Uses medicine_stock_summary view for aggregated queries
- * - Optimized getTotalQuantity with single row lookup
- * - Added getStockSummary for complete stock metrics
- * - Added getLowStockMedicines for proactive alerts
- *
- * VALIDAÇÃO ZOD:
- * - Todos os dados de entrada são validados antes de enviar ao Supabase
- * - Erros de validação retornam mensagens em português
- * - Nenhum payload inválido é enviado ao backend
- */
+const stockRepo = createStockRepository({ client: supabase, getUserId })
+const purchaseRepo = createPurchaseRepository({ client: supabase, getUserId })
+
 export const stockService = {
-  /**
-   * Get stock for a specific medicine
-   */
-  async getByMedicine(medicineId) {
-    const { data, error } = await supabase
-      .from('stock')
-      .select('*')
-      .eq('medicine_id', medicineId)
-      .eq('user_id', await getUserId())
-      .order('created_at', { ascending: false })
-
-    if (error) throw error
-    return data
-  },
-
-  /**
-   * Get total quantity for a medicine
-   * OPTIMIZED: Uses medicine_stock_summary view for better performance
-   * Falls back to manual calculation if view returns no data
-   */
-  async getTotalQuantity(medicineId) {
-    // Try optimized view first
-    const { data: summaryData, error: summaryError } = await supabase
-      .from('medicine_stock_summary')
-      .select('total_quantity')
-      .eq('medicine_id', medicineId)
-      .eq('user_id', await getUserId())
-      .maybeSingle()
-
-    if (!summaryError && summaryData) {
-      return summaryData.total_quantity
-    }
-
-    // Fallback to manual calculation (backward compatibility)
-    const { data, error } = await supabase
-      .from('stock')
-      .select('quantity')
-      .eq('medicine_id', medicineId)
-      .eq('user_id', await getUserId())
-
-    if (error) throw error
-
-    return data.reduce((total, item) => total + item.quantity, 0)
-  },
-
-  /**
-   * Get complete stock summary for a medicine
-   * Uses medicine_stock_summary view for optimal performance
-   *
-   * @param {string} medicineId - The medicine ID
-   * @returns {Promise<Object>} Stock summary with total_quantity, stock_entries_count, dates
-   */
-  async getStockSummary(medicineId) {
-    const { data, error } = await supabase
-      .from('medicine_stock_summary')
-      .select('*')
-      .eq('medicine_id', medicineId)
-      .eq('user_id', await getUserId())
-      .maybeSingle()
-
-    if (error) throw error
-
-    // Return default summary if no data found
-    if (!data) {
-      return {
-        medicine_id: medicineId,
-        user_id: await getUserId(),
-        total_quantity: 0,
-        stock_entries_count: 0,
-        oldest_entry_date: null,
-        newest_entry_date: null,
-      }
-    }
-
-    return data
-  },
-
-  /**
-   * Get all medicines with low stock for alerts
-   * Uses optimized view with threshold filter
-   *
-   * @param {number} threshold - Quantity threshold (default: 10)
-   * @returns {Promise<Array>} List of medicines below threshold
-   */
-  async getLowStockMedicines(threshold = 10) {
-    const userId = await getUserId()
-
-    // Use the database function for efficient filtering
-    const { data, error } = await supabase.rpc('get_low_stock_medicines', {
-      p_user_id: userId,
-      p_threshold: threshold,
-    })
-
-    if (error) {
-      // Fallback: query the view directly if RPC fails
-      const { data: fallbackData, error: fallbackError } = await supabase
-        .from('medicine_stock_summary')
-        .select('*')
-        .eq('user_id', userId)
-        .lte('total_quantity', threshold)
-        .order('total_quantity', { ascending: true })
-
-      if (fallbackError) throw fallbackError
-      return fallbackData || []
-    }
-
-    return data || []
-  },
-
-  /**
-   * Add stock
-   *
-   * VALIDAÇÃO: Dados são validados com Zod antes de enviar ao Supabase
-   * @throws {Error} Se os dados forem inválidos
-   */
-  async add(stock) {
-    return purchaseService.create(stock)
-  },
-
-  /**
-   * Decrease stock (when medicine is taken)
-   * This finds the oldest stock entry and decrements it
-   *
-   * VALIDAÇÃO: Dados são validados com Zod antes de processar
-   * @throws {Error} Se os dados forem inválidos
-   */
-  async decrease(medicineId, quantity, medicineLogId) {
-    // Validação Zod
-    const validation = validateStockDecrease({ medicine_id: medicineId, quantity })
-    if (!validation.success) {
-      const errorMessages = validation.errors.map((e) => `${e.field}: ${e.message}`).join('; ')
-      throw new Error(`Erro de validação: ${errorMessages}`)
-    }
-
-    if (!medicineLogId) {
-      throw new Error('medicineLogId é obrigatório para consumo FIFO rastreável')
-    }
-
-    const { data, error } = await supabase.rpc('consume_stock_fifo', {
-      p_medicine_id: medicineId,
-      p_quantity: quantity,
-      p_medicine_log_id: medicineLogId,
-    })
-
-    if (error) throw error
-    return data
-  },
-
-  /**
-   * Increase stock (when a log is deleted or quantity decreased)
-   * It creates a special "adjustment" entry to maintain history integrity
-   *
-   * VALIDAÇÃO: Dados são validados com Zod antes de processar
-   * @throws {Error} Se os dados forem inválidos
-   */
-  async increase(medicineId, quantity, options = {}) {
-    const normalizedOptions =
-      typeof options === 'string' ? { reason: options } : { ...options, quantity }
-
-    const validation = validateStockIncrease({
-      medicine_id: medicineId,
-      quantity,
-      medicine_log_id: normalizedOptions.medicine_log_id ?? null,
-      reason: normalizedOptions.reason ?? 'Ajuste de estoque',
-      notes: normalizedOptions.notes ?? null,
-    })
-
-    if (!validation.success) {
-      const errorMessages = validation.errors.map((e) => `${e.field}: ${e.message}`).join('; ')
-      throw new Error(`Erro de validação: ${errorMessages}`)
-    }
-
-    const payload = validation.data
-
-    if (payload.medicine_log_id) {
-      const { data, error } = await supabase.rpc('restore_stock_for_log', {
-        p_medicine_log_id: payload.medicine_log_id,
-        p_reason: payload.reason,
-      })
-
-      if (error) throw error
-      return data
-    }
-
-    const { data, error } = await supabase.rpc('apply_manual_stock_adjustment', {
-      p_medicine_id: medicineId,
-      p_quantity_delta: quantity,
-      p_reason: payload.reason,
-      p_notes: payload.notes,
-    })
-
-    if (error) throw error
-    return data
-  },
-
-  /**
-   * Delete a stock entry
-   */
-  async delete(id) {
-    const { data: entry, error: fetchError } = await supabase
-      .from('stock')
-      .select('*')
-      .eq('id', id)
-      .eq('user_id', await getUserId())
-      .single()
-
-    if (fetchError) throw fetchError
-
-    if (
-      entry.entry_type === 'purchase' &&
-      entry.original_quantity !== null &&
-      entry.quantity !== entry.original_quantity
-    ) {
-      throw new Error(
-        'Compras com consumo associado não podem ser removidas. Use ajuste manual positivo.'
-      )
-    }
-
-    const { error } = await supabase
-      .from('stock')
-      .delete()
-      .eq('id', id)
-      .eq('user_id', await getUserId())
-
-    if (error) throw error
-  },
+  getByMedicine: (medicineId) => stockRepo.getByMedicine(medicineId),
+  getTotalQuantity: (medicineId) => stockRepo.getTotalQuantity(medicineId),
+  getStockSummary: (medicineId) => stockRepo.getStockSummary(medicineId),
+  getLowStockMedicines: (threshold) => stockRepo.getLowStockMedicines(threshold),
+  // `add` = criar compra (cria entrada real em stock via RPC create_purchase_with_stock)
+  add: (stock) => purchaseRepo.createPurchase(stock),
+  decrease: (medicineId, quantity, medicineLogId) =>
+    stockRepo.decreaseStock(medicineId, quantity, medicineLogId),
+  increase: (medicineId, quantity, options) =>
+    stockRepo.increaseStock(medicineId, quantity, options),
+  delete: (id) => stockRepo.delete(id),
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,7 +22,8 @@ export default [
     '**/scripts/**',
     '**/scratch/**',
     '**/__tests__/**',
-    '**/.agent/**'
+    '**/.agent/**',
+    '**/plans/**',
   ] },
   {
     files: ['**/*.{js,jsx}'],

--- a/packages/core/src/repositories/__tests__/createPurchaseRepository.test.js
+++ b/packages/core/src/repositories/__tests__/createPurchaseRepository.test.js
@@ -1,0 +1,194 @@
+// Parity tests — createPurchaseRepository (Fase 3 S3.2 G2)
+//
+// Garante: chamadas Supabase (table, filter, embed, RPC name + args), formato de
+// erro de validação, e transforms client-side (remaining computado, mapas, média).
+//
+// Mock builder fluente (espelha createProtocolRepository.test.js) + suporte a .rpc.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPurchaseRepository } from '../createPurchaseRepository.js'
+
+function makeBuilder(result) {
+  const builder = {
+    _calls: [],
+    select: vi.fn(function (...a) { this._calls.push(['select', a]); return this }),
+    update: vi.fn(function (...a) { this._calls.push(['update', a]); return this }),
+    eq:     vi.fn(function (...a) { this._calls.push(['eq', a]); return this }),
+    in:     vi.fn(function (...a) { this._calls.push(['in', a]); return this }),
+    order:  vi.fn(function (...a) { this._calls.push(['order', a]); return this }),
+    single: vi.fn(function ()     { this._calls.push(['single', []]); return Promise.resolve(result) }),
+    then: (resolve) => resolve(result),
+  }
+  return builder
+}
+
+function makeClient(result, rpcResult) {
+  const builder = makeBuilder(result)
+  const client = {
+    _builder: builder,
+    _rpcCalls: [],
+    from: vi.fn(() => builder),
+    rpc: vi.fn((name, args) => {
+      client._rpcCalls.push([name, args])
+      return Promise.resolve(rpcResult ?? { data: { id: 'new' }, error: null })
+    }),
+  }
+  return client
+}
+
+const FAKE_USER = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'
+const getUserId = async () => FAKE_USER
+
+// purchase_date no passado pra passar validateStockCreate
+const VALID_INPUT = {
+  medicine_id: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d',
+  quantity: 30,
+  purchase_date: '2026-01-10',
+  unit_price: 12.5,
+}
+
+describe('createPurchaseRepository — parity', () => {
+  let client
+
+  beforeEach(() => {
+    client = makeClient({ data: [], error: null })
+  })
+
+  // ── Constructor validation ──
+  it('throws se client ausente', () => {
+    expect(() => createPurchaseRepository({ getUserId })).toThrow(/client/)
+  })
+  it('throws se getUserId não for função', () => {
+    expect(() => createPurchaseRepository({ client, getUserId: null })).toThrow(/getUserId/)
+  })
+
+  // ── getPurchasesByMedicine (embed + remaining) ──
+  describe('getPurchasesByMedicine', () => {
+    it('embed stock(quantity) e computa remaining = soma quantities', async () => {
+      client = makeClient({
+        data: [
+          { id: 'p1', stock: [{ quantity: 2 }, { quantity: 3 }] },
+          { id: 'p2', stock: [] },
+          { id: 'p3' },
+        ],
+        error: null,
+      })
+      const repo = createPurchaseRepository({ client, getUserId })
+      const result = await repo.getPurchasesByMedicine('med-1')
+      expect(client.from).toHaveBeenCalledWith('purchases')
+      const calls = client._builder._calls
+      expect(calls).toContainEqual(['select', ['*, stock(quantity)']])
+      expect(calls).toContainEqual(['eq', ['medicine_id', 'med-1']])
+      expect(calls).toContainEqual(['eq', ['user_id', FAKE_USER]])
+      expect(result.find((p) => p.id === 'p1').remaining).toBe(5)
+      expect(result.find((p) => p.id === 'p2').remaining).toBe(0)
+      expect(result.find((p) => p.id === 'p3').remaining).toBe(0)
+    })
+  })
+
+  // ── getLatestPurchasesByMedicineIds ──
+  describe('getLatestPurchasesByMedicineIds', () => {
+    it('retorna {} se lista vazia (sem query)', async () => {
+      const repo = createPurchaseRepository({ client, getUserId })
+      expect(await repo.getLatestPurchasesByMedicineIds([])).toEqual({})
+      expect(client.from).not.toHaveBeenCalled()
+    })
+    it('mapeia medicineId → primeira (mais recente) compra', async () => {
+      client = makeClient({
+        data: [
+          { id: 'p1', medicine_id: 'm-a' },
+          { id: 'p2', medicine_id: 'm-a' },
+          { id: 'p3', medicine_id: 'm-b' },
+        ],
+        error: null,
+      })
+      const repo = createPurchaseRepository({ client, getUserId })
+      const map = await repo.getLatestPurchasesByMedicineIds(['m-a', 'm-b'])
+      expect(client._builder._calls).toContainEqual(['in', ['medicine_id', ['m-a', 'm-b']]])
+      expect(map['m-a'].id).toBe('p1')
+      expect(map['m-b'].id).toBe('p3')
+    })
+  })
+
+  // ── getHistoryByMedicineIds ──
+  describe('getHistoryByMedicineIds', () => {
+    it('mapeia medicineId → array de compras', async () => {
+      client = makeClient({
+        data: [
+          { id: 'p1', medicine_id: 'm-a' },
+          { id: 'p2', medicine_id: 'm-a' },
+          { id: 'p3', medicine_id: 'm-b' },
+        ],
+        error: null,
+      })
+      const repo = createPurchaseRepository({ client, getUserId })
+      const map = await repo.getHistoryByMedicineIds(['m-a', 'm-b'])
+      expect(map['m-a']).toHaveLength(2)
+      expect(map['m-b']).toHaveLength(1)
+    })
+  })
+
+  // ── getAverageUnitPriceByMedicineIds ──
+  describe('getAverageUnitPriceByMedicineIds', () => {
+    it('média ponderada via computeAverageUnitPrice (quantity_bought)', async () => {
+      client = makeClient({
+        data: [
+          { medicine_id: 'm-a', quantity_bought: 10, unit_price: 2 },
+          { medicine_id: 'm-a', quantity_bought: 30, unit_price: 6 },
+        ],
+        error: null,
+      })
+      const repo = createPurchaseRepository({ client, getUserId })
+      const map = await repo.getAverageUnitPriceByMedicineIds(['m-a'])
+      // (10*2 + 30*6) / 40 = 200/40 = 5
+      expect(map['m-a']).toBeCloseTo(5)
+    })
+    it('retorna {} se lista vazia', async () => {
+      const repo = createPurchaseRepository({ client, getUserId })
+      expect(await repo.getAverageUnitPriceByMedicineIds([])).toEqual({})
+    })
+  })
+
+  // ── createPurchase ──
+  describe('createPurchase', () => {
+    it('validation fail → Erro de validação', async () => {
+      const repo = createPurchaseRepository({ client, getUserId })
+      await expect(repo.createPurchase({ quantity: 1 })).rejects.toThrow(/Erro de validação/)
+    })
+    it('validation ok → RPC create_purchase_with_stock com param mapping', async () => {
+      const repo = createPurchaseRepository({ client, getUserId })
+      await repo.createPurchase(VALID_INPUT)
+      const call = client._rpcCalls.find(([n]) => n === 'create_purchase_with_stock')
+      expect(call[1]).toMatchObject({
+        p_medicine_id: VALID_INPUT.medicine_id,
+        p_quantity: 30,
+        p_unit_price: 12.5,
+        p_purchase_date: '2026-01-10',
+      })
+    })
+  })
+
+  // ── updatePurchase ──
+  describe('updatePurchase', () => {
+    beforeEach(() => {
+      client = makeClient({ data: { id: 'p-1' }, error: null })
+    })
+    it('atualiza metadados SEM quantity_bought', async () => {
+      const repo = createPurchaseRepository({ client, getUserId })
+      await repo.updatePurchase('p-1', VALID_INPUT)
+      const calls = client._builder._calls
+      const updateCall = calls.find(([m]) => m === 'update')
+      const payload = updateCall[1][0]
+      expect(payload).toHaveProperty('unit_price', 12.5)
+      expect(payload).toHaveProperty('purchase_date', '2026-01-10')
+      expect(payload).not.toHaveProperty('quantity_bought')
+      expect(payload).not.toHaveProperty('quantity')
+      expect(calls).toContainEqual(['eq', ['id', 'p-1']])
+      expect(calls).toContainEqual(['eq', ['user_id', FAKE_USER]])
+    })
+    it('validation fail → Erro de validação', async () => {
+      const repo = createPurchaseRepository({ client, getUserId })
+      await expect(repo.updatePurchase('p-1', { quantity: -5 })).rejects.toThrow(/Erro de validação/)
+    })
+  })
+})

--- a/packages/core/src/repositories/__tests__/createStockRepository.test.js
+++ b/packages/core/src/repositories/__tests__/createStockRepository.test.js
@@ -1,0 +1,276 @@
+// Parity tests — createStockRepository (Fase 3 S3.2 G2)
+//
+// Garante que web e mobile, ao injetarem client + getUserId, produzem:
+//   - As mesmas chamadas Supabase (table, filter, RPC name + args, payload)
+//   - O mesmo formato de erro de validação
+//   - Transforms client-side aplicados (PO-9 filter, adjustToBalance delta)
+//
+// Mock builder fluente (espelha createProtocolRepository.test.js) + suporte a .rpc/.maybeSingle.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createStockRepository } from '../createStockRepository.js'
+
+// ---------- Mock Supabase fluent builder ----------
+function makeBuilder(result) {
+  const builder = {
+    _calls: [],
+    select:      vi.fn(function (...a) { this._calls.push(['select', a]); return this }),
+    insert:      vi.fn(function (...a) { this._calls.push(['insert', a]); return this }),
+    update:      vi.fn(function (...a) { this._calls.push(['update', a]); return this }),
+    delete:      vi.fn(function (...a) { this._calls.push(['delete', a]); return this }),
+    eq:          vi.fn(function (...a) { this._calls.push(['eq', a]); return this }),
+    lte:         vi.fn(function (...a) { this._calls.push(['lte', a]); return this }),
+    in:          vi.fn(function (...a) { this._calls.push(['in', a]); return this }),
+    order:       vi.fn(function (...a) { this._calls.push(['order', a]); return this }),
+    single:      vi.fn(function ()     { this._calls.push(['single', []]); return Promise.resolve(result) }),
+    maybeSingle: vi.fn(function ()     { this._calls.push(['maybeSingle', []]); return Promise.resolve(result) }),
+    then: (resolve) => resolve(result),
+  }
+  return builder
+}
+
+function makeClient(result, rpcResult) {
+  const builder = makeBuilder(result)
+  const client = {
+    _builder: builder,
+    _rpcCalls: [],
+    from: vi.fn(() => builder),
+    rpc: vi.fn((name, args) => {
+      client._rpcCalls.push([name, args])
+      return Promise.resolve(rpcResult ?? { data: { ok: true }, error: null })
+    }),
+  }
+  return client
+}
+
+const FAKE_USER = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'
+const getUserId = async () => FAKE_USER
+
+describe('createStockRepository — parity', () => {
+  let client
+
+  beforeEach(() => {
+    client = makeClient({ data: [], error: null })
+  })
+
+  // ── Constructor validation ──
+  it('throws se client ausente', () => {
+    expect(() => createStockRepository({ getUserId })).toThrow(/client/)
+  })
+  it('throws se getUserId não for função', () => {
+    expect(() => createStockRepository({ client, getUserId: null })).toThrow(/getUserId/)
+  })
+
+  // ── getMedicinesWithStockOrActiveProtocol (PO-9 filter) ──
+  describe('getMedicinesWithStockOrActiveProtocol', () => {
+    it('filtra client-side: inclui se hasActiveProtocol OU totalStock > 0', async () => {
+      const rows = [
+        { id: 'm-keep-stock', protocols: [], medicine_stock_summary: [{ total_quantity: 5 }] },
+        { id: 'm-drop', protocols: [], medicine_stock_summary: [{ total_quantity: 0 }] },
+        {
+          id: 'm-keep-proto',
+          protocols: [{ active: true, frequency: 'diario', start_date: '2020-01-01', end_date: null }],
+          medicine_stock_summary: [{ total_quantity: 0 }],
+        },
+      ]
+      client = makeClient({ data: rows, error: null })
+      const repo = createStockRepository({ client, getUserId })
+      const result = await repo.getMedicinesWithStockOrActiveProtocol()
+      expect(client.from).toHaveBeenCalledWith('medicines')
+      const calls = client._builder._calls
+      expect(calls).toContainEqual(['eq', ['user_id', FAKE_USER]])
+      // NÃO filtra protocols.active no servidor (apenas user_id + order)
+      expect(calls.find(([m, a]) => m === 'eq' && a[0] === 'protocols.active')).toBeUndefined()
+      const ids = result.map((m) => m.id)
+      expect(ids).toContain('m-keep-stock')
+      expect(ids).toContain('m-keep-proto')
+      expect(ids).not.toContain('m-drop')
+    })
+
+    it('valida userId como uuid', async () => {
+      const badClient = makeClient({ data: [], error: null })
+      const repo = createStockRepository({ client: badClient, getUserId: async () => 'not-a-uuid' })
+      await expect(repo.getMedicinesWithStockOrActiveProtocol()).rejects.toThrow()
+    })
+  })
+
+  // ── getByMedicine ──
+  describe('getByMedicine', () => {
+    it('select stock + eq medicine_id/user_id + order created_at desc', async () => {
+      const repo = createStockRepository({ client, getUserId })
+      await repo.getByMedicine('med-1')
+      expect(client.from).toHaveBeenCalledWith('stock')
+      const calls = client._builder._calls
+      expect(calls).toContainEqual(['eq', ['medicine_id', 'med-1']])
+      expect(calls).toContainEqual(['eq', ['user_id', FAKE_USER]])
+      expect(calls).toContainEqual(['order', ['created_at', { ascending: false }]])
+    })
+  })
+
+  // ── getStockSummary ──
+  describe('getStockSummary', () => {
+    it('maybeSingle + default object se data null', async () => {
+      client = makeClient({ data: null, error: null })
+      const repo = createStockRepository({ client, getUserId })
+      const result = await repo.getStockSummary('med-1')
+      expect(client.from).toHaveBeenCalledWith('medicine_stock_summary')
+      expect(client._builder._calls).toContainEqual(['maybeSingle', []])
+      expect(result).toMatchObject({ medicine_id: 'med-1', total_quantity: 0 })
+    })
+    it('retorna data se presente', async () => {
+      client = makeClient({ data: { medicine_id: 'med-1', total_quantity: 42 }, error: null })
+      const repo = createStockRepository({ client, getUserId })
+      expect(await repo.getStockSummary('med-1')).toMatchObject({ total_quantity: 42 })
+    })
+  })
+
+  // ── getStockSummaryMap ──
+  describe('getStockSummaryMap', () => {
+    it('reduz rows em mapa medicineId → total_quantity', async () => {
+      client = makeClient({ data: [{ medicine_id: 'a', total_quantity: 3 }, { medicine_id: 'b', total_quantity: null }], error: null })
+      const repo = createStockRepository({ client, getUserId })
+      expect(await repo.getStockSummaryMap()).toEqual({ a: 3, b: 0 })
+    })
+  })
+
+  // ── getTotalQuantity ──
+  describe('getTotalQuantity', () => {
+    it('usa view quando presente', async () => {
+      client = makeClient({ data: { total_quantity: 99 }, error: null })
+      const repo = createStockRepository({ client, getUserId })
+      expect(await repo.getTotalQuantity('med-1')).toBe(99)
+    })
+    it('fallback soma manual quando view vazia', async () => {
+      // maybeSingle retorna null → cai no fallback (then resolve mesma data... ajustamos)
+      const builder = makeBuilder(null)
+      let mode = 'summary'
+      builder.maybeSingle = vi.fn(() => Promise.resolve({ data: null, error: null }))
+      builder.then = (resolve) => resolve({ data: [{ quantity: 2 }, { quantity: 3 }], error: null })
+      void mode
+      const fbClient = { _builder: builder, from: vi.fn(() => builder), rpc: vi.fn() }
+      const repo = createStockRepository({ client: fbClient, getUserId })
+      expect(await repo.getTotalQuantity('med-1')).toBe(5)
+    })
+  })
+
+  // ── getLowStockMedicines ──
+  describe('getLowStockMedicines', () => {
+    it('chama RPC get_low_stock_medicines com threshold', async () => {
+      client = makeClient({ data: [], error: null }, { data: [{ id: 'm' }], error: null })
+      const repo = createStockRepository({ client, getUserId })
+      const result = await repo.getLowStockMedicines(5)
+      expect(client._rpcCalls).toContainEqual(['get_low_stock_medicines', { p_user_id: FAKE_USER, p_threshold: 5 }])
+      expect(result).toEqual([{ id: 'm' }])
+    })
+    it('fallback view se RPC erra', async () => {
+      client = makeClient({ data: [{ id: 'fb' }], error: null }, { data: null, error: new Error('rpc fail') })
+      const repo = createStockRepository({ client, getUserId })
+      const result = await repo.getLowStockMedicines()
+      expect(client.from).toHaveBeenCalledWith('medicine_stock_summary')
+      expect(result).toEqual([{ id: 'fb' }])
+    })
+  })
+
+  // ── decreaseStock ──
+  describe('decreaseStock', () => {
+    it('throws se medicineLogId ausente', async () => {
+      const repo = createStockRepository({ client, getUserId })
+      await expect(repo.decreaseStock('a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d', 2, null)).rejects.toThrow(/medicineLogId/)
+    })
+    it('validation fail → Erro de validação', async () => {
+      const repo = createStockRepository({ client, getUserId })
+      await expect(repo.decreaseStock('not-uuid', 2, 'log-1')).rejects.toThrow(/Erro de validação/)
+    })
+    it('chama RPC consume_stock_fifo', async () => {
+      const repo = createStockRepository({ client, getUserId })
+      await repo.decreaseStock('a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d', 2, 'log-1')
+      expect(client._rpcCalls).toContainEqual([
+        'consume_stock_fifo',
+        { p_medicine_id: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d', p_quantity: 2, p_medicine_log_id: 'log-1' },
+      ])
+    })
+  })
+
+  // ── increaseStock ──
+  describe('increaseStock', () => {
+    const MED = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'
+    it('com medicine_log_id → restore_stock_for_log', async () => {
+      const repo = createStockRepository({ client, getUserId })
+      const LOG_ID = 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e'
+      await repo.increaseStock(MED, 2, { medicine_log_id: LOG_ID, reason: 'estorno' })
+      const call = client._rpcCalls.find(([n]) => n === 'restore_stock_for_log')
+      expect(call[1]).toMatchObject({ p_medicine_log_id: LOG_ID, p_reason: 'estorno' })
+    })
+    it('sem medicine_log_id → apply_manual_stock_adjustment delta positivo', async () => {
+      const repo = createStockRepository({ client, getUserId })
+      await repo.increaseStock(MED, 4, { reason: 'ajuste', notes: 'x' })
+      const call = client._rpcCalls.find(([n]) => n === 'apply_manual_stock_adjustment')
+      expect(call[1]).toMatchObject({ p_medicine_id: MED, p_quantity_delta: 4, p_reason: 'ajuste' })
+    })
+  })
+
+  // ── adjustToBalance (PO-6 delta branches) ──
+  describe('adjustToBalance', () => {
+    const MED = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'
+    function clientWithTotal(total) {
+      const builder = makeBuilder(null)
+      builder.maybeSingle = vi.fn(() => Promise.resolve({ data: { total_quantity: total }, error: null }))
+      const c = { _builder: builder, _rpcCalls: [], from: vi.fn(() => builder),
+        rpc: vi.fn((name, args) => { c._rpcCalls.push([name, args]); return Promise.resolve({ data: {}, error: null }) }) }
+      return c
+    }
+    it('throws se reason ausente', async () => {
+      const repo = createStockRepository({ client, getUserId })
+      await expect(repo.adjustToBalance(MED, 10, null)).rejects.toThrow(/Motivo/)
+    })
+    it('throws se newBalance negativo', async () => {
+      const repo = createStockRepository({ client, getUserId })
+      await expect(repo.adjustToBalance(MED, -1, 'r')).rejects.toThrow(/negativo/)
+    })
+    it('delta=0 → no-op, retorna {delta:0}', async () => {
+      const c = clientWithTotal(10)
+      const repo = createStockRepository({ client: c, getUserId })
+      const res = await repo.adjustToBalance(MED, 10, 'r')
+      expect(res).toEqual({ delta: 0, before: 10, after: 10 })
+      expect(c._rpcCalls).toHaveLength(0)
+    })
+    it('delta>0 → increaseStock (apply_manual_stock_adjustment positivo)', async () => {
+      const c = clientWithTotal(5)
+      const repo = createStockRepository({ client: c, getUserId })
+      const res = await repo.adjustToBalance(MED, 12, 'compra extra')
+      expect(res).toEqual({ delta: 7, before: 5, after: 12 })
+      const call = c._rpcCalls.find(([n]) => n === 'apply_manual_stock_adjustment')
+      expect(call[1]).toMatchObject({ p_quantity_delta: 7 })
+    })
+    it('delta<0 → apply_manual_stock_adjustment com delta negativo', async () => {
+      const c = clientWithTotal(20)
+      const repo = createStockRepository({ client: c, getUserId })
+      const res = await repo.adjustToBalance(MED, 8, 'perda')
+      expect(res).toEqual({ delta: -12, before: 20, after: 8 })
+      const call = c._rpcCalls.find(([n]) => n === 'apply_manual_stock_adjustment')
+      expect(call[1]).toMatchObject({ p_quantity_delta: -12, p_reason: 'perda' })
+    })
+    it('sobrevive a destructuring (usa repo.* não this.*)', async () => {
+      const c = clientWithTotal(5)
+      const repo = createStockRepository({ client: c, getUserId })
+      const { adjustToBalance } = repo
+      const res = await adjustToBalance(MED, 9, 'r')
+      expect(res.delta).toBe(4)
+    })
+  })
+
+  // ── delete ──
+  describe('delete', () => {
+    it('apaga entry sem consumo associado', async () => {
+      client = makeClient({ data: { entry_type: 'purchase', original_quantity: 10, quantity: 10 }, error: null })
+      const repo = createStockRepository({ client, getUserId })
+      await repo.delete('s-1')
+      expect(client._builder._calls).toContainEqual(['delete', []])
+    })
+    it('bloqueia delete de compra com consumo associado', async () => {
+      client = makeClient({ data: { entry_type: 'purchase', original_quantity: 10, quantity: 4 }, error: null })
+      const repo = createStockRepository({ client, getUserId })
+      await expect(repo.delete('s-1')).rejects.toThrow(/consumo associado/)
+    })
+  })
+})

--- a/packages/core/src/repositories/createPurchaseRepository.js
+++ b/packages/core/src/repositories/createPurchaseRepository.js
@@ -1,0 +1,176 @@
+// createPurchaseRepository.js — Factory CRUD canônico de compras (Fase 3 S3.2 G2).
+//
+// Espelha o pattern de createProtocolRepository (Fase 2 G2).
+// Fonte de verdade do comportamento: stockService mobile consolidado (S3.1).
+// Validação Zod create é canônica (via @dosiq/core stockSchema).
+//
+// Métodos (nomes mobile — sem param userId, resolvido via getUserId injetado):
+// - getPurchasesByMedicine(medicineId)               → embed stock(quantity), map remaining
+// - getLatestPurchasesByMedicineIds(medicineIds)     → mapa medicineId → última compra
+// - getHistoryByMedicineIds(medicineIds)             → mapa medicineId → array (web; paridade)
+// - getAverageUnitPriceByMedicineIds(medicineIds)    → preço médio ponderado (computeAverageUnitPrice)
+// - createPurchase(input)                            → validateStockCreate + RPC create_purchase_with_stock
+// - updatePurchase(id, input)                        → update metadados (NÃO quantity_bought)
+
+import { validateStockCreate } from '../schemas/stockSchema.js'
+import { computeAverageUnitPrice } from '../utils/stock.js'
+
+function fmtZodErr(errors) {
+  return errors.map((e) => `${e.field}: ${e.message}`).join('; ')
+}
+
+/**
+ * Cria um repositório CRUD de compras parametrizado por plataforma.
+ *
+ * @param {Object} deps
+ * @param {Object} deps.client       Cliente Supabase.
+ * @param {Function} deps.getUserId  Async () => string. Resolve user_id da sessão.
+ */
+export function createPurchaseRepository({ client, getUserId }) {
+  if (!client) throw new Error('createPurchaseRepository: client é obrigatório')
+  if (typeof getUserId !== 'function') {
+    throw new Error('createPurchaseRepository: getUserId deve ser função async')
+  }
+
+  const repo = {
+    /**
+     * Histórico de compras de um medicamento.
+     * Embed do lote em `stock` (FK stock.purchase_id → purchases.id) pra expor o
+     * saldo restante de cada compra. `remaining` = soma das entries do lote
+     * (normalmente 1). Sem isso o PurchaseCard mostrava sempre "0 restantes".
+     */
+    async getPurchasesByMedicine(medicineId) {
+      const userId = await getUserId()
+      const { data, error } = await client
+        .from('purchases')
+        .select('*, stock(quantity)')
+        .eq('medicine_id', medicineId)
+        .eq('user_id', userId)
+        .order('purchase_date', { ascending: false })
+        .order('created_at', { ascending: false })
+
+      if (error) throw error
+      return (data || []).map((p) => ({
+        ...p,
+        remaining: (p.stock || []).reduce((acc, s) => acc + (Number(s.quantity) || 0), 0),
+      }))
+    },
+
+    /**
+     * Última compra de cada medicineId (mapa medicineId → purchase).
+     */
+    async getLatestPurchasesByMedicineIds(medicineIds) {
+      if (!medicineIds || medicineIds.length === 0) return {}
+      const userId = await getUserId()
+      const { data, error } = await client
+        .from('purchases')
+        .select('*')
+        .eq('user_id', userId)
+        .in('medicine_id', medicineIds)
+        .order('purchase_date', { ascending: false })
+        .order('created_at', { ascending: false })
+
+      if (error) throw error
+      return (data || []).reduce((map, p) => {
+        if (!map[p.medicine_id]) map[p.medicine_id] = p
+        return map
+      }, {})
+    },
+
+    /**
+     * Histórico completo por medicineId (mapa medicineId → array de compras).
+     * Web expõe; incluído pra paridade.
+     */
+    async getHistoryByMedicineIds(medicineIds) {
+      if (!medicineIds || medicineIds.length === 0) return {}
+      const userId = await getUserId()
+      const { data, error } = await client
+        .from('purchases')
+        .select('*')
+        .eq('user_id', userId)
+        .in('medicine_id', medicineIds)
+        .order('purchase_date', { ascending: false })
+        .order('created_at', { ascending: false })
+
+      if (error) throw error
+      return (data || []).reduce((map, p) => {
+        if (!map[p.medicine_id]) map[p.medicine_id] = []
+        map[p.medicine_id].push(p)
+        return map
+      }, {})
+    },
+
+    /**
+     * Preço médio unitário ponderado por medicineId (mapa medicineId → preço).
+     * Reusa computeAverageUnitPrice de @dosiq/core (lê quantity_bought ?? quantity).
+     */
+    async getAverageUnitPriceByMedicineIds(medicineIds) {
+      if (!medicineIds || medicineIds.length === 0) return {}
+      const historyByMedicine = await repo.getHistoryByMedicineIds(medicineIds)
+      return Object.fromEntries(
+        Object.entries(historyByMedicine).map(([medicineId, entries]) => [
+          medicineId,
+          computeAverageUnitPrice(entries),
+        ]),
+      )
+    },
+
+    /**
+     * Cria compra + atualiza saldo (atômico via RPC).
+     * @throws {Error} se validation Zod falhar
+     */
+    async createPurchase(input) {
+      const validation = validateStockCreate(input)
+      if (!validation.success) throw new Error(`Erro de validação: ${fmtZodErr(validation.errors)}`)
+      const p = validation.data
+
+      const { data, error } = await client.rpc('create_purchase_with_stock', {
+        p_medicine_id: p.medicine_id,
+        p_quantity: p.quantity,
+        p_unit_price: p.unit_price ?? 0,
+        p_purchase_date: p.purchase_date,
+        p_expiration_date: p.expiration_date,
+        p_pharmacy: p.pharmacy,
+        p_laboratory: p.laboratory,
+        p_notes: p.notes,
+      })
+
+      if (error) throw error
+      return data
+    },
+
+    /**
+     * Edita uma purchase existente — APENAS metadados (preço, datas, farmácia,
+     * lab, notas). NÃO altera `quantity_bought`: a quantidade está amarrada ao
+     * lote em `stock` (saldo + FIFO) e qualquer correção de saldo passa pelo
+     * fluxo dedicado "Acertar saldo" (PO-6). Editar quantidade aqui causaria
+     * desync silencioso (sem trigger no DB que propague).
+     */
+    async updatePurchase(id, input) {
+      const userId = await getUserId()
+      const validation = validateStockCreate(input)
+      if (!validation.success) throw new Error(`Erro de validação: ${fmtZodErr(validation.errors)}`)
+      const p = validation.data
+
+      const { data, error } = await client
+        .from('purchases')
+        .update({
+          unit_price: p.unit_price ?? 0,
+          purchase_date: p.purchase_date,
+          expiration_date: p.expiration_date,
+          pharmacy: p.pharmacy,
+          laboratory: p.laboratory,
+          notes: p.notes,
+        })
+        .eq('id', id)
+        .eq('user_id', userId)
+        .select()
+        .single()
+
+      if (error) throw error
+      return data
+    },
+  }
+
+  return repo
+}

--- a/packages/core/src/repositories/createStockRepository.js
+++ b/packages/core/src/repositories/createStockRepository.js
@@ -1,0 +1,345 @@
+// createStockRepository.js — Factory CRUD canônico de estoque (Fase 3 S3.2 G2).
+//
+// Espelha o pattern de createProtocolRepository (Fase 2 G2).
+// Web e mobile injetam: client Supabase, getUserId, e (opcional) transforms.
+// Fonte de verdade do comportamento: stockService mobile consolidado (S3.1).
+// Validação Zod decrease/increase é canônica (via @dosiq/core stockSchema).
+//
+// Métodos (nomes mobile — sem param userId, resolvido via getUserId injetado):
+// - getMedicinesWithStockOrActiveProtocol()  → PO-9: ativos hoje OU saldo > 0 (filtro client-side)
+// - getByMedicine(medicineId)                → stock entries, order created_at desc
+// - getStockSummary(medicineId)              → view medicine_stock_summary maybeSingle + default
+// - getStockSummaryMap()                     → mapa medicineId → total_quantity (bulk)
+// - getTotalQuantity(medicineId)             → view first, fallback soma manual
+// - getLowStockMedicines(threshold)          → RPC get_low_stock_medicines + fallback view
+// - decreaseStock(medicineId, qty, logId)    → validateStockDecrease + RPC consume_stock_fifo
+// - increaseStock(medicineId, qty, options)  → validateStockIncrease; restore vs ajuste manual
+// - adjustToBalance(medId, newBalance, ...)  → PO-6: delta → increase/decrease
+// - delete(id)                               → web-only (guarda contra apagar compra consumida); paridade
+
+import {
+  validateStockDecrease,
+  validateStockIncrease,
+} from '../schemas/stockSchema.js'
+import { z } from 'zod'
+import { getTodayLocal, isProtocolActiveOnDate } from '../utils/dateUtils.js'
+
+function fmtZodErr(errors) {
+  return errors.map((e) => `${e.field}: ${e.message}`).join('; ')
+}
+
+/**
+ * Cria um repositório CRUD de estoque parametrizado por plataforma.
+ *
+ * @param {Object} deps
+ * @param {Object} deps.client       Cliente Supabase.
+ * @param {Function} deps.getUserId  Async () => string. Resolve user_id da sessão.
+ */
+// NOTA: factory excede max-lines-per-function por agregar os métodos de estoque
+// num único objeto (pattern canônico de createProtocolRepository). Warning aceito (R-221 SQP).
+export function createStockRepository({ client, getUserId }) {
+  if (!client) throw new Error('createStockRepository: client é obrigatório')
+  if (typeof getUserId !== 'function') {
+    throw new Error('createStockRepository: getUserId deve ser função async')
+  }
+
+  // Objeto construído numa const estável (repo) — métodos que chamam outros
+  // métodos usam `repo.*` (não `this.*`) pra sobreviver a destructuring em hooks.
+  const repo = {
+    // === READS ===
+
+    /**
+     * Medicamentos do hub de estoque (PO-9 §0.7): lista quem tem protocolo ativo
+     * HOJE OU saldo positivo. NÃO filtra protocols.active no servidor — atividade
+     * é avaliada no client via isProtocolActiveOnDate, inclusão considera totalStock > 0.
+     *
+     * @returns {Promise<Array>} medicines crus (medicine_stock_summary + protocols)
+     */
+    async getMedicinesWithStockOrActiveProtocol() {
+      const userId = await getUserId()
+      z.string().uuid().parse(userId)
+      const { data, error } = await client
+        .from('medicines')
+        .select(`
+        id,
+        name,
+        laboratory,
+        dosage_unit,
+        dosage_per_pill,
+        medicine_stock_summary!left (
+          total_quantity
+        ),
+        protocols (
+          id,
+          dosage_per_intake,
+          time_schedule,
+          frequency,
+          active,
+          start_date,
+          end_date
+        )
+      `)
+        .eq('user_id', userId)
+        .order('name')
+
+      if (error) throw error
+
+      const today = getTodayLocal()
+      return (data || []).filter((m) => {
+        const hasActiveProtocol = (m.protocols || []).some(
+          (p) => p.active && isProtocolActiveOnDate(p, today),
+        )
+        const totalStock = m.medicine_stock_summary?.[0]?.total_quantity ?? 0
+        return hasActiveProtocol || totalStock > 0
+      })
+    },
+
+    /**
+     * Stock entries de um medicamento (order created_at desc).
+     */
+    async getByMedicine(medicineId) {
+      const userId = await getUserId()
+      const { data, error } = await client
+        .from('stock')
+        .select('*')
+        .eq('medicine_id', medicineId)
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false })
+
+      if (error) throw error
+      return data || []
+    },
+
+    /**
+     * Summary agregado (total_quantity, entries_count, datas).
+     * Usa view medicine_stock_summary; default object se ausente.
+     */
+    async getStockSummary(medicineId) {
+      const userId = await getUserId()
+      const { data, error } = await client
+        .from('medicine_stock_summary')
+        .select('*')
+        .eq('medicine_id', medicineId)
+        .eq('user_id', userId)
+        .maybeSingle()
+
+      if (error) throw error
+      return (
+        data ?? {
+          medicine_id: medicineId,
+          user_id: userId,
+          total_quantity: 0,
+          stock_entries_count: 0,
+          oldest_entry_date: null,
+          newest_entry_date: null,
+        }
+      )
+    },
+
+    /**
+     * Mapa medicineId → total_quantity de todos os meds do usuário (bulk).
+     * @returns {Promise<Record<string, number>>}
+     */
+    async getStockSummaryMap() {
+      const userId = await getUserId()
+      z.string().uuid().parse(userId)
+      const { data, error } = await client
+        .from('medicine_stock_summary')
+        .select('medicine_id, total_quantity')
+        .eq('user_id', userId)
+
+      if (error) throw error
+      return (data || []).reduce((map, row) => {
+        map[row.medicine_id] = row.total_quantity ?? 0
+        return map
+      }, {})
+    },
+
+    /**
+     * Total quantity (com fallback manual caso view não retorne).
+     */
+    async getTotalQuantity(medicineId) {
+      const userId = await getUserId()
+      const { data: summary, error: summaryError } = await client
+        .from('medicine_stock_summary')
+        .select('total_quantity')
+        .eq('medicine_id', medicineId)
+        .eq('user_id', userId)
+        .maybeSingle()
+
+      if (!summaryError && summary) return summary.total_quantity
+
+      const { data, error } = await client
+        .from('stock')
+        .select('quantity')
+        .eq('medicine_id', medicineId)
+        .eq('user_id', userId)
+
+      if (error) throw error
+      return (data || []).reduce((acc, e) => acc + (e.quantity || 0), 0)
+    },
+
+    /**
+     * Medicamentos com stock baixo. Usa RPC; fallback view direto.
+     */
+    async getLowStockMedicines(threshold = 10) {
+      const userId = await getUserId()
+      const { data, error } = await client.rpc('get_low_stock_medicines', {
+        p_user_id: userId,
+        p_threshold: threshold,
+      })
+
+      if (error) {
+        const { data: fallback, error: fbErr } = await client
+          .from('medicine_stock_summary')
+          .select('*')
+          .eq('user_id', userId)
+          .lte('total_quantity', threshold)
+          .order('total_quantity', { ascending: true })
+
+        if (fbErr) throw fbErr
+        return fallback || []
+      }
+      return data || []
+    },
+
+    // === WRITES ===
+
+    /**
+     * Consumo FIFO (chamado quando dose é registrada).
+     * @throws {Error} se medicineLogId ausente ou validation falhar
+     */
+    async decreaseStock(medicineId, quantity, medicineLogId) {
+      const validation = validateStockDecrease({ medicine_id: medicineId, quantity })
+      if (!validation.success) throw new Error(`Erro de validação: ${fmtZodErr(validation.errors)}`)
+      if (!medicineLogId) throw new Error('medicineLogId é obrigatório para consumo FIFO rastreável')
+
+      const { data, error } = await client.rpc('consume_stock_fifo', {
+        p_medicine_id: medicineId,
+        p_quantity: quantity,
+        p_medicine_log_id: medicineLogId,
+      })
+
+      if (error) throw error
+      return data
+    },
+
+    /**
+     * Estorna stock (delete de log) OU ajuste manual positivo.
+     * Se `options.medicine_log_id` presente → restore_stock_for_log RPC.
+     * Senão → apply_manual_stock_adjustment RPC.
+     */
+    async increaseStock(medicineId, quantity, options = {}) {
+      const normalized =
+        typeof options === 'string'
+          ? { reason: options, quantity }
+          : { ...options, quantity }
+
+      const validation = validateStockIncrease({
+        medicine_id: medicineId,
+        quantity,
+        medicine_log_id: normalized.medicine_log_id ?? null,
+        reason: normalized.reason ?? 'Ajuste de estoque',
+        notes: normalized.notes ?? null,
+      })
+
+      if (!validation.success) throw new Error(`Erro de validação: ${fmtZodErr(validation.errors)}`)
+      const payload = validation.data
+
+      if (payload.medicine_log_id) {
+        const { data, error } = await client.rpc('restore_stock_for_log', {
+          p_medicine_log_id: payload.medicine_log_id,
+          p_reason: payload.reason,
+        })
+        if (error) throw error
+        return data
+      }
+
+      const { data, error } = await client.rpc('apply_manual_stock_adjustment', {
+        p_medicine_id: medicineId,
+        p_quantity_delta: quantity,
+        p_reason: payload.reason,
+        p_notes: payload.notes,
+      })
+
+      if (error) throw error
+      return data
+    },
+
+    /**
+     * Ajuste manual — modo único "Acertar saldo" (PO-6).
+     * Calcula delta = newBalance - currentTotal e dispara increase/decrease.
+     *
+     * @param {string} medicineId
+     * @param {number} newBalance - saldo final desejado (>=0)
+     * @param {string} reason - motivo (obrigatório PO-6)
+     * @param {string|null} notes
+     * @returns {Promise<{delta:number, before:number, after:number}>}
+     */
+    async adjustToBalance(medicineId, newBalance, reason, notes) {
+      if (!reason) throw new Error('Motivo é obrigatório para ajuste manual')
+      if (newBalance < 0) throw new Error('Saldo final não pode ser negativo')
+
+      // Usar repo.* (não this.*) — métodos podem ser destructurados em hooks
+      // (ex: const { adjustToBalance } = useStockMutation()), perdendo `this`.
+      const current = await repo.getTotalQuantity(medicineId)
+      const delta = newBalance - current
+
+      if (delta === 0) {
+        return { delta: 0, before: current, after: newBalance }
+      }
+
+      if (delta > 0) {
+        await repo.increaseStock(medicineId, delta, { reason, notes })
+      } else {
+        // delta negativo — ajuste manual decrementa via RPC com quantity_delta negativo
+        const { error } = await client.rpc('apply_manual_stock_adjustment', {
+          p_medicine_id: medicineId,
+          p_quantity_delta: delta,
+          p_reason: reason,
+          p_notes: notes ?? null,
+        })
+        if (error) throw error
+      }
+
+      // Return padronizado nos 3 branches — API previsível
+      return { delta, before: current, after: newBalance }
+    },
+
+    /**
+     * Apaga uma stock entry. Web-only (mobile não expõe — mantido na factory pra
+     * paridade). Guarda contra apagar compra com consumo associado.
+     */
+    async delete(id) {
+      const userId = await getUserId()
+      const { data: entry, error: fetchError } = await client
+        .from('stock')
+        .select('*')
+        .eq('id', id)
+        .eq('user_id', userId)
+        .single()
+
+      if (fetchError) throw fetchError
+
+      if (
+        entry.entry_type === 'purchase' &&
+        entry.original_quantity !== null &&
+        entry.quantity !== entry.original_quantity
+      ) {
+        throw new Error(
+          'Compras com consumo associado não podem ser removidas. Use ajuste manual positivo.',
+        )
+      }
+
+      const { error } = await client
+        .from('stock')
+        .delete()
+        .eq('id', id)
+        .eq('user_id', userId)
+
+      if (error) throw error
+    },
+  }
+
+  return repo
+}

--- a/packages/core/src/repositories/index.js
+++ b/packages/core/src/repositories/index.js
@@ -1,3 +1,5 @@
 export { createMedicineRepository } from './createMedicineRepository.js'
 export { createProtocolRepository } from './createProtocolRepository.js'
 export { createTreatmentPlanRepository } from './createTreatmentPlanRepository.js'
+export { createStockRepository } from './createStockRepository.js'
+export { createPurchaseRepository } from './createPurchaseRepository.js'


### PR DESCRIPTION
## Summary
- **G2** — extrai a lógica CRUD de estoque/compras do `stockService` mobile para duas factories canônicas em `@dosiq/core`: `createStockRepository` (10 métodos) + `createPurchaseRepository` (6 métodos). Espelham o pattern de `createProtocolRepository` (injetam `client` + `getUserId`; métodos sem param `userId`). Mobile `stockService` vira composição das duas instâncias; callers (hooks/screens) dropam o arg `userId`.
- **G3** — web `stockService`/`purchaseService` viram adapters finos que compõem as factories injetando `supabase`+`getUserId` da sessão web, expondo a API histórica (`add`/`decrease`/`increase`/`getByMedicine`/...) por delegação. Remove lógica duplicada (queries inline + `calculateWeightedAverage`); média ponderada agora usa `computeAverageUnitPrice` canônico.
- **Parity tests** — 37 casos (25 stock + 12 purchase) com mock builder fluente, espelhando `createProtocolRepository.test.js`.
- Net **-752 linhas** (deduplicação web↔mobile).

## Decisões
- **Naming canônico = nomes mobile** (factory expõe `decreaseStock`/`getPurchasesByMedicine`/`createPurchase`...); web mapeia via adapter. Mantém callers web intactos.
- `getUserId` injetado no construtor (não param por método) — consistente com factories de medicine/protocol/treatmentPlan.
- `getStockData` legacy mobile preservado (sem callers reais) — remoção em fix-pack pós-Fase 3.
- Web `purchaseService.getByMedicine` agora embute `stock(quantity)` + campo `remaining` (aditivo).

## Validação
- Parity core: 37/37 ✓
- `validate:agent`: **830/830** ✓ · lint 0 erros (só warnings `max-lines-per-function` aceitos R-221 SQP, iguais a `createProtocolRepository`)
- Smoke PO mobile (G2): ✓ aprovado

## Test plan
- [x] Parity tests core (stock + purchase)
- [x] Suite web crítica (stockService/purchaseService/logService/dashboard)
- [x] Smoke PO mobile (hub Estoque, detalhe, histórico, compra, ajuste de saldo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)