### PR TITLE
feat(mobile): empty state do dashboard guia pro CRUD in-app

### DIFF
--- a/apps/mobile/src/features/dashboard/screens/TodayScreen.jsx
+++ b/apps/mobile/src/features/dashboard/screens/TodayScreen.jsx
@@ -181,7 +181,7 @@ function TodayScreenContent({
           protocols={protocols} isComplex={isComplex} timeline={timeline}
           shifts={shifts} groupedTimeline={groupedTimeline} countsByShift={countsByShift}
           expandedShifts={expandedShifts} toggleShift={toggleShift} handleOpenRegister={handleOpenRegister}
-          hasMedicines={Object.keys(medicines).length > 0} navigation={navigation}
+          hasMedicines={Object.keys(medicines || {}).length > 0} navigation={navigation}
         />
       </ScrollView>
       <DoseRegisterModal

--- a/apps/mobile/src/features/dashboard/screens/TodayScreen.jsx
+++ b/apps/mobile/src/features/dashboard/screens/TodayScreen.jsx
@@ -128,7 +128,7 @@ function _buildHeaderData(user) {
 // Conteúdo principal da tela (pós-carregamento) — extrai render para reduzir complexidade
 function TodayScreenContent({
   data, stale, isDaySegregated, loading, refresh,
-  timeline, stockAlerts, protocols, stats,
+  timeline, stockAlerts, protocols, stats, medicines,
   isComplex, shifts, groupedTimeline, countsByShift,
   expandedShifts, toggleShift,
   modalProtocol, modalScheduledTime, medicineName, handleOpenRegister, handleRegisterSuccess, handleCloseRegister,
@@ -181,6 +181,7 @@ function TodayScreenContent({
           protocols={protocols} isComplex={isComplex} timeline={timeline}
           shifts={shifts} groupedTimeline={groupedTimeline} countsByShift={countsByShift}
           expandedShifts={expandedShifts} toggleShift={toggleShift} handleOpenRegister={handleOpenRegister}
+          hasMedicines={Object.keys(medicines).length > 0} navigation={navigation}
         />
       </ScrollView>
       <DoseRegisterModal
@@ -207,12 +208,31 @@ function TodayScreenContent({
 }
 
 // Renderiza a agenda de doses (Simple ou Complex mode)
-function TodayAgendaContent({ protocols, isComplex, timeline, shifts, groupedTimeline, countsByShift, expandedShifts, toggleShift, handleOpenRegister }) {
+function TodayAgendaContent({ protocols, isComplex, timeline, shifts, groupedTimeline, countsByShift, expandedShifts, toggleShift, handleOpenRegister, hasMedicines, navigation }) {
   if (protocols.length === 0) {
+    // Empty state inteligente (tudo in-app — os CRUDs já vivem no nativo):
+    // - sem medicamento E sem tratamento → começa cadastrando o 1º medicamento;
+    // - já tem medicamento, falta tratamento → vai direto pro form de tratamento.
+    const empty = hasMedicines
+      ? {
+          message: 'Você ainda não tem tratamentos ativos.\nQue tal criar o primeiro?',
+          action: {
+            label: 'Adicionar tratamento',
+            onPress: () => navigation?.navigate(ROUTES.TREATMENTS, { screen: ROUTES.PROTOCOL_FORM }),
+          },
+        }
+      : {
+          message: 'Vamos começar?\nCadastre seu primeiro medicamento para o Dosiq te lembrar na hora certa.',
+          action: {
+            label: 'Cadastrar primeiro medicamento',
+            onPress: () => navigation?.navigate(ROUTES.TREATMENTS, { screen: ROUTES.MEDICINE_CREATE }),
+          },
+        }
     return (
       <EmptyState
         icon={<Pill size={48} color={colors.status.success} />}
-        message={'Sem tratamentos ativos.\nAdicione tratamentos na versão web.'}
+        message={empty.message}
+        action={empty.action}
       />
     )
   }

--- a/apps/mobile/src/shared/components/states/EmptyState.jsx
+++ b/apps/mobile/src/shared/components/states/EmptyState.jsx
@@ -5,7 +5,7 @@ import { View, Text, StyleSheet, Pressable } from 'react-native'
 import { colors } from '../../styles/tokens'
 
 // `action` opcional: { label, onPress } → renderiza um botão primário (CTA).
-export default function EmptyState({ title, message = 'Nenhum dado encontrado', icon = '📭', action = null }) {
+export default function EmptyState({ title, message = 'Nenhum dado encontrado', icon = '💊', action = null }) {
   return (
     <View style={styles.container}>
       <Text style={styles.icon}>{icon}</Text>

--- a/apps/mobile/src/shared/components/states/EmptyState.jsx
+++ b/apps/mobile/src/shared/components/states/EmptyState.jsx
@@ -1,15 +1,21 @@
 // EmptyState.jsx — estado vazio genérico para telas mobile
 // Exibido quando a query retorna dados mas a lista está vazia
 
-import { View, Text, StyleSheet } from 'react-native'
+import { View, Text, StyleSheet, Pressable } from 'react-native'
 import { colors } from '../../styles/tokens'
 
-export default function EmptyState({ title, message = 'Nenhum dado encontrado', icon = '📭' }) {
+// `action` opcional: { label, onPress } → renderiza um botão primário (CTA).
+export default function EmptyState({ title, message = 'Nenhum dado encontrado', icon = '📭', action = null }) {
   return (
     <View style={styles.container}>
       <Text style={styles.icon}>{icon}</Text>
       {title && <Text style={styles.title}>{title}</Text>}
       <Text style={styles.text}>{message}</Text>
+      {action ? (
+        <Pressable style={styles.actionBtn} onPress={action.onPress} accessibilityRole="button">
+          <Text style={styles.actionText}>{action.label}</Text>
+        </Pressable>
+      ) : null}
     </View>
   )
 }
@@ -36,6 +42,19 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: 'bold',
     color: colors.text.primary,
+    textAlign: 'center',
+  },
+  actionBtn: {
+    marginTop: 12,
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderRadius: 999,
+    backgroundColor: colors.brand.primary,
+  },
+  actionText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.text.inverse,
     textAlign: 'center',
   },
 })


### PR DESCRIPTION
## Problema
`TodayScreen` mostrava no estado vazio: *"Sem tratamentos ativos. Adicione tratamentos na versão web."* — copy desatualizada: desde a Fase 4 todos os CRUDs vivem no app nativo.

## Solução — empty state inteligente in-app
`EmptyState` ganha prop opcional `action` ({ label, onPress }) → botão primário (CTA). Default de ícone agora `💊` (era `📭`).

`TodayScreen` decide o caso pelos dados:
| Estado | CTA |
|--------|-----|
| 0 medicamento **e** 0 tratamento | **Cadastrar primeiro medicamento** → `MEDICINE_CREATE` |
| tem medicamento, 0 tratamento | **Adicionar tratamento** → `PROTOCOL_FORM` |

> Onboarding é root-gate por flag (não rota navegável mid-sessão) → CTA leva ao 1º passo equivalente (`MEDICINE_CREATE`), entregando o "começar aqui" sem reentrada no wizard. Nav cross-tab via `ROUTES.TREATMENTS`.

## Teste
`npm test --workspace @dosiq/mobile TodayScreen` → 5/5 verdes. Lint limpo.

## AI Review Response
| Suggestion | Priority | Decision | Reason |
|------------|----------|----------|--------|
| Fallback seguro em `Object.keys(medicines)` | Medium | Applied | Commit 94be04f4 — `Object.keys(medicines \|\| {})` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)