### PR TITLE
chore(mobile): declara pt-BR no binário iOS (localização)

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -57,6 +57,10 @@ module.exports = {
       infoPlist: {
         ITSAppUsesNonExemptEncryption: false,
         UIBackgroundModes: ['remote-notification'],
+        // App é pt-BR nativo: declara a região/localização no binário p/ a App
+        // Store e o iOS tratarem como Português (Brasil), não inglês (default).
+        CFBundleDevelopmentRegion: 'pt-BR',
+        CFBundleLocalizations: ['pt-BR'],
       },
       // UL-S1: Universal Links iOS
       associatedDomains: ['applinks:dosiq.app'],


### PR DESCRIPTION
## O que muda
Adiciona ao `ios.infoPlist` do `app.config.js`:
- `CFBundleDevelopmentRegion: 'pt-BR'`
- `CFBundleLocalizations: ['pt-BR']`

## Por quê
App é pt-BR nativo, mas o binário não declarava localização → iOS/App Store assumiam inglês (região default), aparecendo como "Idiomas: inglês" na loja. Declarar pt-BR no binário faz o TestFlight/App Store tratarem o app como Português (Brasil).

## Escopo / efeito
- Entra no **próximo build EAS** (mexe no binário; não afeta builds já publicados).
- **Não** altera o listing da loja (nome/descrição/keywords) — isso é manual no App Store Connect (Primary Language / localization pt-BR).
- Android: idioma de listing é resolvido no Play Console (sem análogo direto no app.config).

## Teste
`node -e` valida que `app.config.js` exporta os campos corretos. Sem impacto em runtime JS / testes.

## AI Review Response
| Suggestion | Priority | Decision | Reason |
|------------|----------|----------|--------|
| _(aguardando review)_ | — | — | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)