### PR TITLE
feat(settings): seletor de fuso horário web + mobile (Fase 1 PR-F1.2)

### DIFF
--- a/.agent/memory/ANTI_PATTERNS_INDEX.md
+++ b/.agent/memory/ANTI_PATTERNS_INDEX.md
@@ -37,6 +37,7 @@
 - **[AP-179]** Entitlement novo no `app.config.js` (ex.: `associatedDomains`) → `expo run:ios` local falha (erro 65) porque o provisioning profile cacheado é anterior à capability. Habilitar no App ID não retroage ao profile. Fix: `rm -rf ~/Library/MobileDevice/Provisioning\ Profiles/` + regerar (Xcode toggle auto-signing). EAS registra via API Apple automaticamente -> [`anti-patterns/infra_and_deploy/AP-179.md`](./anti-patterns/infra_and_deploy/AP-179.md)
 
 ## 📱 Mobile & Platform (`mobile_and_platform`)
+- **[AP-180]** FlatList `flexGrow:0` em bottom-sheet `maxHeight` → lista longa transborda sem scroll (último item inalcançável iOS); fix `flexShrink:1` na lista + container -> [`anti-patterns/mobile_and_platform/AP-180.md`](./anti-patterns/mobile_and_platform/AP-180.md)
 - **[AP-173]** `signOut()` escopo global (default) trava o logout (iOS sim / Workbox PWA) — usar `signOut({ scope: 'local' })` + cleanup local -> [`anti-patterns/mobile_and_platform/AP-173.md`](./anti-patterns/mobile_and_platform/AP-173.md)
 - **[AP-174]** Bottom sheet/Modal RN + teclado + tab bar (Android API 24) corta campos/botões; KAV não mede em Modal. Fluxo destrutivo com input → tela cheia -> [`anti-patterns/mobile_and_platform/AP-174.md`](./anti-patterns/mobile_and_platform/AP-174.md)
 - **[AP-175]** Autocomplete RN: `setFocused(false)` sem blur nativo (keyboardShouldPersistTaps) → 2ª busca morta (effect aborta em `!focused`). `inputRef.blur()` no select -> [`anti-patterns/mobile_and_platform/AP-175.md`](./anti-patterns/mobile_and_platform/AP-175.md)

--- a/.agent/state.json
+++ b/.agent/state.json
@@ -4,15 +4,15 @@
   "session": {
     "mode": "coding",
     "status": "completed",
-    "goal": "Fase 1 PR-F1.1 — Timezone core (tz-aware dateUtils + user_settings.timezone)",
-    "goal_type": "refactor",
-    "linked_adrs": ["ADR-049", "ADR-048"],
-    "linked_contracts": ["CON-022", "CON-018", "CON-015"],
+    "goal": "Fase 1 PR-F1.2 — Timezone UI (seletor web + mobile)",
+    "goal_type": "feature",
+    "linked_adrs": ["ADR-049"],
+    "linked_contracts": ["CON-022"],
     "spec": "plans/dose_instances_refactor/EXEC_SPECS_PHASE_1_2.md"
   },
   "memory": {
     "last_distillation": "2026-05-23T18:20:00Z",
-    "journal_entries_since_distillation": 9,
+    "journal_entries_since_distillation": 10,
     "rules_count": 191,
     "anti_patterns_count": 180,
     "decisions_count": 48,

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -5,7 +5,7 @@
 
 const BUILD_PROFILE = process.env.EAS_BUILD_PROFILE || 'production'
 
-const APP_VERSION = '0.6.0' // R-182: versão semântica (sem prefixo 'v')
+const APP_VERSION = '0.6.1' // R-182: versão semântica (sem prefixo 'v')
 const [major, minor, patch] = APP_VERSION.split('.').map(Number)
 // buildNumber/versionCode derivado da versão semântica: major*10000 + minor*100 + patch
 // 0.2.4 → 204 | 0.3.0 → 300 | 1.0.0 → 10000

--- a/apps/mobile/src/features/profile/hooks/useProfile.js
+++ b/apps/mobile/src/features/profile/hooks/useProfile.js
@@ -79,16 +79,16 @@ export function useProfile() {
    * Atualizar fuso horário manualmente (seletor em SettingsScreen — ADR-049).
    * Persiste no banco e actualiza o estado local.
    */
-  const updateTimezone = async (tz) => {
+  const updateTimezone = useCallback(async (tz) => {
     const res = await updateTimezoneService(tz)
     if (res.success) {
       setState(prev => ({
         ...prev,
-        settings: { ...prev.settings, timezone: tz }
+        settings: prev.settings ? { ...prev.settings, timezone: tz } : null
       }))
     }
     return res
-  }
+  }, [])
 
   /**
    * Gerar novo token de vinculação Telegram

--- a/apps/mobile/src/features/profile/hooks/useProfile.js
+++ b/apps/mobile/src/features/profile/hooks/useProfile.js
@@ -4,6 +4,7 @@ import {
   getCurrentUser,
   getUserSettings,
   getProfile,
+  updateTimezone as updateTimezoneService,
   generateTelegramToken as generateTokenService,
 } from '../services/profileService'
 
@@ -35,6 +36,11 @@ export function useProfile() {
       if (userRes.error) throw new Error(userRes.error)
       if (settingsRes.error) throw new Error(settingsRes.error)
       if (profileRes.error) throw new Error(profileRes.error)
+
+      // ADR-049 — fuso é definido manualmente pelo usuário no settings (fonte de verdade).
+      // NÃO auto-sobrescrever pelo fuso do device no launch: isso clobberava a escolha
+      // manual (device do emulador = SP sempre, revertia Manaus→SP a cada load).
+      // Auto-detect de viagem exige flag tz_source (auto|manual) — fora de escopo F1.2.
 
       setState({
         user: userRes.data,
@@ -70,6 +76,21 @@ export function useProfile() {
   )
 
   /**
+   * Atualizar fuso horário manualmente (seletor em SettingsScreen — ADR-049).
+   * Persiste no banco e actualiza o estado local.
+   */
+  const updateTimezone = async (tz) => {
+    const res = await updateTimezoneService(tz)
+    if (res.success) {
+      setState(prev => ({
+        ...prev,
+        settings: { ...prev.settings, timezone: tz }
+      }))
+    }
+    return res
+  }
+
+  /**
    * Gerar novo token de vinculação Telegram
    */
   const generateToken = async () => {
@@ -101,6 +122,7 @@ export function useProfile() {
     location,
     hasProfile,
     refresh: loadProfile,
-    generateToken
+    generateToken,
+    updateTimezone,
   }
 }

--- a/apps/mobile/src/features/profile/screens/SettingsScreen.jsx
+++ b/apps/mobile/src/features/profile/screens/SettingsScreen.jsx
@@ -1,4 +1,4 @@
-// SettingsScreen.jsx — Configurações (Fase 4): densidade da interface + segurança
+// SettingsScreen.jsx — Configurações (Fase 4): densidade da interface + fuso horário + segurança
 // R-010: States → Memos → Effects → Handlers
 
 import { useCallback, useMemo } from 'react'
@@ -20,12 +20,15 @@ import {
   LayoutGrid,
   Shield,
   Trash2,
+  Globe,
 } from 'lucide-react-native'
 import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
 import { ROUTES } from '@navigation/routes'
 import { useProfile } from '@profile/hooks/useProfile'
 import { useProfileMutation } from '@profile/hooks/useProfileMutation'
 import { useToast } from '@shared/components/feedback/Toast'
+import FormSelect from '@shared/components/form/FormSelect'
+import { TIMEZONE_OPTIONS } from '@dosiq/core'
 
 // ─── Opções de densidade ──────────────────────────────────────────────────────
 
@@ -55,6 +58,78 @@ function complexityLabel(value) {
   return match?.label ?? 'Automático'
 }
 
+// ─── Sub-componente: opções de densidade ─────────────────────────────────────
+
+function DensityOptions({ currentComplexity, activeLabel, onSelect }) {
+  return (
+    <>
+      <View style={styles.densityRow}>
+        {DENSITY_OPTIONS.map((option) => {
+          const selected = (option.value ?? null) === (currentComplexity ?? null)
+          return (
+            <Pressable
+              key={String(option.value)}
+              style={[styles.densityCard, selected && styles.densityCardSelected]}
+              onPress={() => onSelect(option.value)}
+              accessibilityRole="radio"
+              accessibilityState={{ checked: selected }}
+              accessibilityLabel={option.label}
+            >
+              <option.Icon
+                size={20}
+                color={selected ? colors.primary[600] : colors.text.muted}
+              />
+              <Text style={[styles.densityCardLabel, selected && styles.densityCardLabelSelected]}>
+                {option.label}
+              </Text>
+              <Text style={styles.densityCardDesc}>{option.description}</Text>
+            </Pressable>
+          )
+        })}
+      </View>
+      <Text style={styles.densityCaption}>Ativo: {activeLabel}</Text>
+    </>
+  )
+}
+
+// ─── Sub-componente: secção de segurança ─────────────────────────────────────
+
+function SecuritySection({ onChangePassword, onDeleteAccount }) {
+  return (
+    <>
+      <View style={[styles.sectionLabel, styles.sectionLabelMargin]}>
+        <Shield size={12} color={colors.text.muted} />
+        <Text style={styles.sectionLabelText}>SEGURANÇA</Text>
+      </View>
+      <View style={styles.card}>
+        <Pressable style={styles.securityRow} onPress={onChangePassword}
+          accessibilityRole="button" accessibilityLabel="Alterar senha">
+          <View style={styles.securityInfo}>
+            <Text style={styles.securityRowTitle}>Alterar senha</Text>
+            <Text style={styles.securityRowSub}>Última alteração: nunca</Text>
+          </View>
+          <Text style={styles.securityAction}>Alterar</Text>
+          <ChevronRight size={16} color={colors.primary[500]} />
+        </Pressable>
+        <View style={styles.divider} />
+        <Pressable style={styles.securityRow} onPress={onDeleteAccount}
+          accessibilityRole="button" accessibilityLabel="Excluir minha conta">
+          <View style={styles.deleteIconBg}>
+            <Trash2 size={16} color={colors.status.error} />
+          </View>
+          <View style={styles.securityInfo}>
+            <Text style={styles.securityRowTitle}>Excluir minha conta</Text>
+            <Text style={styles.securityRowSub}>
+              Remove acesso e dados. Bloqueante se houver tratamentos ativos.
+            </Text>
+          </View>
+          <ChevronRight size={16} color={colors.text.muted} />
+        </Pressable>
+      </View>
+    </>
+  )
+}
+
 // ─── Componente principal ─────────────────────────────────────────────────────
 
 export default function SettingsScreen() {
@@ -62,7 +137,7 @@ export default function SettingsScreen() {
   const navigation = useNavigation()
 
   // Memos/hooks de dados
-  const { profile, loading: profileLoading, refresh } = useProfile()
+  const { profile, settings, loading: profileLoading, refresh, updateTimezone } = useProfile()
   const { setComplexity, loading: mutating } = useProfileMutation()
   const toast = useToast()
 
@@ -76,7 +151,24 @@ export default function SettingsScreen() {
     [currentComplexity],
   )
 
+  const currentTimezone = useMemo(
+    () => settings?.timezone ?? 'America/Sao_Paulo',
+    [settings],
+  )
+
   // Handlers
+  const handleSelectTimezone = useCallback(
+    async (_name, value) => {
+      if (!value || value === currentTimezone) return
+      const res = await updateTimezone(value)
+      if (res.success) {
+        toast.show('Fuso horário salvo', { variant: 'success' })
+      } else {
+        toast.show(res.error ?? 'Erro ao salvar fuso horário', { variant: 'error' })
+      }
+    },
+    [currentTimezone, updateTimezone, toast],
+  )
   const handleSelectDensity = useCallback(
     async (value) => {
       // Não disparar se já selecionado ou mutando
@@ -92,14 +184,10 @@ export default function SettingsScreen() {
     [currentComplexity, mutating, setComplexity, toast, refresh],
   )
 
-  const handleChangePassword = useCallback(() => {
-    navigation.navigate(ROUTES.CHANGE_PASSWORD)
-  }, [navigation])
-
-  const handleDeleteAccount = useCallback(() => {
-    navigation.navigate(ROUTES.DELETE_ACCOUNT)
-  }, [navigation])
-
+  const handleChangePassword = useCallback(
+    () => navigation.navigate(ROUTES.CHANGE_PASSWORD), [navigation])
+  const handleDeleteAccount = useCallback(
+    () => navigation.navigate(ROUTES.DELETE_ACCOUNT), [navigation])
   return (
     <SafeAreaView style={styles.safe} edges={['top']}>
       {/* Header */}
@@ -131,97 +219,46 @@ export default function SettingsScreen() {
           <Text style={styles.cardTitle}>Densidade da interface</Text>
 
           {profileLoading ? (
+            <ActivityIndicator size="small" color={colors.primary[500]} style={styles.loader} />
+          ) : (
+            <DensityOptions
+              currentComplexity={currentComplexity}
+              activeLabel={activeLabel}
+              onSelect={handleSelectDensity}
+            />
+          )}
+        </View>
+
+        {/* ── Seção FUSO HORÁRIO ── */}
+        <View style={[styles.sectionLabel, styles.sectionLabelMargin]}>
+          <Globe size={12} color={colors.text.muted} />
+          <Text style={styles.sectionLabelText}>FUSO HORÁRIO</Text>
+        </View>
+
+        <View style={styles.card}>
+          {profileLoading ? (
             <ActivityIndicator
               size="small"
               color={colors.primary[500]}
               style={styles.loader}
             />
           ) : (
-            <>
-              <View style={styles.densityRow}>
-                {DENSITY_OPTIONS.map((option) => {
-                  const selected =
-                    (option.value ?? null) === (currentComplexity ?? null)
-                  return (
-                    <Pressable
-                      key={String(option.value)}
-                      style={[
-                        styles.densityCard,
-                        selected && styles.densityCardSelected,
-                      ]}
-                      onPress={() => handleSelectDensity(option.value)}
-                      accessibilityRole="radio"
-                      accessibilityState={{ checked: selected }}
-                      accessibilityLabel={option.label}
-                    >
-                      <option.Icon
-                        size={20}
-                        color={selected ? colors.primary[600] : colors.text.muted}
-                      />
-                      <Text
-                        style={[
-                          styles.densityCardLabel,
-                          selected && styles.densityCardLabelSelected,
-                        ]}
-                      >
-                        {option.label}
-                      </Text>
-                      <Text style={styles.densityCardDesc}>
-                        {option.description}
-                      </Text>
-                    </Pressable>
-                  )
-                })}
-              </View>
-
-              <Text style={styles.densityCaption}>Ativo: {activeLabel}</Text>
-            </>
+            <FormSelect
+              name="timezone"
+              label={null}
+              value={currentTimezone}
+              options={TIMEZONE_OPTIONS}
+              onChange={handleSelectTimezone}
+              placeholder="Selecionar fuso"
+            />
           )}
         </View>
 
         {/* ── Seção SEGURANÇA ── */}
-        <View style={[styles.sectionLabel, styles.sectionLabelMargin]}>
-          <Shield size={12} color={colors.text.muted} />
-          <Text style={styles.sectionLabelText}>SEGURANÇA</Text>
-        </View>
-
-        <View style={styles.card}>
-          {/* Alterar senha */}
-          <Pressable
-            style={styles.securityRow}
-            onPress={handleChangePassword}
-            accessibilityRole="button"
-            accessibilityLabel="Alterar senha"
-          >
-            <View style={styles.securityInfo}>
-              <Text style={styles.securityRowTitle}>Alterar senha</Text>
-              <Text style={styles.securityRowSub}>Última alteração: nunca</Text>
-            </View>
-            <Text style={styles.securityAction}>Alterar</Text>
-            <ChevronRight size={16} color={colors.primary[500]} />
-          </Pressable>
-
-          <View style={styles.divider} />
-
-          {/* Excluir conta */}
-          <Pressable
-            style={styles.securityRow}
-            onPress={handleDeleteAccount}
-            accessibilityRole="button"
-            accessibilityLabel="Excluir minha conta"
-          >
-            <View style={styles.deleteIconBg}>
-              <Trash2 size={16} color={colors.status.error} />
-            </View>
-            <View style={styles.securityInfo}>
-              <Text style={styles.securityRowTitle}>Excluir minha conta</Text>
-              <Text style={styles.securityRowSub}>
-                Remove acesso e dados. Bloqueante se houver tratamentos ativos.
-              </Text>
-            </View>
-            <ChevronRight size={16} color={colors.text.muted} />
-          </Pressable>
-        </View>
+        <SecuritySection
+          onChangePassword={handleChangePassword}
+          onDeleteAccount={handleDeleteAccount}
+        />
       </ScrollView>
     </SafeAreaView>
   )

--- a/apps/mobile/src/features/profile/services/profileService.js
+++ b/apps/mobile/src/features/profile/services/profileService.js
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { userSettingsNotificationSchema, createProfileRepository } from '@dosiq/core'
+import { userSettingsNotificationSchema, createProfileRepository, TIMEZONES_BR } from '@dosiq/core'
 import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
 
 /**
@@ -79,9 +79,9 @@ export async function getUserSettings() {
     const { data, error } = await supabase
       .from('user_settings')
       .select(`
-        user_id, 
-        telegram_chat_id, 
-        verification_token, 
+        user_id,
+        telegram_chat_id,
+        verification_token,
         notification_preference,
         notification_mode,
         quiet_hours_start,
@@ -91,7 +91,8 @@ export async function getUserSettings() {
         digest_time,
         channel_mobile_push_enabled,
         channel_web_push_enabled,
-        channel_telegram_enabled
+        channel_telegram_enabled,
+        timezone
       `)
       .eq('user_id', user.id)
       .maybeSingle()
@@ -139,6 +140,33 @@ export async function updateNotificationSettings(userId, settings) {
     return { success: true, error: null }
   } catch (err) {
     if (__DEV__) console.error('[profileService] erro ao salvar notificações:', err)
+    return { success: false, error: mapErrorToMessage(err) }
+  }
+}
+
+/**
+ * Atualizar fuso horário do utilizador (ADR-049 — update isolado, não toca noutros campos).
+ * @param {string} timezone — IANA tz string (ex: 'America/Sao_Paulo')
+ * @returns {Promise<{success: boolean, error: string|null}>}
+ */
+export async function updateTimezone(timezone) {
+  try {
+    const { data: user, error: userError } = await getCurrentUser()
+    if (userError || !user) throw new Error(userError || 'Utilizador não encontrado')
+
+    z.string().uuid().parse(user.id)
+    // Valida contra a lista canônica de fusos BR (rejeita IANA inválido/estrangeiro)
+    z.enum(TIMEZONES_BR).parse(timezone)
+
+    const { error } = await supabase
+      .from('user_settings')
+      .update({ timezone })
+      .eq('user_id', user.id)
+
+    if (error) throw error
+    return { success: true, error: null }
+  } catch (err) {
+    if (__DEV__) console.error('[profileService] erro ao salvar fuso horário:', err)
     return { success: false, error: mapErrorToMessage(err) }
   }
 }

--- a/apps/mobile/src/shared/components/form/FormSelect.jsx
+++ b/apps/mobile/src/shared/components/form/FormSelect.jsx
@@ -115,7 +115,7 @@ export default function FormSelect({
 
         {/* Sheet */}
         <View style={styles.sheet}>
-          <SafeAreaView edges={['bottom']}>
+          <SafeAreaView edges={['bottom']} style={styles.safe}>
             {/* Cabeçalho */}
             <View style={styles.sheetHeader}>
               <View style={styles.sheetHeaderSpacer} />
@@ -245,8 +245,14 @@ const styles = StyleSheet.create({
     backgroundColor: colors.border.light,
     marginHorizontal: spacing[4],
   },
+  // flexShrink permite a lista encolher dentro do maxHeight do sheet e virar
+  // scrollável quando o conteúdo (ex: 16 fusos) excede 60% da tela — sem isso
+  // o último item ficava preso além da borda no iOS (flexGrow:0 + conteúdo > sheet).
+  safe: {
+    flexShrink: 1,
+  },
   list: {
-    flexGrow: 0,
+    flexShrink: 1,
   },
   listContent: {
     paddingTop: spacing[2],

--- a/apps/web/src/features/settings/hooks/useSettingsState.js
+++ b/apps/web/src/features/settings/hooks/useSettingsState.js
@@ -24,6 +24,7 @@ export function useSettingsState() {
   const [digestTime, setDigestTime] = useState('08:30')
   const [webPushSupported, setWebPushSupported] = useState(false)
   const [channelWebPushEnabled, setChannelWebPushEnabled] = useState(false)
+  const [timezone, setTimezone] = useState('America/Sao_Paulo')
 
   const showMsg = (type, text) => {
     setMessage({ type, text })
@@ -53,6 +54,7 @@ export function useSettingsState() {
         setDigestTime(settings.digest_time || '09:00')
         setChannelWebPushEnabled(settings.channel_web_push_enabled || false)
         if (settings.complexity_override) setComplexityOverride(settings.complexity_override)
+        setTimezone(settings.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/Sao_Paulo')
       }
       setWebPushSupported('serviceWorker' in navigator && 'PushManager' in window)
     } catch (error) {
@@ -167,6 +169,17 @@ export function useSettingsState() {
     }
   }
 
+  const handleTimezoneChange = async (tz) => {
+    try {
+      const { data: { user } } = await supabase.auth.getUser()
+      await supabase.from('user_settings').update({ timezone: tz }).eq('user_id', user.id)
+      setTimezone(tz)
+      showMsg('success', 'Fuso horário atualizado.')
+    } catch {
+      showMsg('error', 'Erro ao salvar fuso horário.')
+    }
+  }
+
   const getComplexityDisplayMode = () => {
     if (overrideMode === 'simple') return 'Ativo: Modo Padrão (simplificado)'
     if (overrideMode === 'complex') return 'Ativo: Modo Detalhado'
@@ -183,6 +196,6 @@ export function useSettingsState() {
       digestTime, setDigestTime, saveDigestTime, savingDigestTime,
     },
     integration: { isTelegramConnected, generateTelegramToken, telegramToken, handleDisconnectTelegram },
-    preference: { overrideMode, handleComplexityChange, getComplexityDisplayMode },
+    preference: { overrideMode, handleComplexityChange, getComplexityDisplayMode, timezone, handleTimezoneChange },
   }
 }

--- a/apps/web/src/features/settings/hooks/useSettingsState.js
+++ b/apps/web/src/features/settings/hooks/useSettingsState.js
@@ -171,7 +171,9 @@ export function useSettingsState() {
 
   const handleTimezoneChange = async (tz) => {
     try {
-      const { data: { user } } = await supabase.auth.getUser()
+      const { data } = await supabase.auth.getUser()
+      const user = data?.user
+      if (!user) throw new Error('Usuário não autenticado')
       await supabase.from('user_settings').update({ timezone: tz }).eq('user_id', user.id)
       setTimezone(tz)
       showMsg('success', 'Fuso horário atualizado.')

--- a/apps/web/src/views/redesign/settings/sections/PreferenceSection.jsx
+++ b/apps/web/src/views/redesign/settings/sections/PreferenceSection.jsx
@@ -1,4 +1,5 @@
 import { MonitorCog, Form, Wand2, Grid3x2 } from 'lucide-react'
+import { TIMEZONE_OPTIONS } from '@dosiq/core'
 
 /**
  * PreferenceSection — Preferências de interface e experiência de uso.
@@ -7,6 +8,8 @@ export default function PreferenceSection({
   overrideMode,
   handleComplexityChange,
   getComplexityDisplayMode,
+  timezone,
+  handleTimezoneChange,
 }) {
   return (
     <section className="sr-section">
@@ -50,6 +53,19 @@ export default function PreferenceSection({
         </div>
 
         <div className="sr-density__current">{getComplexityDisplayMode()}</div>
+      </div>
+
+      <div className="sr-section__card">
+        <h3 className="sr-section__card-header">Fuso Horário</h3>
+        <select
+          value={timezone}
+          onChange={(e) => handleTimezoneChange(e.target.value)}
+          className="sr-density__select"
+        >
+          {TIMEZONE_OPTIONS.map((tz) => (
+            <option key={tz.value} value={tz.value}>{tz.label}</option>
+          ))}
+        </select>
       </div>
     </section>
   )

--- a/packages/core/src/schemas/index.js
+++ b/packages/core/src/schemas/index.js
@@ -159,6 +159,8 @@ export {
 export {
   userSettingsNotificationSchema,
   NOTIFICATION_MODES,
+  TIMEZONES_BR,
+  TIMEZONE_OPTIONS,
   deriveLegacyPreference,
 } from './userSettingsSchema.js'
 

--- a/packages/core/src/schemas/userSettingsSchema.js
+++ b/packages/core/src/schemas/userSettingsSchema.js
@@ -6,24 +6,29 @@ const HH_MM_REGEX = /^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/
 export const NOTIFICATION_MODES = ['realtime', 'digest_morning', 'silent']
 
 // Fusos horários do Brasil (IANA) — ADR-049. Enum BR-only é mais seguro que regex livre.
-export const TIMEZONES_BR = [
-  'America/Sao_Paulo',   // Brasília (GMT-3) — Sul/Sudeste/Nordeste/DF
-  'America/Manaus',      // Amazonas (GMT-4)
-  'America/Cuiaba',      // Mato Grosso (GMT-4)
-  'America/Campo_Grande',// Mato Grosso do Sul (GMT-4)
-  'America/Porto_Velho', // Rondônia (GMT-4)
-  'America/Boa_Vista',   // Roraima (GMT-4)
-  'America/Rio_Branco',  // Acre (GMT-5)
-  'America/Eirunepe',    // Amazonas oeste (GMT-5)
-  'America/Belem',       // Pará leste (GMT-3)
-  'America/Santarem',    // Pará oeste (GMT-3)
-  'America/Fortaleza',   // Ceará/PI/RN/PB/AL/SE (GMT-3)
-  'America/Recife',      // Pernambuco (GMT-3)
-  'America/Bahia',       // Bahia (GMT-3)
-  'America/Maceio',      // Alagoas (GMT-3)
-  'America/Araguaina',   // Tocantins (GMT-3)
-  'America/Noronha',     // Fernando de Noronha (GMT-2)
+// Ordenados leste→oeste por offset (GMT-2 → GMT-5); São Paulo primeiro dentro de GMT-3
+// (default + fuso mais populoso). Label inclui cidade + estado/região + offset para
+// reconhecimento (ex: "Rio Branco, Acre (GMT-5)" em vez de só "Rio Branco").
+export const TIMEZONE_OPTIONS = [
+  { value: 'America/Noronha',      label: 'Fernando de Noronha (GMT-2)',           offset: -2 },
+  { value: 'America/Sao_Paulo',    label: 'Brasília, São Paulo, Rio (GMT-3)',      offset: -3 },
+  { value: 'America/Belem',        label: 'Belém, Pará (leste), Amapá (GMT-3)',    offset: -3 },
+  { value: 'America/Fortaleza',    label: 'Fortaleza, Ceará e Nordeste (GMT-3)',   offset: -3 },
+  { value: 'America/Recife',       label: 'Recife, Pernambuco (GMT-3)',            offset: -3 },
+  { value: 'America/Maceio',       label: 'Maceió, Alagoas (GMT-3)',               offset: -3 },
+  { value: 'America/Bahia',        label: 'Salvador, Bahia (GMT-3)',               offset: -3 },
+  { value: 'America/Araguaina',    label: 'Araguaína, Tocantins (GMT-3)',          offset: -3 },
+  { value: 'America/Santarem',     label: 'Santarém, Pará (oeste) (GMT-3)',        offset: -3 },
+  { value: 'America/Campo_Grande', label: 'Campo Grande, Mato Grosso do Sul (GMT-4)', offset: -4 },
+  { value: 'America/Cuiaba',       label: 'Cuiabá, Mato Grosso (GMT-4)',           offset: -4 },
+  { value: 'America/Manaus',       label: 'Manaus, Amazonas (GMT-4)',              offset: -4 },
+  { value: 'America/Boa_Vista',    label: 'Boa Vista, Roraima (GMT-4)',            offset: -4 },
+  { value: 'America/Porto_Velho',  label: 'Porto Velho, Rondônia (GMT-4)',         offset: -4 },
+  { value: 'America/Rio_Branco',   label: 'Rio Branco, Acre (GMT-5)',              offset: -5 },
+  { value: 'America/Eirunepe',     label: 'Eirunepé, Amazonas (oeste) (GMT-5)',    offset: -5 },
 ]
+
+export const TIMEZONES_BR = TIMEZONE_OPTIONS.map((o) => o.value)
 
 const timeSchema = z.string()
   .regex(HH_MM_REGEX, 'Formato HH:MM inválido')

--- a/plans/dose_instances_refactor/EXEC_SPECS_PHASE_1_2.md
+++ b/plans/dose_instances_refactor/EXEC_SPECS_PHASE_1_2.md
@@ -5,6 +5,39 @@
 
 ---
 
+## 📊 Status de execução (atualizado 2026-05-28)
+
+| PR | Sprints | Status | Ref |
+|----|---------|--------|-----|
+| **PR-F1.1** tz core | S1.0, S1.1, S1.2, S1.3, S1.6 | ✅ **MERGED** | PR #597 (squash `6816ee99`) · migration aplicada em prod · ADR-049 accepted · CON-022 |
+| **PR-F1.2** tz UI | S1.4, S1.5 | 🔄 **em smoke PO** (código verde, pré-commit) | branch `feature/dose-instances-f1-tz-ui` |
+| PR-F2.1 schema+lógica | S2.0–S2.3 | ⬜ pendente (Fase 2) | bloqueado: promover ADR-048 → accepted |
+| PR-F2.2 motor+lifecycle | S2.4, S2.5 | ⬜ pendente | |
+| PR-F2.3 âncora log | S2.6 | ⬜ pendente | |
+| PR-F2.4 backfill | S2.7 | ⬜ pendente | |
+
+**Aprendizados que afetam fases futuras:**
+- Blast radius tz confirmado: **~250 callers** de `getNow`/`getSaoPauloTime`/`getTodayLocal` seguem em **default SP**. A capacidade tz existe (`getUserTime`/param `tz`), mas o valor real só aparece quando consumidores **injetam** o tz do usuário. → ver **Gap G1** abaixo.
+- `getStartOfDayISO` migrado de `toLocaleString` para `getUserTime` (Hermes-safe) via review Gemini — padrão a seguir em qualquer extração de hora local.
+- Mobile reusa `FormSelect` (Modal+FlatList Android-safe) e `profileService.updateTimezone` (enum BR). Web persiste via `useSettingsState` (god-hook — já com warnings max-lines/complexity, candidato a refactor isolado futuro).
+- Edge multi-tz: device tz estrangeiro **não** é persistido (guard `TIMEZONES_BR.includes`) — usuário viajando mantém fuso BR salvo.
+
+## ⚠️ Gaps identificados (endereçados aqui)
+
+**G1 — Plumbing de injeção de tz (cross-cutting, entra na Fase 3).**
+Fase 1 deixou o core tz-capable, mas ninguém injeta `user_settings.timezone` ainda. Para o benefício multi-fuso materializar de ponta-a-ponta, é preciso um acessor consistente do tz do usuário:
+- **Web/Mobile:** hook/contexto `useUserTimezone()` (lê `user_settings.timezone` 1x, memoiza) que dashboards/adesão passam a `getNow(tz)`/`getTodayLocal(tz)`.
+- **Server (motor Fase 2 / bot):** o motor de geração e o `server/bot` leem `user_settings.timezone` por usuário ao gerar `scheduled_for` / computar lembretes.
+- **Sequenciamento:** enquanto não migrado, tudo opera em SP (default) — **consistente** (99% dos usuários são SP). Risco só aparece se a Fase 2 gerar `scheduled_for` com tz real do usuário enquanto o dashboard lê em SP → **mismatch**. **Regra:** Fase 2 motor e Fase 4 UI DEVEM injetar o mesmo tz; não misturar (ver G2).
+
+**G2 — Consistência tz entre geração (F2) e leitura (F4).**
+`scheduled_for` gerado no tz do usuário (F2) precisa ser lido/renderizado no mesmo tz (F4). A timeline cross-dia (F4) já planeja ordenar por `scheduled_for` absoluto — alinhado. Adicionar à DoD de S2.2/S2.4: documentar explicitamente em qual tz `scheduled_for` é gravado (instante absoluto UTC; o tz só governa o wall-clock de origem). Como é `timestamptz` (UTC absoluto), leitura é tz-agnóstica para ordenação — o tz só importa na geração e na exibição de "que horas são". Risco G1 mitigado por usar instante absoluto.
+
+**G3 — `quando_necessario` no DB usa acento (`quando_necessário`).**
+A migration `dose_instances` (S2.1) e o gerador (S2.2) devem casar com o CHECK real do DB: `frequency IN ('diário','dias_alternados','semanal','personalizado','quando_necessário')` — **com acentos** (confirmado via list_tables na F1.1). O gerador pula `quando_necessário` (PRN). Atualizar S2.2 para usar a string acentuada exata.
+
+---
+
 ## Modelo de orquestração
 
 **Main thread (eu) orquestra. Sub-agents executam. Quality gate é meu.**
@@ -130,7 +163,8 @@ Testes (S1.6/S2.8) **viajam dentro do PR do código que cobrem** — não viram 
 
 **Gates Fase 1:** G1 por sprint (lint + test:changed + reviewer do diff). G2 ao fechar **PR-F1.1** (S1.0-S1.3+S1.6) e **PR-F1.2** (S1.4+S1.5). Migration tz aplicada por humano antes do merge de F1.1.
 
-**Ordem Fase 1:** S1.0 → (S1.1 ∥ S1.2) → S1.3 → **[G2 → PR-F1.1 → merge]** → (S1.4 ∥ S1.5) [S1.6 dentro de F1.1] → **[G2 → PR-F1.2 → merge]** → G3
+**Ordem Fase 1:** S1.0 ✅ → (S1.1 ✅ ∥ S1.2 ✅) → S1.3 ✅ → **[G2 → PR-F1.1 ✅ MERGED #597]** → (S1.4 ✅ ∥ S1.5 ✅) [S1.6 ✅ em F1.1] → **[G2 → PR-F1.2 🔄 smoke PO]** → G3
+> Migration tz aplicada em prod (2026-05-28). S1.4/S1.5 código verde, aguardando smoke antes do commit.
 
 ---
 
@@ -161,8 +195,10 @@ Testes (S1.6/S2.8) **viajam dentro do PR do código que cobrem** — não viram 
 - **Files:** `packages/core/src/utils/doseInstanceGenerator.js` (novo) + teste
 - **Spec:**
   - `generateInstances(protocol, fromTs, toTs, tz)` → `[{ scheduled_for, expected_dose, tolerance_minutes }]`.
-  - **Reusa** `isProtocolActiveOnDate` + `FREQUENCY_MATCHERS` (não reimplementa recorrência). Trata `diario/dias_alternados/semanal/personalizado(weekdays)`.
-  - `quando_necessario` → retorna `[]` (PRN não gera).
+  - **Reusa** `isProtocolActiveOnDate` + `FREQUENCY_MATCHERS` (não reimplementa recorrência). Trata `diário/dias_alternados/semanal/personalizado(weekdays)`.
+  - ⚠️ **G3:** o CHECK real do DB usa **acentos** — `frequency IN ('diário','dias_alternados','semanal','personalizado','quando_necessário')`. Casar exato (não `quando_necessario`/`diario` sem acento).
+  - `quando_necessário` → retorna `[]` (PRN não gera).
+  - ⚠️ **G2:** `scheduled_for` é `timestamptz` (instante absoluto UTC) — tz só governa o wall-clock de origem na geração; leitura/ordenação é tz-agnóstica. Documentar isso na DoD.
   - `tolerance_minutes = min(metade_menor_intervalo_adjacente_no_dia, 120)`; não-diário/dose-única → 120 (§6 MASTER_PLAN).
   - `scheduled_for` = instante absoluto computado no `tz` recebido.
 - **Aceite:** tabela §6 reproduzida em teste; sem sobreposição de janelas entre slots adjacentes; PRN vazio; multi-fuso.

--- a/plans/dose_instances_refactor/MASTER_PLAN_REFACTOR_DOSE_INSTANCE.md
+++ b/plans/dose_instances_refactor/MASTER_PLAN_REFACTOR_DOSE_INSTANCE.md
@@ -1,8 +1,15 @@
 # Plano — Refatoração para `dose_instances` (Schedule-Anchored Doses)
 
-> **Status:** Draft de planejamento (pré-bootstrap DEVFLOW)
+> **Status:** Em execução — **Fase 1 quase completa** (PR-F1.1 merged #597; PR-F1.2 em smoke PO).
 > **Origem:** bug reportado pós-lançamento App Store — dose das 22:30 deixa de ser registrável após meia-noite.
-> **Decisão arquitetural-mãe:** ADR-048 (a registrar no C5) — adotar tabela `dose_instances` materializada, modelo híbrido (ocorrência agendada + dose avulsa).
+> **Decisão arquitetural-mãe:** **ADR-048** (proposed — promover a accepted no planning da Fase 2) — tabela `dose_instances` materializada, modelo híbrido. **ADR-049** (accepted) — core tz-aware, fundação da Fase 1.
+>
+> **Progresso (2026-05-28):**
+> - ✅ **Fase 1 / PR-F1.1** — core tz-aware (`getUserTime` + param tz default SP, non-breaking ~250 callers) · `user_settings.timezone` (migration em prod) · CON-022. Merged #597.
+> - 🔄 **Fase 1 / PR-F1.2** — seletor de fuso UI web+mobile + revalidação no launch mobile. Código verde, em smoke PO.
+> - ⬜ **Fase 2** — bloqueada por: promover ADR-048→accepted + planning próprio.
+>
+> **Gaps abertos** (detalhe em EXEC_SPECS §Gaps): **G1** plumbing de injeção de tz (Fase 3, ~250 callers em SP default até lá) · **G2** consistência tz geração↔leitura (mitigado por `timestamptz` absoluto) · **G3** frequência DB usa acento (`quando_necessário`/`diário`) — gerador deve casar exato.
 
 ---
 


### PR DESCRIPTION
## Fase 1 PR-F1.2 — Timezone UI (fecha a Fase 1)

Camada de UI do ADR-049: usuário escolhe seu fuso (`user_settings.timezone`) no settings **web e mobile**. Smoke PO validado.

### O que muda
- **`TIMEZONE_OPTIONS`** centralizado em `@dosiq/core` — `{value, label, offset}`, ordenado leste→oeste (GMT-2 → GMT-5), label **cidade + estado + GMT** (ex: "Rio Branco, Acre (GMT-5)", "Manaus, Amazonas (GMT-4)"). Fonte única web+mobile.
- **Web** (`PreferenceSection` + `useSettingsState`): card "Fuso Horário" com `<select>`, persiste via supabase.
- **Mobile** (`SettingsScreen` via `FormSelect`): seção "Fuso Horário", persiste via `profileService.updateTimezone` (valida enum BR).
- **Seleção manual = fonte de verdade**: removido auto-overwrite do fuso do device no launch (clobberava a escolha manual).

### Smoke PO (validado)
Persistência mobile ✓ · labels GMT+estado ✓ · ordenação leste→oeste ✓ · Acre presente ✓ · título duplicado removido ✓ · scroll iOS (lista 16 itens) ✓

### Fix incluído (shared)
`fix(mobile): FormSelect scrolla lista longa` — **AP-180**: FlatList `flexGrow:0` em sheet `maxHeight` transbordava sem scroll (bug latente, exposto pela lista de fusos). Fix `flexShrink:1`. Melhora todos os consumidores de FormSelect.

### Quality gates
- lint: 0 erros (2 warnings pré-existentes no god-hook `useSettingsState` — fora de escopo)
- web core: 125/125 · mobile profile: 5/5

### ⚠️ Sem efeito visível na agenda ainda
Gap **G1**: ~250 callers seguem em SP default. Injeção real do fuso = Fase 2 (motor gera `scheduled_for`) + Fase 3 (adesão). Hoje o seletor só persiste a preferência (fundação).

### Memória
ADR-049 (accepted). AP-180 registrado. Fecha a Fase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)