### PR TITLE
feat(mobile): signup confirm + permissão de push contextual + Notificações inbox-first

### DIFF
--- a/apps/mobile/src/features/dashboard/screens/__tests__/TodayScreen.test.jsx
+++ b/apps/mobile/src/features/dashboard/screens/__tests__/TodayScreen.test.jsx
@@ -5,6 +5,13 @@ import { useTodayData } from '@dashboard/hooks/useTodayData';
 // Mock do hook de dados
 jest.mock('@dashboard/hooks/useTodayData');
 
+// Mock react-navigation — TodayScreen usa useFocusEffect (refresh on focus, Fase 4)
+// que exige um NavigationContainer; sem isto o render lança fora do container.
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+  useFocusEffect: () => {},
+}));
+
 // Mock do lucide-react-native
 jest.mock('lucide-react-native', () => ({
   Pill: 'Pill',

--- a/apps/mobile/src/features/onboarding/screens/OnboardingTreatmentStep.jsx
+++ b/apps/mobile/src/features/onboarding/screens/OnboardingTreatmentStep.jsx
@@ -70,7 +70,9 @@ export default function OnboardingTreatmentStep() {
         return
       }
       const normalized = str.replace(',', '.')
-      if (normalized === '.' || normalized.endsWith('.')) {
+      // Mantém string em intermediários: termina em "." OU é decimal com zero à
+      // direita ("1,50"/"1,0") — converter agora engoliria o zero digitado.
+      if (normalized === '.' || normalized.endsWith('.') || (normalized.includes('.') && normalized.endsWith('0'))) {
         form.handleChange(name, str)
         return
       }

--- a/apps/mobile/src/features/onboarding/screens/OnboardingTreatmentStep.jsx
+++ b/apps/mobile/src/features/onboarding/screens/OnboardingTreatmentStep.jsx
@@ -17,7 +17,8 @@ import WeekdaySelector from '@treatments/components/WeekdaySelector'
 import TimeSchedulePicker from '@treatments/components/TimeSchedulePicker'
 import { useToast } from '@shared/components/feedback/Toast'
 import { protocolService } from '@treatments/services/protocolService'
-import { requestPushPermission } from '@platform/notifications/requestPushPermission'
+import { enablePushAtIntent } from '@platform/notifications/pushPermission'
+import { supabase } from '@platform/supabase/nativeSupabaseClient'
 import { useOnboarding } from '../OnboardingContext'
 import OnboardingHeader from '@features/onboarding/components/OnboardingHeader'
 import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
@@ -58,6 +59,27 @@ export default function OnboardingTreatmentStep() {
   // Handlers
   const setFrequency = useCallback((freq) => form.handleChange('frequency', freq), [form])
 
+  // Dose: converte para número já no onChange (paridade com ProtocolFormScreen).
+  // Sem isto a string "1" valida contra z.number() no blur → "Use apenas números".
+  // Intermediários ("0,", ".") ficam como string (converter agora apagaria a vírgula).
+  const handleDoseChange = useCallback(
+    (name, raw) => {
+      const str = String(raw ?? '')
+      if (str === '') {
+        form.handleChange(name, '')
+        return
+      }
+      const normalized = str.replace(',', '.')
+      if (normalized === '.' || normalized.endsWith('.')) {
+        form.handleChange(name, str)
+        return
+      }
+      const num = Number(normalized)
+      form.handleChange(name, Number.isFinite(num) ? num : str)
+    },
+    [form],
+  )
+
   const handleConcluir = useCallback(async () => {
     // Coerce dose string ("1" / "0,5") → number antes do validate (AP-167).
     const dose = Number(String(form.values.dosage_per_intake ?? '').replace(',', '.'))
@@ -72,7 +94,15 @@ export default function OnboardingTreatmentStep() {
         dosage_per_intake: dose,
         treatment_plan_id: null,
       })
-      if (remind) await requestPushPermission().catch(() => {})
+      // Ponto de intenção: só pede permissão de push se o usuário LIGOU o lembrete.
+      // Concedeu → registra token já (lembretes funcionam de cara). Negou no SO →
+      // segue o fluxo; a dona Maria reativa depois em Configurações (sem nag aqui).
+      if (remind) {
+        const { granted } = await enablePushAtIntent({ supabase }).catch(() => ({ granted: false }))
+        if (!granted) {
+          show('Tudo bem! Você pode ligar os lembretes depois em Configurações.', { variant: 'info', duration: 6000 })
+        }
+      }
       await finish()
     } catch (err) {
       setSubmitting(false)
@@ -145,7 +175,7 @@ export default function OnboardingTreatmentStep() {
             keyboardType="decimal-pad"
             value={String(form.values.dosage_per_intake ?? '')}
             error={form.touched.dosage_per_intake ? form.errors.dosage_per_intake : undefined}
-            onChange={form.handleChange}
+            onChange={handleDoseChange}
             onBlur={form.handleBlur}
           />
 

--- a/apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx
+++ b/apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx
@@ -409,6 +409,9 @@ export default function NotificationPreferencesScreen({ navigation }) {
   const [quietHoursEnd, setQuietHoursEnd] = useState('07:00')
   const [digestTime, setDigestTime] = useState('07:00')
   const [hasPermission, setHasPermission] = useState(false)
+  // Ref de permissão (R-010: declarado junto aos states, antes de effects/handlers).
+  // null = ainda não sabido; usado p/ agir só na transição negado→concedido.
+  const wasGrantedRef = useRef(null)
 
   // Carregar valores do banco ao montar
   useEffect(() => {
@@ -421,7 +424,7 @@ export default function NotificationPreferencesScreen({ navigation }) {
       setQuietHoursStart(settings.quiet_hours_start ?? '22:00')
       setQuietHoursEnd(settings.quiet_hours_end ?? '07:00')
       setDigestTime(settings.digest_time ?? '07:00')
-      setNotificationMode(settings.notification_mode)
+      setNotificationMode(settings.notification_mode ?? 'realtime')
 
       // Design A: canais independentes, sempre sincronizados (sem master global).
       setMobilePushEnabled(
@@ -458,11 +461,6 @@ export default function NotificationPreferencesScreen({ navigation }) {
   }, [user, mobilePushEnabled, isTelegramConnected, webPushEnabled, notificationMode,
       quietHoursEnabled, quietHoursStart, quietHoursEnd, digestTime, refresh])
 
-  // Guarda o último estado de permissão para agir só na TRANSIÇÃO negado→concedido.
-  // null = ainda não sabido (1º check não conta como transição — não atropela um
-  // OFF deliberado de quem já tinha permissão).
-  const wasGrantedRef = useRef(null)
-
   const checkPermission = useCallback(async () => {
     try {
       // Leitura PURA do status — NUNCA dispara o prompt do SO.
@@ -470,8 +468,9 @@ export default function NotificationPreferencesScreen({ navigation }) {
       setHasPermission(granted)
       // Transição real negado→concedido (ex.: voltou das Configs do SO autorizando):
       // registra o device E liga o canal — autorizar é intenção clara de receber push.
+      // userId explícito evita getUser() redundante (já temos user do useAuth).
       if (wasGrantedRef.current === false && granted) {
-        registerPushToken({ supabase }).catch(() => {})
+        registerPushToken({ supabase, userId: user?.id }).catch(() => {})
         setMobilePushEnabled(true)
         persist({ mobilePushEnabled: true })
       }
@@ -479,7 +478,7 @@ export default function NotificationPreferencesScreen({ navigation }) {
     } catch (err) {
       debugLog('NotificationPreferencesScreen', `Erro permissão: ${err.message}`)
     }
-  }, [persist])
+  }, [persist, user])
 
   // Re-checa permissão ao focar a tela (navegação)...
   useFocusEffect(

--- a/apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx
+++ b/apps/mobile/src/features/profile/screens/NotificationPreferencesScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, startTransition } from 'react'
+import React, { useState, useEffect, useCallback, useRef, startTransition } from 'react'
 import {
   View,
   Text,
@@ -10,13 +10,15 @@ import {
   Linking,
   Modal,
   FlatList,
+  AppState,
 } from 'react-native'
-import { Bell, Smartphone, Send, Globe, Mail, ChevronRight, Check } from 'lucide-react-native'
+import { Bell, Smartphone, Send, Globe, ChevronRight, Check, AlertTriangle } from 'lucide-react-native'
+import { useFocusEffect } from '@react-navigation/native'
 import { useAuth } from '@platform/auth/hooks/useAuth'
 import { useProfile } from '@profile/hooks/useProfile'
-import { requestPushPermission } from '@platform/notifications/requestPushPermission'
-import { getExpoPushToken } from '@platform/notifications/getExpoPushToken'
-import { syncNotificationDevice } from '@platform/notifications/syncNotificationDevice'
+import { getPushPermissionStatus, enablePushAtIntent } from '@platform/notifications/pushPermission'
+import { registerPushToken } from '@platform/notifications/registerPushToken'
+import { supabase } from '@platform/supabase/nativeSupabaseClient'
 import { updateNotificationSettings } from '../services/profileService'
 import ScreenContainer from '@shared/components/ui/ScreenContainer'
 import { colors, spacing, borderRadius, shadows } from '@shared/styles/tokens'
@@ -32,8 +34,11 @@ const HOURS = Array.from({ length: 24 }, (_, i) => {
 
 // Constrói o payload de configurações de notificação para o banco
 function _buildNotificationSettingsPayload(patch, state) {
+  // Design A (inbox-first): sem master global. Cada canal persiste sozinho; os
+  // lembretes do inbox independem disto. notification_preference é derivado dos
+  // canais (legado — api/notify ainda usa como fallback): 'none' só se tudo off.
   const { mobilePushEnabled, isTelegramConnected, webPushEnabled, notificationMode,
-          quietHoursEnabled, quietHoursStart, quietHoursEnd, digestTime, globalEnabled } = state
+          quietHoursEnabled, quietHoursStart, quietHoursEnd, digestTime } = state
   const mobile = patch.mobilePushEnabled ?? mobilePushEnabled
   const telegram = isTelegramConnected
   const web = patch.webPushEnabled ?? webPushEnabled
@@ -42,20 +47,20 @@ function _buildNotificationSettingsPayload(patch, state) {
   const qStart = patch.quietHoursStart ?? quietHoursStart
   const qEnd = patch.quietHoursEnd ?? quietHoursEnd
   const dTime = patch.digestTime ?? digestTime
-  const global = patch.globalEnabled ?? globalEnabled
 
   return {
     notification_mode: mode,
-    quiet_hours_start: (global && qEnabled) ? qStart : null,
-    quiet_hours_end: (global && qEnabled) ? qEnd : null,
-    quiet_hours_enabled: global && qEnabled,
+    quiet_hours_start: qEnabled ? qStart : null,
+    quiet_hours_end: qEnabled ? qEnd : null,
+    quiet_hours_enabled: qEnabled,
     digest_time: dTime,
-    channel_mobile_push_enabled: global && mobile,
-    channel_web_push_enabled: global && web,
-    channel_telegram_enabled: global && telegram,
-    notification_preference: global
-      ? deriveLegacyPreference({ channel_mobile_push_enabled: mobile, channel_telegram_enabled: telegram })
-      : 'none',
+    channel_mobile_push_enabled: mobile,
+    channel_web_push_enabled: web,
+    channel_telegram_enabled: telegram,
+    notification_preference: deriveLegacyPreference({
+      channel_mobile_push_enabled: mobile,
+      channel_telegram_enabled: telegram,
+    }),
   }
 }
 
@@ -154,10 +159,12 @@ function TimePicker({ value, onChange, label }) {
   )
 }
 
-// Seção de canais: App Push + Telegram + Web + Email
+// Seção de canais de aviso (entrega): App Push + Telegram + Web + Email.
+// Inbox-first: NÃO gateados por master. O push reflete a PERMISSÃO real do SO —
+// se negada, mostra OFF + legenda "bloqueado" e o tap dispara o CTA p/ Configs.
 function NotificationChannelsSection({
-  globalEnabled,
   mobilePushEnabled,
+  hasPermission,
   webPushEnabled,
   isTelegramConnected,
   onMobilePushToggle,
@@ -165,20 +172,43 @@ function NotificationChannelsSection({
 }) {
   return (
     <View style={styles.card}>
-      <View style={styles.channelRow}>
-        <View style={styles.rowLeft}>
-          <Smartphone size={20} color={colors.brand.primary} strokeWidth={2} />
-          <Text style={styles.rowLabel}>App (push)</Text>
+      {!hasPermission ? (
+        // Bloqueado no SO: linha em destaque âmbar, tocável → abre Configurações
+        // (via onMobilePushToggle → Alert/openSettings). Chip "Ativar" deixa a
+        // ação óbvia para a dona Maria.
+        <TouchableOpacity
+          style={[styles.channelRow, styles.channelRowBlocked]}
+          onPress={() => onMobilePushToggle(true)}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel="Notificações no celular bloqueadas. Toque para ativar nas Configurações."
+        >
+          <View style={styles.rowLeft}>
+            <AlertTriangle size={20} color={colors.status.warning} strokeWidth={2} />
+            <View style={styles.flexShrink}>
+              <Text style={styles.rowLabel}>Celular</Text>
+              <Text style={styles.rowHintWarning}>Bloqueado — toque para ativar nas Configurações</Text>
+            </View>
+          </View>
+          <View style={styles.activateChip}>
+            <Text style={styles.activateChipText}>Ativar</Text>
+          </View>
+        </TouchableOpacity>
+      ) : (
+        <View style={styles.channelRow}>
+          <View style={styles.rowLeft}>
+            <Smartphone size={20} color={colors.brand.primary} strokeWidth={2} />
+            <Text style={styles.rowLabel}>Celular</Text>
+          </View>
+          <Switch
+            value={mobilePushEnabled}
+            onValueChange={onMobilePushToggle}
+            trackColor={{ false: colors.neutral[200], true: colors.brand.primary }}
+            thumbColor={colors.bg.card}
+            accessibilityLabel="Ativar notificações no celular"
+          />
         </View>
-        <Switch
-          value={mobilePushEnabled && globalEnabled}
-          onValueChange={onMobilePushToggle}
-          disabled={!globalEnabled}
-          trackColor={{ false: colors.neutral[200], true: colors.brand.primary }}
-          thumbColor={colors.bg.card}
-          accessibilityLabel="Ativar notificações push do aplicativo"
-        />
-      </View>
+      )}
 
       <View style={styles.divider} />
 
@@ -213,24 +243,12 @@ function NotificationChannelsSection({
           </Text>
         </View>
       </View>
-
-      <View style={styles.divider} />
-
-      <View style={[styles.channelRow, styles.rowSoon]} pointerEvents="none">
-        <View style={styles.rowLeft}>
-          <Mail size={20} color={colors.text.muted} strokeWidth={2} />
-          <Text style={styles.rowLabel}>Email</Text>
-        </View>
-        <View style={[styles.badge, styles.badgeDisconnected]}>
-          <Text style={[styles.badgeText, styles.badgeTextDisconnected]}>EM BREVE</Text>
-        </View>
-      </View>
     </View>
   )
 }
 
 // Seção de modo de envio (radio buttons)
-function NotificationModeSection({ globalEnabled, notificationMode, onModeSelect }) {
+function NotificationModeSection({ notificationMode, onModeSelect }) {
   const MODES = [
     { value: 'realtime', label: 'Alertas unitários' },
     { value: 'digest_morning', label: 'Resumo diário' },
@@ -243,7 +261,6 @@ function NotificationModeSection({ globalEnabled, notificationMode, onModeSelect
           <TouchableOpacity
             style={styles.modeRow}
             onPress={() => onModeSelect(m.value)}
-            disabled={!globalEnabled}
             activeOpacity={0.7}
             accessibilityLabel={`Modo: ${m.label}`}
             accessibilityRole="radio"
@@ -252,7 +269,7 @@ function NotificationModeSection({ globalEnabled, notificationMode, onModeSelect
             <View style={[styles.radio, notificationMode === m.value && styles.radioActive]}>
               {notificationMode === m.value && <View style={styles.radioDot} />}
             </View>
-            <Text style={[styles.rowLabel, !globalEnabled && { color: colors.text.muted }]}>
+            <Text style={styles.rowLabel}>
               {m.label}
             </Text>
           </TouchableOpacity>
@@ -265,13 +282,12 @@ function NotificationModeSection({ globalEnabled, notificationMode, onModeSelect
 
 // Render principal da tela de preferências (pós-carregamento)
 function NotificationPreferencesContent({
-  navigation, globalEnabled, mobilePushEnabled, webPushEnabled, isTelegramConnected,
+  navigation, mobilePushEnabled, hasPermission, webPushEnabled, isTelegramConnected,
   showChannelWarning, notificationMode, digestTime, quietHoursEnabled, quietHoursStart, quietHoursEnd,
-  handleGlobalToggle, handleMobilePushToggle, handleTelegramPress, handleModeSelect,
+  handleMobilePushToggle, handleTelegramPress, handleModeSelect,
   handleQuietHoursToggle, setDigestTime, setQuietHoursStart, setQuietHoursEnd, persist,
 }) {
-  const bellColor = globalEnabled ? colors.brand.primary : colors.text.muted
-  const showDigest = notificationMode === 'digest_morning' && globalEnabled
+  const showDigest = notificationMode === 'digest_morning'
 
   return (
     <ScreenContainer>
@@ -284,36 +300,35 @@ function NotificationPreferencesContent({
           <Text style={styles.subtitle}>Escolha onde e quando ser avisado.</Text>
         </View>
 
+        {/* Inbox-first: lembretes sempre existem no app; canais abaixo são extras. */}
         <View style={[styles.card, styles.globalRow]}>
           <View style={styles.rowLeft}>
-            <Bell size={20} color={bellColor} strokeWidth={2} />
-            <Text style={styles.rowLabel}>Notificações ativas</Text>
+            <Bell size={20} color={colors.brand.primary} strokeWidth={2} />
+            <View style={styles.flexShrink}>
+              <Text style={styles.rowLabel}>Lembretes sempre ligados</Text>
+              <Text style={styles.rowHint}>
+                Sempre no app. Escolha abaixo como também ser avisada.
+              </Text>
+            </View>
           </View>
-          <Switch
-            value={globalEnabled}
-            onValueChange={handleGlobalToggle}
-            trackColor={{ false: colors.neutral[200], true: colors.brand.primary }}
-            thumbColor={colors.bg.card}
-            accessibilityLabel="Ativar ou desativar todas as notificações"
-          />
         </View>
 
-        <Text style={styles.sectionLabel}>CANAIS</Text>
+        <Text style={styles.sectionLabel}>CANAIS DE AVISO</Text>
         <NotificationChannelsSection
-          globalEnabled={globalEnabled} mobilePushEnabled={mobilePushEnabled}
+          mobilePushEnabled={mobilePushEnabled} hasPermission={hasPermission}
           webPushEnabled={webPushEnabled} isTelegramConnected={isTelegramConnected}
           onMobilePushToggle={handleMobilePushToggle} onTelegramPress={handleTelegramPress}
         />
 
         {showChannelWarning && (
           <Text style={styles.channelWarning}>
-            Ative ao menos um canal para receber lembretes de dose.
+            Ative ao menos um canal para ser avisada fora do app.
           </Text>
         )}
 
         <Text style={styles.sectionLabel}>MODO DE ENVIO</Text>
         <NotificationModeSection
-          globalEnabled={globalEnabled} notificationMode={notificationMode} onModeSelect={handleModeSelect}
+          notificationMode={notificationMode} onModeSelect={handleModeSelect}
         />
 
         {showDigest && (
@@ -331,7 +346,7 @@ function NotificationPreferencesContent({
         )}
 
         <NotificationQuietHoursSection
-          globalEnabled={globalEnabled} quietHoursEnabled={quietHoursEnabled}
+          quietHoursEnabled={quietHoursEnabled}
           quietHoursStart={quietHoursStart} quietHoursEnd={quietHoursEnd}
           onToggle={handleQuietHoursToggle}
           onStartChange={(v) => { setQuietHoursStart(v); persist({ quietHoursStart: v }) }}
@@ -346,7 +361,6 @@ function NotificationPreferencesContent({
 
 // Seção de horas silenciosas
 function NotificationQuietHoursSection({
-  globalEnabled,
   quietHoursEnabled,
   quietHoursStart,
   quietHoursEnd,
@@ -358,20 +372,19 @@ function NotificationQuietHoursSection({
     <>
       <Text style={styles.sectionLabel}>NÃO ME INCOMODE</Text>
       <View style={[styles.card, styles.globalRow]}>
-        <Text style={[styles.rowLabel, !globalEnabled && { color: colors.text.muted }]}>
+        <Text style={styles.rowLabel}>
           Silenciar por período
         </Text>
         <Switch
-          value={quietHoursEnabled && globalEnabled}
+          value={quietHoursEnabled}
           onValueChange={onToggle}
-          disabled={!globalEnabled}
           trackColor={{ false: colors.neutral[200], true: colors.brand.primary }}
           thumbColor={colors.bg.card}
           accessibilityLabel="Ativar horas de silêncio"
         />
       </View>
 
-      {quietHoursEnabled && globalEnabled && (
+      {quietHoursEnabled && (
         <View style={[styles.card, styles.timeRow]}>
           <Text style={styles.rowLabel}>Das</Text>
           <TimePicker value={quietHoursStart} label="Início do silêncio" onChange={onStartChange} />
@@ -388,7 +401,6 @@ export default function NotificationPreferencesScreen({ navigation }) {
   const { settings, refresh } = useProfile()
   const isTelegramConnected = !!settings?.telegram_chat_id
 
-  const [globalEnabled, setGlobalEnabled] = useState(true)
   const [mobilePushEnabled, setMobilePushEnabled] = useState(true)
   const [webPushEnabled, setWebPushEnabled] = useState(false)
   const [notificationMode, setNotificationMode] = useState('realtime')
@@ -409,46 +421,26 @@ export default function NotificationPreferencesScreen({ navigation }) {
       setQuietHoursStart(settings.quiet_hours_start ?? '22:00')
       setQuietHoursEnd(settings.quiet_hours_end ?? '07:00')
       setDigestTime(settings.digest_time ?? '07:00')
-
-      const isGlobal = pref !== 'none'
-      setGlobalEnabled(isGlobal)
       setNotificationMode(settings.notification_mode)
 
-      // Apenas sincroniza canais individuais se o global estiver ON
-      if (isGlobal) {
-        setMobilePushEnabled(
-          settings.channel_mobile_push_enabled ??
-          (pref === 'mobile_push' || pref === 'both')
-        )
-        setWebPushEnabled(settings.channel_web_push_enabled ?? false)
-      }
+      // Design A: canais independentes, sempre sincronizados (sem master global).
+      setMobilePushEnabled(
+        settings.channel_mobile_push_enabled ??
+        (pref === 'mobile_push' || pref === 'both')
+      )
+      setWebPushEnabled(settings.channel_web_push_enabled ?? false)
     })
   }, [settings])
 
-  async function checkPermission() {
-    try {
-      const { granted } = await requestPushPermission()
-      setHasPermission(granted)
-    } catch (err) {
-      debugLog('NotificationPreferencesScreen', `Erro permissão: ${err.message}`)
-    }
-  }
-
-  useEffect(() => {
-    startTransition(() => {
-      checkPermission()
-    })
-  }, [])
-
-  const hasAnyChannel = mobilePushEnabled || isTelegramConnected || webPushEnabled
-  const showChannelWarning = globalEnabled && !hasAnyChannel
+  const hasAnyChannel = (mobilePushEnabled && hasPermission) || isTelegramConnected || webPushEnabled
+  const showChannelWarning = !hasAnyChannel
 
   // Salvar no banco (debounce manual: chama após cada alteração)
   const persist = useCallback(async (patch) => {
     if (!user?.id) return
     const state = {
       mobilePushEnabled, isTelegramConnected, webPushEnabled, notificationMode,
-      quietHoursEnabled, quietHoursStart, quietHoursEnd, digestTime, globalEnabled,
+      quietHoursEnabled, quietHoursStart, quietHoursEnd, digestTime,
     }
     try {
       const payload = _buildNotificationSettingsPayload(patch, state)
@@ -464,44 +456,69 @@ export default function NotificationPreferencesScreen({ navigation }) {
       Alert.alert('Erro', 'Não foi possível salvar as preferências: ' + err.message)
     }
   }, [user, mobilePushEnabled, isTelegramConnected, webPushEnabled, notificationMode,
-      quietHoursEnabled, quietHoursStart, quietHoursEnd, digestTime, globalEnabled, refresh])
+      quietHoursEnabled, quietHoursStart, quietHoursEnd, digestTime, refresh])
+
+  // Guarda o último estado de permissão para agir só na TRANSIÇÃO negado→concedido.
+  // null = ainda não sabido (1º check não conta como transição — não atropela um
+  // OFF deliberado de quem já tinha permissão).
+  const wasGrantedRef = useRef(null)
+
+  const checkPermission = useCallback(async () => {
+    try {
+      // Leitura PURA do status — NUNCA dispara o prompt do SO.
+      const { granted } = await getPushPermissionStatus()
+      setHasPermission(granted)
+      // Transição real negado→concedido (ex.: voltou das Configs do SO autorizando):
+      // registra o device E liga o canal — autorizar é intenção clara de receber push.
+      if (wasGrantedRef.current === false && granted) {
+        registerPushToken({ supabase }).catch(() => {})
+        setMobilePushEnabled(true)
+        persist({ mobilePushEnabled: true })
+      }
+      wasGrantedRef.current = granted
+    } catch (err) {
+      debugLog('NotificationPreferencesScreen', `Erro permissão: ${err.message}`)
+    }
+  }, [persist])
+
+  // Re-checa permissão ao focar a tela (navegação)...
+  useFocusEffect(
+    useCallback(() => {
+      startTransition(() => { checkPermission() })
+    }, [checkPermission])
+  )
+
+  // ...e ao voltar do background (ex.: retorno das Configurações do SO). Isto NÃO
+  // é foco de navegação — a tela nunca perdeu foco; só o app foi pro background.
+  // Sem este listener o toggle não atualizava ao reconceder a permissão no SO.
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (next) => {
+      if (next === 'active') checkPermission()
+    })
+    return () => sub.remove()
+  }, [checkPermission])
 
   async function handleMobilePushToggle(val) {
     if (val && !hasPermission) {
-      const { granted } = await requestPushPermission()
+      // Ponto de intenção: pede permissão e registra o token se concedido.
+      const { granted, blocked } = await enablePushAtIntent({ supabase })
       if (!granted) {
-        Alert.alert(
-          'Permissão necessária',
-          'Abrir Configurações para ativar notificações?',
-          [
-            { text: 'Cancelar', style: 'cancel' },
-            { text: 'Abrir Configurações', onPress: () => Linking.openSettings() },
-          ]
-        )
+        if (blocked) {
+          Alert.alert(
+            'Permissão necessária',
+            'Abrir Configurações para ativar notificações?',
+            [
+              { text: 'Cancelar', style: 'cancel' },
+              { text: 'Abrir Configurações', onPress: () => Linking.openSettings() },
+            ]
+          )
+        }
         return
       }
       setHasPermission(true)
-      try {
-        const token = await getExpoPushToken()
-        await syncNotificationDevice({ supabase: user?.supabase, userId: user.id, token })
-      } catch (syncErr) {
-        debugLog('NotificationPreferencesScreen', `Erro sync device: ${syncErr.message}`)
-      }
     }
     setMobilePushEnabled(val)
     persist({ mobilePushEnabled: val })
-  }
-
-  function handleGlobalToggle(val) {
-    setGlobalEnabled(val)
-    // Se está ativando e nada está ligado, ativa mobile_push como padrão
-    // para evitar que o estado volte a 'none' no DB e dê snap-back para off
-    if (val && !hasAnyChannel) {
-      setMobilePushEnabled(true)
-      persist({ globalEnabled: true, mobilePushEnabled: true })
-    } else {
-      persist({ globalEnabled: val })
-    }
   }
 
   function handleModeSelect(mode) {
@@ -521,12 +538,12 @@ export default function NotificationPreferencesScreen({ navigation }) {
   return (
     <NotificationPreferencesContent
       navigation={navigation}
-      globalEnabled={globalEnabled} mobilePushEnabled={mobilePushEnabled}
+      mobilePushEnabled={mobilePushEnabled} hasPermission={hasPermission}
       webPushEnabled={webPushEnabled} isTelegramConnected={isTelegramConnected}
       showChannelWarning={showChannelWarning} notificationMode={notificationMode}
       digestTime={digestTime} quietHoursEnabled={quietHoursEnabled}
       quietHoursStart={quietHoursStart} quietHoursEnd={quietHoursEnd}
-      handleGlobalToggle={handleGlobalToggle} handleMobilePushToggle={handleMobilePushToggle}
+      handleMobilePushToggle={handleMobilePushToggle}
       handleTelegramPress={handleTelegramPress} handleModeSelect={handleModeSelect}
       handleQuietHoursToggle={handleQuietHoursToggle}
       setDigestTime={setDigestTime} setQuietHoursStart={setQuietHoursStart}
@@ -629,6 +646,30 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: colors.text.muted,
     marginTop: 2,
+  },
+  rowHintWarning: {
+    fontSize: 12,
+    color: colors.status.warning,
+    marginTop: 2,
+  },
+  flexShrink: {
+    flex: 1,
+  },
+  channelRowBlocked: {
+    // Banda âmbar preenchendo todo o row (full-width); conteúdo segue no padding
+    // padrão do channelRow, alinhado com Telegram/Web.
+    backgroundColor: colors.supplement[50],
+  },
+  activateChip: {
+    backgroundColor: colors.status.warning,
+    borderRadius: borderRadius.full,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[1],
+  },
+  activateChipText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.bg.card,
   },
 
   // Badges

--- a/apps/mobile/src/features/treatments/hooks/useProtocolFormSubmit.js
+++ b/apps/mobile/src/features/treatments/hooks/useProtocolFormSubmit.js
@@ -8,6 +8,8 @@
 
 import { useCallback, useState } from 'react'
 import { treatmentPlanService } from '../services/treatmentPlanService'
+import { getPushPermissionStatus, enablePushAtIntent } from '@platform/notifications/pushPermission'
+import { supabase } from '@platform/supabase/nativeSupabaseClient'
 
 function coerceDose(form) {
   const raw = form.values.dosage_per_intake
@@ -73,6 +75,16 @@ export function useProtocolFormSubmit({ editId, form, planField, mutation, show,
       const result = editId
         ? await mutation.update(editId, payload, { goBack: true })
         : await mutation.create(payload, { goBack: true })
+
+      // Ponto de intenção #2: ao criar tratamento manualmente, se NUNCA pedimos
+      // push (status undetermined), pede agora — é o momento em que lembretes de
+      // dose fazem sentido. Só na 1ª vez (undetermined); depois nunca mais (sem nag).
+      if (!editId && result) {
+        const { status } = await getPushPermissionStatus()
+        if (status === 'undetermined') {
+          await enablePushAtIntent({ supabase }).catch(() => {})
+        }
+      }
 
       if (!result) setSubmitting(false)
     } catch (err) {

--- a/apps/mobile/src/navigation/Navigation.jsx
+++ b/apps/mobile/src/navigation/Navigation.jsx
@@ -44,6 +44,8 @@ export default function Navigation() {
   const [onboardingNeeded, setOnboardingNeeded] = useState(false)
 
   // Setup push notifications pós-login (H6.3)
+  // Setup push register-only: nunca pede permissão (isso é dos pontos de intenção
+  // — onboarding/criação de tratamento/configs). Só registra token se já concedido.
   usePushNotifications({ supabase, session })
 
   // Handler para rastrear mudanças de tela — getCurrentRoute é mais robusto com nested navigators
@@ -123,23 +125,27 @@ export default function Navigation() {
         }
       }
 
-      // Implicit flow: dosiq://auth/callback#access_token=...&refresh_token=...&type=recovery
+      // Implicit flow: dosiq://auth/callback#access_token=...&refresh_token=...&type=recovery|signup
       const hash = url.split('#')[1]
       if (!hash) return
       const sp = new URLSearchParams(hash)
       const tokenType = sp.get('type')
       const accessToken = sp.get('access_token')
       const refreshToken = sp.get('refresh_token')
-      if (tokenType === 'recovery' && accessToken && refreshToken) {
+      if (accessToken && refreshToken && (tokenType === 'recovery' || tokenType === 'signup')) {
         try {
           const { error } = await supabase.auth.setSession({
             access_token: accessToken,
             refresh_token: refreshToken,
           })
-          if (error) debugLog('Navigation', 'setSession recovery falhou', error.message)
-          else setIsPasswordRecovery(true) // dispara SIGNED_IN, não PASSWORD_RECOVERY
+          if (error) {
+            debugLog('Navigation', `setSession ${tokenType} falhou`, error.message)
+          } else if (tokenType === 'recovery') {
+            setIsPasswordRecovery(true) // recovery → tela de redefinir senha
+          }
+          // signup: setSession dispara SIGNED_IN → app abre logado (gate de onboarding)
         } catch (e) {
-          debugLog('Navigation', 'Exceção em setSession recovery', e?.message)
+          debugLog('Navigation', `Exceção em setSession ${tokenType}`, e?.message)
         }
       }
     }

--- a/apps/mobile/src/platform/auth/__tests__/authService.test.js
+++ b/apps/mobile/src/platform/auth/__tests__/authService.test.js
@@ -107,6 +107,7 @@ describe('authService', () => {
       expect(supabase.auth.signUp).toHaveBeenCalledWith({
         email: 'novo@example.com',
         password: 'Senha123!',
+        options: { emailRedirectTo: 'dosiq://auth/callback' },
       })
     })
 

--- a/apps/mobile/src/platform/auth/authService.js
+++ b/apps/mobile/src/platform/auth/authService.js
@@ -107,6 +107,12 @@ export async function signUpWithEmail(email, password, confirmPassword) {
     const { error: authError } = await supabase.auth.signUp({
       email: validation.data.email,
       password: validation.data.password,
+      options: {
+        // Deeplink first: o link de confirmação reabre o app já logado
+        // (handler em Navigation.jsx trata type=signup). Mesmo callback do
+        // recovery — já liberado no allow-list do Supabase.
+        emailRedirectTo: 'dosiq://auth/callback',
+      },
     })
 
     if (authError) {

--- a/apps/mobile/src/platform/notifications/__tests__/usePushNotifications.test.js
+++ b/apps/mobile/src/platform/notifications/__tests__/usePushNotifications.test.js
@@ -25,6 +25,9 @@ jest.mock('expo-notifications', () => ({
   getLastNotificationResponseAsync: jest.fn(() => Promise.resolve(null)),
   addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
   setNotificationHandler: jest.fn(),
+  // Register-only: hook lê status (puro), não pede permissão. 'denied' mantém os
+  // testes focados em deeplink sem acionar registro de token.
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'denied', canAskAgain: false })),
 }))
 
 jest.mock('../requestPushPermission', () => ({

--- a/apps/mobile/src/platform/notifications/pushPermission.js
+++ b/apps/mobile/src/platform/notifications/pushPermission.js
@@ -1,0 +1,53 @@
+// Permissão de push — modelo CONTEXTUAL (não pedir no 1º load).
+//
+// Princípio (persona dona Maria, non-tech): o prompt do OS é "bala única". Pedir
+// sem contexto → usuário nega por reflexo → push morre (reativar exige ir nas
+// Configurações do SO, que ela não faz). Então só pedimos em momentos de INTENÇÃO
+// clara: toggle de lembrete no onboarding, criação manual do 1º tratamento, ou ao
+// ligar notificações nas Configurações.
+//
+// - getPushPermissionStatus(): leitura PURA do status, NUNCA dispara prompt.
+// - ensurePushPermission(): pede só se ainda dá (undetermined). Se negado e sem
+//   poder repedir, retorna { blocked:true } para o caller oferecer deep link p/
+//   as Configurações do SO.
+// - enablePushAtIntent(): ensure + registra o token se concedido (one-call dos
+//   pontos de intenção).
+
+import * as Notifications from 'expo-notifications'
+import { registerPushToken } from './registerPushToken'
+import { debugLog } from '@shared/utils/debugLog'
+
+// Status puro — sem efeitos colaterais. 'granted' | 'undetermined' | 'denied'.
+export async function getPushPermissionStatus() {
+  const { status, canAskAgain } = await Notifications.getPermissionsAsync()
+  return { status, canAskAgain, granted: status === 'granted' }
+}
+
+// Pede permissão apenas em ponto de intenção. Nunca repete prompt já negado.
+// Retorna { granted, blocked }: blocked=true quando negado e não dá p/ repedir
+// (caller deve oferecer abrir Configurações do SO).
+export async function ensurePushPermission() {
+  const { status, canAskAgain } = await Notifications.getPermissionsAsync()
+  if (status === 'granted') return { granted: true, blocked: false }
+  if (canAskAgain) {
+    const res = await Notifications.requestPermissionsAsync()
+    const granted = res.status === 'granted'
+    return { granted, blocked: !granted && res.canAskAgain === false }
+  }
+  // negado + não pode repedir → só via Configurações do SO
+  return { granted: false, blocked: true }
+}
+
+// One-call para pontos de intenção: pede (se cabível) e, se concedido, registra
+// o token imediatamente (para os lembretes funcionarem já, sem esperar relaunch).
+export async function enablePushAtIntent({ supabase }) {
+  const { granted, blocked } = await ensurePushPermission()
+  if (granted) {
+    try {
+      await registerPushToken({ supabase })
+    } catch (err) {
+      debugLog('pushPermission', 'registerPushToken falhou', err?.message)
+    }
+  }
+  return { granted, blocked }
+}

--- a/apps/mobile/src/platform/notifications/registerPushToken.js
+++ b/apps/mobile/src/platform/notifications/registerPushToken.js
@@ -1,0 +1,31 @@
+// Registra o Expo push token no backend — assume permissão JÁ concedida (não
+// pede). Usado pelo setup global (register-only) e pelos pontos de intenção
+// (após enablePushAtIntent conceder). Idempotente.
+
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { getExpoPushToken } from './getExpoPushToken'
+import { syncNotificationDevice } from './syncNotificationDevice'
+import { debugLog } from '@shared/utils/debugLog'
+
+export const PUSH_TOKEN_KEY = '@dosiq/expo-push-token'
+
+// Resolve userId pela sessão atual quando não passado. Retorna o token ou null.
+export async function registerPushToken({ supabase, userId }) {
+  const token = await getExpoPushToken()
+  if (!token) return null
+
+  let uid = userId
+  if (!uid) {
+    const { data } = await supabase.auth.getUser()
+    uid = data?.user?.id
+  }
+  if (!uid) {
+    debugLog('registerPushToken', 'sem userId — abortado')
+    return null
+  }
+
+  await syncNotificationDevice({ supabase, userId: uid, token })
+  await AsyncStorage.setItem(PUSH_TOKEN_KEY, token)
+  debugLog('registerPushToken', 'token registrado', token.substring(0, 20) + '...')
+  return token
+}

--- a/apps/mobile/src/platform/notifications/usePushNotifications.js
+++ b/apps/mobile/src/platform/notifications/usePushNotifications.js
@@ -1,20 +1,18 @@
-// Hook para setup de push notifications pós-login
-// Configura: permissão, token registration, notification handlers
-// Cleanup automático em logout (via dependencies)
-// N1.4: deeplink real via navigationRef (foreground/background tap + cold start)
+// Hook para setup de push notifications pós-login — REGISTER-ONLY.
+// NUNCA pede permissão aqui (isso é dos pontos de intenção — ver pushPermission.js).
+// Se a permissão já foi concedida, registra o token; senão, não faz nada.
+// Configura handlers + tap listener (deeplink real via navigationRef).
+// Cleanup automático em logout (via dependencies).
 
 import { useEffect, useRef } from 'react'
 import * as Notifications from 'expo-notifications'
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import { requestPushPermission } from './requestPushPermission'
-import { getExpoPushToken } from './getExpoPushToken'
-import { syncNotificationDevice } from './syncNotificationDevice'
+import { getPushPermissionStatus } from './pushPermission'
+import { registerPushToken, PUSH_TOKEN_KEY } from './registerPushToken'
 import { unregisterNotificationDevice } from './unregisterNotificationDevice'
 import { navigationRef } from '../../navigation/navigationRef'
 import { ROUTES } from '../../navigation/routes'
 import { debugLog } from '@shared/utils/debugLog'
-
-const PUSH_TOKEN_KEY = '@dosiq/expo-push-token'
 
 // Mapa de screen names do payload para rotas do navigator
 const SCREEN_TO_ROUTE = {
@@ -78,25 +76,8 @@ export function usePushNotifications({ supabase, session }) {
           }
         }
 
-        const { granted } = await requestPushPermission()
-
-        if (!granted) {
-          debugLog('[usePushNotifications] Permissão de push não concedida')
-          return
-        }
-
-        const token = await getExpoPushToken()
-        if (!isMounted) return
-
-        await syncNotificationDevice({
-          supabase,
-          userId: session.user.id,
-          token,
-        })
-
-        await AsyncStorage.setItem(PUSH_TOKEN_KEY, token)
-
-        // Configurar handlers (conforme spec Passo 5)
+        // Handlers + tap listener SEMPRE (independem de permissão; harmless se não
+        // houver notificações). Garantem que um tap roteie certo assim que houver.
         Notifications.setNotificationHandler({
           handleNotification: async () => ({
             shouldShowBanner: true,
@@ -105,8 +86,6 @@ export function usePushNotifications({ supabase, session }) {
             shouldSetBadge: false,
           }),
         })
-
-        // Handler de tap em notificação (foreground / background)
         notificationSubscription = Notifications.addNotificationResponseReceivedListener(
           (response) => {
             const navigationData = response.notification.request.content.data?.navigation
@@ -114,7 +93,15 @@ export function usePushNotifications({ supabase, session }) {
           }
         )
 
-        debugLog('[usePushNotifications] Push setup completo: token =', token.substring(0, 20) + '...')
+        // REGISTER-ONLY: registra o token só se a permissão JÁ foi concedida.
+        // NUNCA pedir aqui — o prompt é dos pontos de intenção (pushPermission.js).
+        const { granted } = await getPushPermissionStatus()
+        if (!granted) {
+          debugLog('[usePushNotifications] Sem permissão — register-only, nada a fazer')
+          return
+        }
+        if (!isMounted) return
+        await registerPushToken({ supabase, userId: session.user.id })
       } catch (error) {
         if (isMounted && __DEV__) {
           console.error('[usePushNotifications] Erro durante setup:', error.message)

--- a/apps/mobile/src/screens/SignupScreen.jsx
+++ b/apps/mobile/src/screens/SignupScreen.jsx
@@ -43,16 +43,19 @@ export default function SignupScreen({ navigation }) {
           <View style={styles.successIconWrapper}>
             <Mail size={56} color={colors.brand.primary} />
           </View>
-          <Text style={styles.successTitle}>Verifique seu email</Text>
+          <Text style={styles.successTitle}>Só falta confirmar seu e-mail</Text>
           <Text style={styles.successDescription}>
-            Enviamos um link de confirmação para{'\n'}
+            Mandamos uma mensagem para{'\n'}
             <Text style={styles.successEmail}>{email}</Text>
           </Text>
-          <Text style={styles.successHint}>
-            Após confirmar seu email, faça login para continuar.
+          <Text style={styles.successBody}>
+            Abra o e-mail e toque no link para ativar sua conta. É rapidinho!
           </Text>
-          <Pressable style={styles.button} onPress={() => navigation.navigate(ROUTES.LOGIN)}>
-            <Text style={styles.buttonText}>Ir para Login</Text>
+          <Text style={styles.successHint}>
+            Não chegou em alguns minutos? Veja na pasta de lixo eletrônico. Depois de confirmar, volte ao app e entre com o e-mail e a senha que você criou.
+          </Text>
+          <Pressable style={styles.successButton} onPress={() => navigation.navigate(ROUTES.LOGIN)}>
+            <Text style={styles.buttonText}>Entre com sua conta</Text>
           </Pressable>
         </View>
       </SafeAreaView>
@@ -360,16 +363,32 @@ const styles = StyleSheet.create({
     color: colors.text.secondary,
     textAlign: 'center',
     lineHeight: 24,
-    marginBottom: spacing[3],
+    marginBottom: spacing[4],
   },
   successEmail: {
     fontWeight: '700',
     color: colors.text.primary,
   },
+  successBody: {
+    fontSize: 16,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    lineHeight: 24,
+    marginBottom: spacing[3],
+  },
   successHint: {
     fontSize: 14,
     color: colors.text.muted,
     textAlign: 'center',
-    marginBottom: spacing[6],
+    lineHeight: 20,
+    marginBottom: spacing[8],
+  },
+  successButton: {
+    alignSelf: 'stretch',
+    backgroundColor: colors.brand.primary,
+    height: 54,
+    borderRadius: borderRadius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 })

--- a/apps/mobile/src/screens/__tests__/LandingScreen.test.jsx
+++ b/apps/mobile/src/screens/__tests__/LandingScreen.test.jsx
@@ -58,7 +58,7 @@ describe('LandingScreen', () => {
     const { getByText } = render(<LandingScreen navigation={mockNavigation} />);
     
     expect(getByText('dosiq')).toBeTruthy();
-    expect(getByText(/Sua saúde sob/)).toBeTruthy();
+    expect(getByText(/Nunca mais/)).toBeTruthy();
     expect(getByText('91%')).toBeTruthy();
     expect(getByText('40mg • 1 Comprimido')).toBeTruthy();
     expect(getByText('08:00')).toBeTruthy();


### PR DESCRIPTION
## Resumo

Três frentes de UX no mobile, validadas em dev (build nativo) com o PO:

### 1. Confirmação de signup + deeplink-first
- Tela "verifique e-mail" reescrita (persona dona Maria, label-agnostic).
- `emailRedirectTo: dosiq://auth/callback` + handler `type=signup` → usuário volta do e-mail **já logado** no passo 2 do onboarding.

### 2. Permissão de push contextual (nunca no 1º load)
- `usePushNotifications` vira **register-only** (só registra token se já concedido).
- Pede permissão só em **pontos de intenção**: toggle de lembrete no onboarding, 1ª criação manual de tratamento, toggle nas Configurações.
- Negado → toast gentil / CTA Configurações do SO.

### 3. Tela de Notificações — Design A (inbox-first)
- Remove master "Notificações ativas" → linha info **"Lembretes sempre ligados"**.
- Canais independentes; **"Celular"** reflete a permissão real (banda âmbar + chip **Ativar** quando bloqueado → abre Configs do SO).
- `AppState`/focus recheck: autorizar nas Configs e voltar → toggle **ON** + device registrado (só na transição negado→concedido).
- Remove canal placeholder "Email". Payload sem master (`notification_preference` derivado dos canais). **Zero migration.**

### Correções
- Campo de dose do passo 3 coage p/ número no onChange (não acusa "Use apenas números" em "1"/"1,5").
- Toast de push 6s.
- Regressão pré-existente de testes Landing/Today corrigida.

## Testes
- `npm test --workspace @dosiq/mobile`: **148 passando** (0 falhas), lint 0 erros.

## Validação
PO validou todos os fluxos em build nativo (`expo --device`): deeplink logado, prompt contextual, banda âmbar + retorno das Configs, dose field, Design A.

## AI Review Response
| Suggestion | Priority | Decision | Reason |
|------------|----------|----------|--------|
| Decimal com zero à direita no campo de dose | High | Applied | 5f22bae1 |
| notification_mode fallback 'realtime' | Medium | Applied | 414a22bb |
| registerPushToken userId explícito | Medium | Applied | 414a22bb |
| wasGrantedRef ordem de hooks (R-010) | Medium | Applied | 414a22bb |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
