### PR TITLE
fix(mobile): 8 ajustes de UX/comportamento pós-Fase 3

### DIFF
--- a/apps/mobile/src/features/medications/components/MedicineAnvisaSheet.jsx
+++ b/apps/mobile/src/features/medications/components/MedicineAnvisaSheet.jsx
@@ -9,6 +9,7 @@ import {
   StyleSheet,
   Platform,
   StatusBar,
+  KeyboardAvoidingView,
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { Search, X, Pill, PillBottle } from 'lucide-react-native'
@@ -98,7 +99,12 @@ export function MedicineAnvisaSheet({ open, onClose, onSelect }) {
       // por cima do overlay no Android 7/API 24).
       statusBarTranslucent
     >
-      <View style={styles.root}>
+      <KeyboardAvoidingView
+        style={styles.root}
+        // iOS: eleva o sheet acima do teclado (sem isso o teclado cobre o input
+        // de busca). Android: adjustResize do SO já reposiciona — sem behavior.
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
         {Platform.OS === 'android' ? (
           <View style={{ height: StatusBar.currentHeight ?? 0 }} />
         ) : null}
@@ -143,7 +149,7 @@ export function MedicineAnvisaSheet({ open, onClose, onSelect }) {
             contentContainerStyle={styles.listContent}
           />
         </SafeAreaView>
-      </View>
+      </KeyboardAvoidingView>
     </Modal>
   )
 }

--- a/apps/mobile/src/features/medications/screens/MedicineDetailScreen.jsx
+++ b/apps/mobile/src/features/medications/screens/MedicineDetailScreen.jsx
@@ -62,6 +62,9 @@ export default function MedicineDetailScreen() {
   const navigation = useNavigation()
   const route = useRoute()
   const id = route.params?.id
+  // Vindo do detalhe de um tratamento: a exclusão é sempre bloqueada (medicamento
+  // tem dependência), então ocultamos o botão pra não exibir ação morta.
+  const hideDelete = route.params?.hideDelete === true
   const { data, loading, error, refresh } = useMedicine(id)
   const { preCheck, confirmDelete, isLoading: deleteLoading } = useMedicineDelete(data)
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -310,20 +313,23 @@ export default function MedicineDetailScreen() {
             <Text style={styles.useMeta}>{stockSummary ?? 'Não rastreado'}</Text>
           </View>
 
-          {/* Botão Excluir medicamento */}
-          <Pressable
-            onPress={handleDeletePress}
-            style={({ pressed }) => [
-              styles.deleteButton,
-              pressed && styles.deleteButtonPressed,
-            ]}
-            accessibilityRole="button"
-            accessibilityLabel="Excluir medicamento"
-            disabled={!data || deleteLoading}
-          >
-            <Trash2 size={18} color={colors.status.error} />
-            <Text style={styles.deleteButtonText}>Excluir medicamento</Text>
-          </Pressable>
+          {/* Botão Excluir medicamento — oculto quando vindo de um tratamento
+              (exclusão bloqueada por dependência; ação morta) */}
+          {!hideDelete && (
+            <Pressable
+              onPress={handleDeletePress}
+              style={({ pressed }) => [
+                styles.deleteButton,
+                pressed && styles.deleteButtonPressed,
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel="Excluir medicamento"
+              disabled={!data || deleteLoading}
+            >
+              <Trash2 size={18} color={colors.status.error} />
+              <Text style={styles.deleteButtonText}>Excluir medicamento</Text>
+            </Pressable>
+          )}
         </View>
       </ScrollView>
 

--- a/apps/mobile/src/features/medications/screens/MedicinesListScreen.jsx
+++ b/apps/mobile/src/features/medications/screens/MedicinesListScreen.jsx
@@ -158,7 +158,7 @@ export default function MedicinesListScreen() {
             <Text style={styles.counterText}>
               {filtered.length} {filtered.length === 1 ? 'MEDICAMENTO' : 'MEDICAMENTOS'}
             </Text>
-            <Text style={styles.sortText}>Mais recentes ↓</Text>
+            {/* Ordenação ainda não implementada — placeholder oculto até haver sorting real */}
           </View>
 
           {isFilteredEmpty ? (

--- a/apps/mobile/src/features/stock/components/PurchaseMedicineSheet.jsx
+++ b/apps/mobile/src/features/stock/components/PurchaseMedicineSheet.jsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useState } from 'react'
 import {
   ActivityIndicator,
   FlatList,
+  KeyboardAvoidingView,
   Modal,
   Platform,
   Pressable,
@@ -151,7 +152,12 @@ export default function PurchaseMedicineSheet({ visible, onClose, onSelect }) {
       // screen atual, truncando em Android 7+ / API 24 — AP-165 / R-233).
       statusBarTranslucent
     >
-      <View style={styles.root}>
+      <KeyboardAvoidingView
+        style={styles.root}
+        // iOS: eleva o sheet acima do teclado (sem isso o sheet some atras do
+        // teclado, pior ainda com poucos resultados). Android: adjustResize do SO.
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
         {/* Spacer Android: empurra o sheet abaixo da status bar translúcida (R-233) */}
         {Platform.OS === 'android' ? (
           <View style={{ height: StatusBar.currentHeight ?? 0 }} />
@@ -255,7 +261,7 @@ export default function PurchaseMedicineSheet({ visible, onClose, onSelect }) {
             />
           )}
         </SafeAreaView>
-      </View>
+      </KeyboardAvoidingView>
     </Modal>
   )
 }

--- a/apps/mobile/src/features/stock/hooks/_stockDataTransformer.js
+++ b/apps/mobile/src/features/stock/hooks/_stockDataTransformer.js
@@ -1,4 +1,9 @@
-import { getTodayLocal, isProtocolActiveOnDate } from '@dosiq/core'
+// isProtocolInPeriod = predicado period-only (active flag + janela start/end).
+// NÃO usar isProtocolActiveOnDate (strict, frequency-aware) aqui: ele exige que
+// o tratamento "dispare HOJE", jogando semanal/dias_alternados/quando_necessario
+// pra "sem tratamento ativo" mesmo com a flag active ligada. Pro estoque, ter
+// tratamento ativo = estar no período + active, independente de disparar hoje.
+import { getTodayLocal, isProtocolInPeriod } from '@dosiq/core'
 
 export function transformStockData(rawData) {
   const today = getTodayLocal()
@@ -6,7 +11,7 @@ export function transformStockData(rawData) {
   return rawData.map((item) => {
     const totalQuantity = item.medicine_stock_summary?.[0]?.total_quantity || 0
     const activeProtocols = (item.protocols || []).filter(p =>
-      p.active && isProtocolActiveOnDate(p, today)
+      p.active && isProtocolInPeriod(p, today)
     )
 
     const dailyConsumption = activeProtocols.reduce((acc, p) => {

--- a/apps/mobile/src/features/stock/hooks/useStock.js
+++ b/apps/mobile/src/features/stock/hooks/useStock.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { AppState } from 'react-native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import { getTodayLocal, getNow, parseISO, addDays, isProtocolActiveOnDate } from '@dosiq/core'
+import { getTodayLocal, getNow, parseISO, addDays, isProtocolInPeriod } from '@dosiq/core'
 import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
 import { stockService } from '../services/stockService'
 import { debugLog } from '@shared/utils/debugLog'
@@ -113,11 +113,13 @@ export function useStock() {
     if (!state.data?.active && !state.data?.inactive) return state.data
     const today = getTodayLocal()
 
+    // Period-only (active flag + janela), não strict frequency-aware — senão
+    // semanal/dias_alternados/quando_necessario caem em "sem tratamento ativo".
     const isActiveToday = (item) => {
       if (item.activeProtocols) {
-        return item.activeProtocols.some(p => isProtocolActiveOnDate(p, today))
+        return item.activeProtocols.some(p => isProtocolInPeriod(p, today))
       }
-      return (item.protocols || []).some(p => p.active && isProtocolActiveOnDate(p, today))
+      return (item.protocols || []).some(p => p.active && isProtocolInPeriod(p, today))
     }
 
     const union = [...(state.data.active || []), ...(state.data.inactive || [])]

--- a/apps/mobile/src/features/stock/hooks/useStock.js
+++ b/apps/mobile/src/features/stock/hooks/useStock.js
@@ -115,7 +115,9 @@ export function useStock() {
 
     // Period-only (active flag + janela), não strict frequency-aware — senão
     // semanal/dias_alternados/quando_necessario caem em "sem tratamento ativo".
-    const isActiveToday = (item) => {
+    // Nome reflete período (não "dispara hoje"). Obsolescência na virada do dia
+    // já coberta por _setupMidnightAndAppState (R-175) que dispara loadStock.
+    const isInActivePeriod = (item) => {
       if (item.activeProtocols) {
         return item.activeProtocols.some(p => isProtocolInPeriod(p, today))
       }
@@ -123,9 +125,11 @@ export function useStock() {
     }
 
     const union = [...(state.data.active || []), ...(state.data.inactive || [])]
-    const refinedActive = union.filter(isActiveToday)
+    const refinedActive = union.filter(isInActivePeriod)
+    // totalQuantity > 0: seção inativa só lista saldo positivo (PO-9); item sem
+    // tratamento ativo E sem saldo não aparece. 0 = sem estoque, correto excluir.
     const refinedInactive = union.filter(
-      item => !isActiveToday(item) && (item.totalQuantity ?? 0) > 0,
+      item => !isInActivePeriod(item) && (item.totalQuantity ?? 0) > 0,
     )
 
     return {

--- a/apps/mobile/src/features/treatments/components/MedicineSelectorSheet.jsx
+++ b/apps/mobile/src/features/treatments/components/MedicineSelectorSheet.jsx
@@ -16,6 +16,7 @@ import {
   StyleSheet,
   Platform,
   StatusBar,
+  KeyboardAvoidingView,
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { Search, X, Pill, PillBottle, Plus } from 'lucide-react-native'
@@ -153,7 +154,12 @@ export default function MedicineSelectorSheet({
       // e inputs do form atrás vazam por cima do overlay no Android 7/API 24).
       statusBarTranslucent
     >
-      <View style={styles.root}>
+      <KeyboardAvoidingView
+        style={styles.root}
+        // iOS: eleva o sheet acima do teclado (sem isso, ao digitar a busca o
+        // teclado cobre o input e os resultados filtrados). Android: adjustResize.
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
         {Platform.OS === 'android' ? (
           <View style={{ height: StatusBar.currentHeight ?? 0 }} />
         ) : null}
@@ -216,7 +222,7 @@ export default function MedicineSelectorSheet({
             <Text style={styles.footerBtnText}>Cadastrar novo medicamento</Text>
           </Pressable>
         </SafeAreaView>
-      </View>
+      </KeyboardAvoidingView>
     </Modal>
   )
 }

--- a/apps/mobile/src/features/treatments/components/PlanSelectField.jsx
+++ b/apps/mobile/src/features/treatments/components/PlanSelectField.jsx
@@ -23,6 +23,7 @@ import { selectionTap, lightTap } from '@shared/utils/haptics'
 import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
 
 const CREATE_NEW_VALUE = '__create_new__'
+const NO_PLAN_VALUE = '__no_plan__'
 
 // Paleta sugerida (5 cores) — preferir tokens, mas paleta inline é PT-spec
 // (não há "plan-color" no design tokens; cores escolhidas para boa diferenciação).
@@ -56,6 +57,9 @@ export default function PlanSelectField({
             emoji: EMOJI_CHOICES[0],
           },
         })
+      } else if (planId === NO_PLAN_VALUE) {
+        // Remover de qualquer plano (tratamento "solto")
+        onChange?.({ mode: 'select', planId: null, inline: null })
       } else {
         onChange?.({ mode: 'select', planId: planId || null, inline: null })
       }
@@ -82,6 +86,7 @@ export default function PlanSelectField({
   // Render — modo SELECT
   if (value.mode !== 'inline') {
     const options = [
+      { value: NO_PLAN_VALUE, label: 'Sem plano' },
       ...plans.map((p) => ({
         value: p.id,
         label: `${p.emoji ? `${p.emoji} ` : ''}${p.name}`,
@@ -93,11 +98,13 @@ export default function PlanSelectField({
       <FormSelect
         name="treatment_plan"
         label="Plano terapêutico"
-        value={value.planId}
+        // planId null = sem plano → reflete a opção "Sem plano" selecionada
+        // (em vez do placeholder), deixando explícito que o tratamento fica solto.
+        value={value.planId ?? NO_PLAN_VALUE}
         options={options}
         onChange={handleSelectChange}
         error={error}
-        placeholder={plans.length ? 'Selecione um plano' : 'Sem planos cadastrados'}
+        placeholder="Selecione um plano"
       />
     )
   }

--- a/apps/mobile/src/features/treatments/screens/ProtocolDetailScreen.jsx
+++ b/apps/mobile/src/features/treatments/screens/ProtocolDetailScreen.jsx
@@ -113,7 +113,9 @@ export default function ProtocolDetailScreen() {
   const goToMedicine = useCallback(() => {
     if (!protocol?.medicine?.id) return
     selectionTap()
-    navigation.navigate(ROUTES.MEDICINE_DETAIL, { id: protocol.medicine.id })
+    // hideDelete: medicamento está dentro de um tratamento → exclusão sempre
+    // bloqueada (dependência). Ocultar o botão evita ação morta no detalhe.
+    navigation.navigate(ROUTES.MEDICINE_DETAIL, { id: protocol.medicine.id, hideDelete: true })
   }, [navigation, protocol])
 
   const onDelete = useCallback(() => {

--- a/apps/mobile/src/features/treatments/screens/TreatmentsScreen.jsx
+++ b/apps/mobile/src/features/treatments/screens/TreatmentsScreen.jsx
@@ -242,10 +242,10 @@ export default function TreatmentsScreen() {
                               pressed && styles.addToGroupPressed,
                             ]}
                             accessibilityRole="button"
-                            accessibilityLabel={`Adicionar tratamento ao grupo ${group.title}`}
+                            accessibilityLabel={`Adicionar novo tratamento ao grupo ${group.title}`}
                           >
                             <Plus size={16} color={colors.primary[700]} />
-                            <Text style={styles.addToGroupText}>Adicionar tratamento ao grupo</Text>
+                            <Text style={styles.addToGroupText}>Adicionar novo tratamento ao grupo</Text>
                           </Pressable>
                         </View>
                       )}


### PR DESCRIPTION
## Summary
8 correções de comportamento/UX no app mobile atual, validadas em smoke iOS pelo PO.

| # | Fix | Arquivo(s) |
|---|-----|-----------|
| 1 | Sheet de busca ANVISA eleva acima do teclado iOS (KeyboardAvoidingView) | `MedicineAnvisaSheet.jsx` |
| 2 | Opção **"Sem plano"** no seletor de plano terapêutico (desassocia o tratamento) | `PlanSelectField.jsx` |
| 3 | Estoque classifica "tratamento ativo" por **período** (`isProtocolInPeriod`), não pela versão strict frequency-aware — corrige `quando_necessario`/`semanal`/`dias_alternados` caindo em "sem tratamento ativo" | `_stockDataTransformer.js` · `useStock.js` |
| 4 | Label "**Adicionar novo tratamento ao grupo**" (o clique sempre cria novo) | `TreatmentsScreen.jsx` |
| 5 | Oculta "Excluir medicamento" no detalhe quando aberto a partir de um tratamento (param `hideDelete`) — exclusão sempre bloqueada por dependência | `ProtocolDetailScreen.jsx` · `MedicineDetailScreen.jsx` |
| 6 | Oculta placeholder de ordenação "Mais recentes" (sem sorting previsto) | `MedicinesListScreen.jsx` |
| 7 | FAB de estoque (sheet de seleção) eleva acima do teclado iOS | `PurchaseMedicineSheet.jsx` |
| 8 | Seletor de medicamento (form de tratamento) eleva acima do teclado iOS | `MedicineSelectorSheet.jsx` |

## Notas técnicas
- **Fix 3** corrige a raiz: o barrel `@dosiq/core` exporta `isProtocolActiveOnDate` (strict, frequency-aware — "dispara hoje?") e `isProtocolInPeriod` (period-only). Para classificação de estoque, "ter tratamento ativo" = `active` + dentro do período, independente de disparar hoje. Trocado o predicado no transformer + no re-split de meia-noite do `useStock`.
- **Fixes 1/7/8**: mesmo padrão `KeyboardAvoidingView` (behavior `padding` no iOS) nos 3 sheets de busca. `DoseRegisterModal` já usava. Follow-up sugerido: extrair primitivo `KeyboardAwareBottomSheet` (candidato ao form-kit da Fase 4).

## Test plan
- [x] Smoke iOS (PO): 3 sheets de busca elevam acima do teclado
- [x] Estoque lista PRN/semanal/alternados na seção "com tratamento ativo"
- [x] "Sem plano" desassocia tratamento; "Excluir medicamento" oculto via tratamento; label do grupo; sort oculto
- [ ] Lint/CI (node_modules local corrompido pós-eviction iCloud; validar no CI/worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AI Review Response

| Sugestão | Prioridade | Decisão | Motivo |
|---|---|---|---|
| Renomear isActiveToday → isInActivePeriod | Medium | Aplicada | Commit 3927b007 |
| Refresh meia-noite/AppState | Medium | Já existente | _setupMidnightAndAppState (R-175) + refinedData |
| Verificar check `> 0` | Medium | Intencional | PO-9: seção inativa só com saldo positivo |
| Centralizar em helper | Medium | Follow-up | Período já centralizado via isProtocolInPeriod; split dedicado fora de escopo |
