### PR TITLE
feat(deeplink): Universal Links / App Links + banner 'abra no app' (web mobile)

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -58,6 +58,8 @@ module.exports = {
         ITSAppUsesNonExemptEncryption: false,
         UIBackgroundModes: ['remote-notification'],
       },
+      // UL-S1: Universal Links iOS
+      associatedDomains: ['applinks:dosiq.app'],
     },
     android: {
       package: current.androidPackage,
@@ -68,6 +70,15 @@ module.exports = {
         backgroundColor: '#F0FDFB',
       },
       edgeToEdgeEnabled: true,
+      // UL-S1: App Links Android
+      intentFilters: [
+        {
+          action: 'VIEW',
+          autoVerify: true,
+          data: [{ scheme: 'https', host: 'dosiq.app', pathPrefix: '/auth' }],
+          category: ['BROWSABLE', 'DEFAULT'],
+        },
+      ],
     },
     plugins: [
       '@react-native-firebase/app',

--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -1,0 +1,1 @@
+{"applinks":{"details":[{"appID":"LU8V56S7QF.com.coelhotv.dosiq","paths":["/auth/*"]}]}}

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -12,6 +12,7 @@ import { OnboardingProvider } from '@shared/components/onboarding'
 import { DashboardProvider } from '@dashboard/hooks/useDashboardContext.jsx'
 import InstallPrompt from '@shared/components/pwa/InstallPrompt'
 import { OfflineBanner } from '@shared/components/ui/OfflineBanner'
+import MobileAppBanner from '@shared/components/MobileAppBanner'
 
 const BottomNavRedesign = lazy(() => import('@shared/components/ui/BottomNavRedesign'))
 const Sidebar = lazy(() => import('@shared/components/ui/Sidebar'))
@@ -72,6 +73,8 @@ function AppInner() {
         <a href="#main-content" className="skip-to-content">Ir para conteúdo principal</a>
 
         <div className="app-container">
+          <MobileAppBanner />
+
           {isAuthenticated && (
             <Suspense fallback={null}>
               <Sidebar currentView={currentView} setCurrentView={setCurrentView} onNewDose={() => setIsDoseModalOpen(true)} unreadCount={unreadCount} />

--- a/apps/web/src/shared/components/MobileAppBanner.css
+++ b/apps/web/src/shared/components/MobileAppBanner.css
@@ -8,9 +8,9 @@
   align-items: center;
   gap: var(--space-2, 8px);
   padding: 10px var(--space-4, 16px);
-  background: var(--color-primary-container, #d9e4ff);
-  color: var(--color-on-primary-container, #001a41);
-  border-bottom: 1px solid var(--color-primary, #415f91);
+  background: var(--color-primary, #1f6b4f);
+  color: var(--color-on-primary, #ffffff);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
   font-family: var(--font-body);
   font-size: var(--text-label-md, 13px);
   font-weight: var(--font-weight-medium, 500);
@@ -38,7 +38,10 @@
 
 .mobile-app-banner__icon {
   flex-shrink: 0;
-  color: var(--color-primary, #415f91);
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-sm, 6px);
+  object-fit: contain;
 }
 
 .mobile-app-banner__text {
@@ -51,8 +54,8 @@
   flex-shrink: 0;
   padding: 4px 12px;
   border-radius: var(--radius-full, 9999px);
-  background: var(--color-primary, #415f91);
-  color: var(--color-on-primary, #ffffff);
+  background: #ffffff;
+  color: var(--color-primary, #1f6b4f);
   font-size: var(--text-label-sm, 12px);
   font-weight: var(--font-weight-semibold, 600);
   text-decoration: none;
@@ -62,8 +65,8 @@
 
 .mobile-app-banner__cta:hover,
 .mobile-app-banner__cta:focus-visible {
-  opacity: 0.88;
-  outline: 2px solid var(--color-primary, #415f91);
+  opacity: 0.9;
+  outline: 2px solid #ffffff;
   outline-offset: 2px;
 }
 
@@ -77,14 +80,14 @@
   border: none;
   border-radius: var(--radius-full, 9999px);
   background: transparent;
-  color: var(--color-on-primary-container, #001a41);
+  color: var(--color-on-primary, #ffffff);
   cursor: pointer;
   transition: background 0.15s ease;
 }
 
 .mobile-app-banner__close:hover,
 .mobile-app-banner__close:focus-visible {
-  background: var(--color-primary-container-hover, rgba(65, 95, 145, 0.12));
-  outline: 2px solid var(--color-primary, #415f91);
+  background: rgba(255, 255, 255, 0.18);
+  outline: 2px solid #ffffff;
   outline-offset: 2px;
 }

--- a/apps/web/src/shared/components/MobileAppBanner.css
+++ b/apps/web/src/shared/components/MobileAppBanner.css
@@ -1,5 +1,5 @@
 .mobile-app-banner {
-  position: fixed;
+  position: sticky;
   top: 0;
   left: 0;
   right: 0;

--- a/apps/web/src/shared/components/MobileAppBanner.css
+++ b/apps/web/src/shared/components/MobileAppBanner.css
@@ -1,0 +1,90 @@
+.mobile-app-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: var(--z-toast, 9000);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2, 8px);
+  padding: 10px var(--space-4, 16px);
+  background: var(--color-primary-container, #d9e4ff);
+  color: var(--color-on-primary-container, #001a41);
+  border-bottom: 1px solid var(--color-primary, #415f91);
+  font-family: var(--font-body);
+  font-size: var(--text-label-md, 13px);
+  font-weight: var(--font-weight-medium, 500);
+  /* Animação de entrada respeitando prefers-reduced-motion */
+  animation: banner-slide-in 0.25s ease-out both;
+  contain: layout style;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-app-banner {
+    animation: none;
+  }
+}
+
+@keyframes banner-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-100%);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.mobile-app-banner__icon {
+  flex-shrink: 0;
+  color: var(--color-primary, #415f91);
+}
+
+.mobile-app-banner__text {
+  flex: 1;
+  margin: 0;
+  line-height: 1.3;
+}
+
+.mobile-app-banner__cta {
+  flex-shrink: 0;
+  padding: 4px 12px;
+  border-radius: var(--radius-full, 9999px);
+  background: var(--color-primary, #415f91);
+  color: var(--color-on-primary, #ffffff);
+  font-size: var(--text-label-sm, 12px);
+  font-weight: var(--font-weight-semibold, 600);
+  text-decoration: none;
+  white-space: nowrap;
+  transition: opacity 0.15s ease;
+}
+
+.mobile-app-banner__cta:hover,
+.mobile-app-banner__cta:focus-visible {
+  opacity: 0.88;
+  outline: 2px solid var(--color-primary, #415f91);
+  outline-offset: 2px;
+}
+
+.mobile-app-banner__close {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: var(--radius-full, 9999px);
+  background: transparent;
+  color: var(--color-on-primary-container, #001a41);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.mobile-app-banner__close:hover,
+.mobile-app-banner__close:focus-visible {
+  background: var(--color-primary-container-hover, rgba(65, 95, 145, 0.12));
+  outline: 2px solid var(--color-primary, #415f91);
+  outline-offset: 2px;
+}

--- a/apps/web/src/shared/components/MobileAppBanner.jsx
+++ b/apps/web/src/shared/components/MobileAppBanner.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Smartphone, X } from 'lucide-react'
+import { X } from 'lucide-react'
 import { useIsMobileWeb } from '@shared/hooks/useIsMobileWeb'
 import './MobileAppBanner.css'
 
@@ -51,7 +51,14 @@ export default function MobileAppBanner() {
 
   return (
     <div className="mobile-app-banner" role="banner" aria-label="Recomendação de app nativo">
-      <Smartphone size={16} aria-hidden="true" className="mobile-app-banner__icon" />
+      <img
+        src="/app-icons/web/icon-192.png"
+        alt=""
+        aria-hidden="true"
+        className="mobile-app-banner__icon"
+        width={24}
+        height={24}
+      />
 
       <p className="mobile-app-banner__text">
         Use o Dosiq pelo app — mais rápido e com lembretes

--- a/apps/web/src/shared/components/MobileAppBanner.jsx
+++ b/apps/web/src/shared/components/MobileAppBanner.jsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+import { Smartphone, X } from 'lucide-react'
+import { useIsMobileWeb } from '@shared/hooks/useIsMobileWeb'
+import './MobileAppBanner.css'
+
+/** Chave usada no localStorage para persistir o dismiss com TTL de 30 dias. */
+const STORAGE_KEY = 'dosiq:app-banner-dismissed'
+/** TTL em milissegundos (30 dias). */
+const DISMISS_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+/**
+ * Lê o localStorage e decide se o banner ainda deve estar oculto.
+ * Retorna true quando o banner foi dispensado E o TTL de 30 dias ainda não expirou.
+ */
+function readDismissed() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return false
+    const { dismissedAt } = JSON.parse(raw)
+    return Date.now() - dismissedAt < DISMISS_TTL_MS
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Banner fixo no topo que recomenda o app nativo ao usuário em browser mobile.
+ * Não é exibido quando:
+ *   - O dispositivo não é mobile (UA/userAgentData)
+ *   - O web app já está instalado como PWA standalone
+ *   - O usuário dispensou o banner nos últimos 30 dias
+ */
+export default function MobileAppBanner() {
+  const { isMobile, isStandalone } = useIsMobileWeb()
+
+  // States — inicializados com o valor persistido
+  const [dismissed, setDismissed] = useState(readDismissed)
+
+  // Não renderizar fora das condições de exibição
+  if (!isMobile || isStandalone || dismissed) return null
+
+  // Handlers
+  function handleDismiss() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ dismissedAt: Date.now() }))
+    } catch {
+      // localStorage indisponível (private mode extremo) — ignora silenciosamente
+    }
+    setDismissed(true)
+  }
+
+  return (
+    <div className="mobile-app-banner" role="banner" aria-label="Recomendação de app nativo">
+      <Smartphone size={16} aria-hidden="true" className="mobile-app-banner__icon" />
+
+      <p className="mobile-app-banner__text">
+        Use o Dosiq pelo app — mais rápido e com lembretes
+      </p>
+
+      <a
+        href="https://dosiq.app/"
+        className="mobile-app-banner__cta"
+        aria-label="Abrir o Dosiq no app nativo"
+        rel="noopener noreferrer"
+      >
+        Abrir app
+      </a>
+
+      <button
+        type="button"
+        className="mobile-app-banner__close"
+        onClick={handleDismiss}
+        aria-label="Dispensar banner do app"
+      >
+        <X size={14} aria-hidden="true" />
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/shared/hooks/useIsMobileWeb.js
+++ b/apps/web/src/shared/hooks/useIsMobileWeb.js
@@ -12,17 +12,21 @@ import { useMemo } from 'react'
 export function useIsMobileWeb() {
   // Memos — calculados uma única vez (UA e matchMedia não mudam durante a sessão)
   const isMobile = useMemo(() => {
+    // Guard SSR/testes (Vitest em Node sem DOM completo)
+    if (typeof navigator === 'undefined') return false
     // Preferir a API moderna quando disponível (Chromium 90+)
     if (navigator.userAgentData?.mobile !== undefined) {
       return navigator.userAgentData.mobile
     }
     // Fallback: regex clássica de UA
     return /Android|iPhone|iPad|iPod|Opera Mini|IEMobile|WPDesktop/i.test(
-      navigator.userAgent
+      navigator.userAgent || ''
     )
   }, [])
 
   const isStandalone = useMemo(() => {
+    // Guard SSR/testes
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') return false
     // iOS Safari expõe navigator.standalone
     if (navigator.standalone === true) return true
     // Todos os outros browsers (Chrome, Firefox, Samsung…)

--- a/apps/web/src/shared/hooks/useIsMobileWeb.js
+++ b/apps/web/src/shared/hooks/useIsMobileWeb.js
@@ -1,0 +1,33 @@
+import { useMemo } from 'react'
+
+/**
+ * Detecta se o usuário está em um dispositivo móvel e se o app está rodando
+ * no modo PWA standalone (instalado), para exibir ou ocultar o banner "Abra no app".
+ *
+ * @returns {{ isMobile: boolean, isStandalone: boolean }}
+ *   - isMobile: true quando o UA ou userAgentData indicam dispositivo móvel
+ *   - isStandalone: true quando o web app está instalado como PWA (display-mode: standalone
+ *     ou navigator.standalone, usado pelo iOS Safari)
+ */
+export function useIsMobileWeb() {
+  // Memos — calculados uma única vez (UA e matchMedia não mudam durante a sessão)
+  const isMobile = useMemo(() => {
+    // Preferir a API moderna quando disponível (Chromium 90+)
+    if (navigator.userAgentData?.mobile !== undefined) {
+      return navigator.userAgentData.mobile
+    }
+    // Fallback: regex clássica de UA
+    return /Android|iPhone|iPad|iPod|Opera Mini|IEMobile|WPDesktop/i.test(
+      navigator.userAgent
+    )
+  }, [])
+
+  const isStandalone = useMemo(() => {
+    // iOS Safari expõe navigator.standalone
+    if (navigator.standalone === true) return true
+    // Todos os outros browsers (Chrome, Firefox, Samsung…)
+    return window.matchMedia('(display-mode: standalone)').matches
+  }, [])
+
+  return { isMobile, isStandalone }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,12 @@
     "api/notify.js": { "maxDuration": 60 },
     "api/telegram.js": { "maxDuration": 10 }
   },
+  "headers": [
+    {
+      "source": "/.well-known/apple-app-site-association",
+      "headers": [{ "key": "Content-Type", "value": "application/json" }]
+    }
+  ],
   "rewrites": [
     {
       "source": "/politica-de-privacidade",


### PR DESCRIPTION
## Contexto

Implementa Universal Links (iOS) / App Links (Android) + banner "abra no app" no web mobile. Deriva da spec [EXEC_SPEC_DEEPLINK_UNIVERSAL_LINKS_WEB_BANNER.md](plans/backlog-native_app/EXEC_SPEC_DEEPLINK_UNIVERSAL_LINKS_WEB_BANNER.md) (origem: UX do link de confirmação de e-mail pós-Fase 4).

Substitui o scheme cru `dosiq://` (sem fallback web) por `https://dosiq.app/...` que abre o app se instalado, senão cai no web graciosamente.

## Sprints entregues

### UL-S1 — Universal Links iOS + App Links Android
- **AASA** em `apps/web/public/.well-known/apple-app-site-association` (Team ID `LU8V56S7QF`, paths `/auth/*`)
- `app.config.js`: `ios.associatedDomains` + `android.intentFilters` (`autoVerify`, host `dosiq.app`, pathPrefix `/auth`)
- `vercel.json`: header `Content-Type: application/json` p/ AASA; catch-all/functions intactos
- `assetlinks.json` (Android) já live com fingerprints (Play signing + EAS upload)

### BAN-S1 — banner "abra no app" web mobile
- `useIsMobileWeb` (UA + `userAgentData?.mobile` + standalone PWA; guards SSR/teste)
- `MobileAppBanner` — exibe só quando `isMobile && !isStandalone && !dismissed`; dispensa persiste localStorage TTL 30d; a11y + `prefers-reduced-motion`; `position: sticky` (não sobrepõe topo)
- Logo do app (`/app-icons/web/icon-192.png`) + alto contraste (fundo verde / texto branco)
- Montado no topo do `.app-container`

## Fora deste PR (gated / backlog)
- **UL-S2 (corte do `emailRedirectTo`→https)**: zero-código no web (SDK `detectSessionInUrl: true` auto-completa `/auth/callback`). Flip de `dosiq://`→`https://` fica **gated** até UL verificado em produção. PO adiciona `https://dosiq.app/auth/callback` no allow-list Supabase.
- **BAN-S2 (Smart App Banner iOS)** + CTA apontando pra loja: **bloqueado por publicação**. iOS perto; Android exige 12 beta testers/2 semanas antes de produção. Até lá o CTA cai no web (awareness).

## Limitação conhecida do CTA (não-bug)
"Abrir app" via link **same-domain** no iOS **não abre o app** por design (iOS mantém no Safari), mesmo com UL em prod. O caminho confiável de abrir/instalar é o Smart Banner (BAN-S2) / links de loja — ambos dependem de app publicado. Por ora o banner serve de awareness; tap cai no web.

## Validação pré-merge (PO smoke — R-234)
- [x] Banner aparece em web mobile (Chrome iOS confirmado), logo + contraste OK
- [ ] `.well-known/apple-app-site-association` → 200 + `Content-Type: application/json` (pós-deploy)
- [ ] Android: `adb shell pm get-app-links com.coelhotv.dosiq` → `verified` (build EAS prod-signed; dev nao valida)
- [ ] iOS: validador Apple pós-deploy em prod
- [ ] Sem regressão: `validate:agent` web verde

## AI Review Response
| Suggestion | Priority | Decision | Reason |
|------------|----------|----------|--------|
| `position: fixed` → `sticky` (não sobrepor topo) | Medium | Applied | Commit 8d35d9b7 |
| Guard `navigator` undefined (SSR/Vitest) | Medium | Applied | Commit 8d35d9b7 |
| Guard `window`/`navigator` undefined | Medium | Applied | Commit 8d35d9b7 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)