### PR TITLE
feat(deeplink): UL-S2 — corte do emailRedirectTo do signup para https

### DIFF
--- a/apps/mobile/src/platform/auth/__tests__/authService.test.js
+++ b/apps/mobile/src/platform/auth/__tests__/authService.test.js
@@ -107,7 +107,7 @@ describe('authService', () => {
       expect(supabase.auth.signUp).toHaveBeenCalledWith({
         email: 'novo@example.com',
         password: 'Senha123!',
-        options: { emailRedirectTo: 'dosiq://auth/callback' },
+        options: { emailRedirectTo: 'https://dosiq.app/auth/callback' },
       })
     })
 

--- a/apps/mobile/src/platform/auth/__tests__/authService.test.js
+++ b/apps/mobile/src/platform/auth/__tests__/authService.test.js
@@ -97,18 +97,43 @@ describe('authService', () => {
       expect(result.error).toBe('Email já cadastrado. Faça login.')
     })
 
-    it('retorna success em cadastro bem-sucedido', async () => {
-      supabase.auth.signUp.mockResolvedValue({
-        data: { user: { id: 'user-456', email: 'novo@example.com' } },
-        error: null,
-      })
-      const result = await signUpWithEmail('novo@example.com', 'Senha123!', 'Senha123!')
-      expect(result.success).toBe(true)
-      expect(supabase.auth.signUp).toHaveBeenCalledWith({
-        email: 'novo@example.com',
-        password: 'Senha123!',
-        options: { emailRedirectTo: 'https://dosiq.app/auth/callback' },
-      })
+    it('em produção usa emailRedirectTo https (Universal Link)', async () => {
+      const prevDev = global.__DEV__
+      global.__DEV__ = false
+      try {
+        supabase.auth.signUp.mockResolvedValue({
+          data: { user: { id: 'user-456', email: 'novo@example.com' } },
+          error: null,
+        })
+        const result = await signUpWithEmail('novo@example.com', 'Senha123!', 'Senha123!')
+        expect(result.success).toBe(true)
+        expect(supabase.auth.signUp).toHaveBeenCalledWith({
+          email: 'novo@example.com',
+          password: 'Senha123!',
+          options: { emailRedirectTo: 'https://dosiq.app/auth/callback' },
+        })
+      } finally {
+        global.__DEV__ = prevDev
+      }
+    })
+
+    it('em dev usa o scheme dosiq:// (abre build de dev direto)', async () => {
+      const prevDev = global.__DEV__
+      global.__DEV__ = true
+      try {
+        supabase.auth.signUp.mockResolvedValue({
+          data: { user: { id: 'user-789', email: 'dev@example.com' } },
+          error: null,
+        })
+        await signUpWithEmail('dev@example.com', 'Senha123!', 'Senha123!')
+        expect(supabase.auth.signUp).toHaveBeenCalledWith({
+          email: 'dev@example.com',
+          password: 'Senha123!',
+          options: { emailRedirectTo: 'dosiq://auth/callback' },
+        })
+      } finally {
+        global.__DEV__ = prevDev
+      }
     })
 
     it('trata erro de rede inesperado com fallback', async () => {

--- a/apps/mobile/src/platform/auth/authService.js
+++ b/apps/mobile/src/platform/auth/authService.js
@@ -108,10 +108,11 @@ export async function signUpWithEmail(email, password, confirmPassword) {
       email: validation.data.email,
       password: validation.data.password,
       options: {
-        // Deeplink first: o link de confirmação reabre o app já logado
-        // (handler em Navigation.jsx trata type=signup). Mesmo callback do
-        // recovery — já liberado no allow-list do Supabase.
-        emailRedirectTo: 'dosiq://auth/callback',
+        // Universal Link / App Link (UL-S2): https abre o app se instalado
+        // (associatedDomains iOS verificado; Android autoVerify após Play),
+        // senão cai no web /auth/callback que auto-completa via detectSessionInUrl.
+        // dosiq:// segue no allow-list como rede de segurança.
+        emailRedirectTo: 'https://dosiq.app/auth/callback',
       },
     })
 

--- a/apps/mobile/src/platform/auth/authService.js
+++ b/apps/mobile/src/platform/auth/authService.js
@@ -108,11 +108,14 @@ export async function signUpWithEmail(email, password, confirmPassword) {
       email: validation.data.email,
       password: validation.data.password,
       options: {
-        // Universal Link / App Link (UL-S2): https abre o app se instalado
-        // (associatedDomains iOS verificado; Android autoVerify após Play),
-        // senão cai no web /auth/callback que auto-completa via detectSessionInUrl.
-        // dosiq:// segue no allow-list como rede de segurança.
-        emailRedirectTo: 'https://dosiq.app/auth/callback',
+        // Universal Link / App Link (UL-S2): em produção, https abre o app se
+        // instalado (associatedDomains iOS; Android autoVerify), senão cai no web
+        // /auth/callback (detectSessionInUrl auto-completa). Em dev (__DEV__),
+        // mantém o scheme dosiq:// — abre o build de dev direto, sem mandar o
+        // usuário pro web/banco de produção. dosiq:// segue no allow-list.
+        emailRedirectTo: __DEV__
+          ? 'dosiq://auth/callback'
+          : 'https://dosiq.app/auth/callback',
       },
     })
 


### PR DESCRIPTION
## O que muda
`signUpWithEmail` passa a usar `emailRedirectTo` com guard de ambiente:
- **produção**: `https://dosiq.app/auth/callback` (Universal/App Link)
- **dev (`__DEV__`)**: `dosiq://auth/callback` (abre build de dev direto, sem mandar pro web/banco de produção)

Fecha o UL-S2 da spec [EXEC_SPEC_DEEPLINK_UNIVERSAL_LINKS_WEB_BANNER.md](plans/backlog-native_app/EXEC_SPEC_DEEPLINK_UNIVERSAL_LINKS_WEB_BANNER.md), pós-merge do UL-S1+BAN-S1 (#585).

## Por que agora (UL verificado em prod nos dois SOs)
- AASA `dosiq.app/.well-known/apple-app-site-association` → 200 `application/json` + Apple CDN 200
- `assetlinks.json` → 200
- `/auth/callback` web → 200 (SPA; `detectSessionInUrl` auto-completa)
- `https://dosiq.app/auth/callback` no allow-list Supabase
- **iOS Universal Link validado em device** ✅
- **Android App Link `verified`** (device Xiaomi, closed testing, fingerprint Play App Signing) ✅

## Comportamento por plataforma (produção)
| | Resultado |
|--|--|
| iOS c/ app | abre app (UL nativo) ✅ |
| Android c/ app | abre app (App Link `verified`) ✅ |
| Desktop sem app | web completa o auth (corrige erro anterior do scheme) |

`dosiq://auth/callback` mantido no allow-list como rede de segurança.

## Testes
`npm test --workspace @dosiq/mobile authService` → 20/20 verdes (asserts p/ caminho prod E dev).

## AI Review Response
| Suggestion | Priority | Decision | Reason |
|------------|----------|----------|--------|
| Guard `__DEV__` no emailRedirectTo (paridade de ambiente) | Medium | Applied | Commit ee327d8b |
| Ajuste de teste p/ `__DEV__` | Medium | Applied | Commit ee327d8b (testes p/ ambos os caminhos) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)