### PR TITLE
feat(dose-instances): schema + motor + repository (PR-F2.1)

### DIFF
--- a/.agent/memory/ANTI_PATTERNS_INDEX.md
+++ b/.agent/memory/ANTI_PATTERNS_INDEX.md
@@ -1,6 +1,7 @@
 # DEVFLOW Anti-Patterns Index
 
 ## 📦 Data & Schema (`data_and_schema`)
+- **[AP-181]** `FREQUENCY_MATCHERS` (isProtocolActiveOnDate) desatualizado vs DB: falta `dias_alternados` (→ vira diário) e `personalizado` → false (→ nunca ativo); latente (0 protocolos afetados em prod), fix na Fase 3 -> [`anti-patterns/data_and_schema/AP-181.md`](./anti-patterns/data_and_schema/AP-181.md)
 - **[AP-164]** Função com mesmo nome em arquivos diferentes do mesmo package — barrel `export *` colide silenciosamente; consumer importa a errada (isProtocolActiveOnDate strict vs period-only) -> [`anti-patterns/data_and_schema/AP-164.md`](./anti-patterns/data_and_schema/AP-164.md)
 - **[AP-168]** Cache invalidation incompleto em mutation — esquece snapshots adjacentes (toggleActive invalidou só protocols, esqueceu treatments-snapshot) -> [`anti-patterns/data_and_schema/AP-168.md`](./anti-patterns/data_and_schema/AP-168.md)
 - **[AP-058]** z.record() argumento único quebra parse em Zod v4 — TypeError '_zod' com objetos não-vazios -> [`anti-patterns/data_and_schema/AP-058.md`](./anti-patterns/data_and_schema/AP-058.md)

--- a/.agent/memory/anti-patterns/data_and_schema/AP-181.md
+++ b/.agent/memory/anti-patterns/data_and_schema/AP-181.md
@@ -1,0 +1,58 @@
+---
+id: AP-181
+title: FREQUENCY_MATCHERS de isProtocolActiveOnDate desatualizado vs frequências reais do DB
+status: warm
+discovered: 2026-05-28
+discovered_in: PR-F2.1 (dose_instances — preflight do gerador)
+trigger_count: 1
+tags:
+  - adherence
+  - frequency
+  - recurrence
+  - schema-drift
+linked_rules: []
+linked_aps:
+  - AP-164
+linked_adrs:
+  - ADR-048
+---
+
+# AP-181 — `FREQUENCY_MATCHERS` divergente das frequências reais do DB
+
+## Sintoma
+Em `packages/core/src/utils/adherenceLogic.js`, o `FREQUENCY_MATCHERS` (usado por
+`isProtocolActiveOnDate`) **não cobre** as strings de frequência que o CHECK do DB
+realmente armazena:
+
+- `dias_alternados` → **ausente** do Map → cai no default `() => true` → tratado como
+  **diário** (ativo todo dia), quando deveria alternar.
+- `personalizado` → mapeado para `() => false` → protocolo **nunca** fica ativo,
+  quando deveria casar pelos `weekdays` (igual a `semanal`, conforme PR #592).
+
+O DB usa (CHECK confirmado): `'diário','dias_alternados','semanal','personalizado','quando_necessário'`.
+Já `getDailyDoseRate` (mesmo arquivo) trata `dias_alternados` (÷2) e `personalizado`
+(weekday-based) **corretamente** — ou seja, há divergência interna entre duas funções
+do mesmo módulo.
+
+## Impacto
+- Adesão e qualquer consumidor de `isProtocolActiveOnDate` enxergam dias errados para
+  protocolos `dias_alternados`/`personalizado`.
+- O motor `dose_instances` (ADR-048) reusa `isProtocolActiveOnDate` como fonte única de
+  recorrência → herdaria a geração errada (alternado→diário; personalizado→zero).
+- **Não afeta prod hoje** (28/05/2026): 0 protocolos usam essas frequências (26 diário,
+  1 semanal, 1 quando_necessário). Bug latente, dispara quando usuário criar uma.
+
+## Por que não foi corrigido em PR-F2.1
+Corrigir o `FREQUENCY_MATCHERS` **muda comportamento de adesão** (callers em
+`calculateAdherenceStats`/`calculateDosesByDate`) — fora do escopo "zero behavior change"
+do PR-F2.1 (schema+gerador+repo). O gerador reusa a função como-está → permanece
+**consistente** com o que o dashboard mostra hoje.
+
+## Como aplicar (fix futuro — Fase 3)
+Na refatoração de adesão por scheduled-time (Fase 3), corrigir o Map:
+- adicionar `['dias_alternados', (p,_d,t) => _isAlternatingMatch(p, t)]`
+- trocar `['personalizado', () => false]` por `['personalizado', (p,dow) => _isWeeklyMatch(p, dow)]`
+- adicionar testes multi-frequência cobrindo geração + adesão; regenerar `dose_instances`
+  dos protocolos afetados (idempotente via upsert).
+
+Relacionado a [[AP-164]] (mesma família `isProtocolActiveOnDate`: strict vs period-only).

--- a/docs/migrations/20260528_create_dose_instances.sql
+++ b/docs/migrations/20260528_create_dose_instances.sql
@@ -1,0 +1,103 @@
+-- Migration: dose_instances (schedule-anchored doses) — ADR-048 / Fase 2 PR-F2.1
+-- Data: 2026-05-28
+--
+-- Materializa cada ocorrência agendada de dose como linha própria, ancorada ao
+-- instante de schedule (`scheduled_for`, timestamptz absoluto). Substitui o modelo
+-- inferencial atual (medicine_logs casado por janela ±2h sobre taken_at), que perde
+-- a âncora ao cruzar a meia-noite (bug da dose 22:30).
+--
+-- Comportamento: ADITIVO. Nenhum código em produção lê estas tabelas/colunas ainda
+-- (PR-F2.1 entrega schema + gerador + repository, sem wiring). Defaults preservam o
+-- estado atual de protocols/medicine_logs. Segura de aplicar antes do merge.
+--
+-- Pré-requisito de tz: Fase 1 (ADR-049) — `scheduled_for` depende de
+-- user_settings.timezone, gravado pelo motor de geração (PR-F2.2).
+
+-- ============================================================================
+-- 1. dose_instances — ocorrências materializadas
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.dose_instances (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           uuid NOT NULL,
+  protocol_id       uuid NOT NULL REFERENCES public.protocols(id) ON DELETE CASCADE,
+  scheduled_for     timestamptz NOT NULL,           -- instante absoluto (UTC); tz do usuário governa só o wall-clock de origem
+  expected_dose     numeric NOT NULL,               -- dosagem esperada congelada no momento da geração
+  status            text NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending','taken','missed','skipped_paused','skipped_user')),
+  medicine_log_id   uuid REFERENCES public.medicine_logs(id) ON DELETE SET NULL,  -- elo quando tomada
+  tolerance_minutes int NOT NULL DEFAULT 120,        -- janela dinâmica (§6 MASTER_PLAN), computada na geração
+  notified_at       timestamptz,                     -- idempotência de notificação
+  snoozed_until     timestamptz,
+  created_at        timestamptz DEFAULT now(),
+  CONSTRAINT uq_dose_instance UNIQUE (protocol_id, scheduled_for)  -- habilita upsert idempotente (ON CONFLICT DO NOTHING)
+);
+
+COMMENT ON TABLE public.dose_instances IS 'Ocorrências de dose materializadas (schedule-anchored) — ADR-048. status: pending|taken|missed|skipped_paused|skipped_user (skipped_* são neutros para adesão).';
+COMMENT ON COLUMN public.dose_instances.scheduled_for IS 'Instante absoluto (timestamptz UTC). O tz do usuário só governa o wall-clock de origem na geração; leitura/ordenação é tz-agnóstica.';
+COMMENT ON COLUMN public.dose_instances.tolerance_minutes IS 'Janela de tolerância dinâmica: min(metade do menor intervalo adjacente, 120) para diário multi-dose; 120 para não-diário/dose-única.';
+
+-- Índices de leitura (timeline por usuário; wipe/lifecycle por protocolo+status)
+CREATE INDEX IF NOT EXISTS idx_dose_instances_user_scheduled
+  ON public.dose_instances (user_id, scheduled_for);
+CREATE INDEX IF NOT EXISTS idx_dose_instances_protocol_status
+  ON public.dose_instances (protocol_id, status);
+
+-- Grants obrigatórios (CLAUDE.md — pós 30/10/2026 novas tabelas não recebem grants automáticos)
+-- anon negado explicitamente (defense-in-depth): dose_instances nunca tem dado público.
+REVOKE ALL ON public.dose_instances FROM anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.dose_instances TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.dose_instances TO service_role;
+ALTER TABLE public.dose_instances ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS dose_instances_owner ON public.dose_instances;
+CREATE POLICY dose_instances_owner ON public.dose_instances
+  FOR ALL
+  TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- ============================================================================
+-- 2. dose_adherence_monthly — rollup mensal (cold; agregados imutáveis)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.dose_adherence_monthly (
+  user_id      uuid NOT NULL,
+  protocol_id  uuid NOT NULL REFERENCES public.protocols(id) ON DELETE CASCADE,
+  month        date NOT NULL,            -- 1º dia do mês
+  expected     int NOT NULL,
+  taken        int NOT NULL,
+  missed       int NOT NULL,
+  PRIMARY KEY (user_id, protocol_id, month)
+);
+
+COMMENT ON TABLE public.dose_adherence_monthly IS 'Rollup mensal de adesão (ADR-048 §7). Agregados imutáveis de meses fechados; permite podar dose_instances raw (>18 meses) sem perder histórico.';
+
+REVOKE ALL ON public.dose_adherence_monthly FROM anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.dose_adherence_monthly TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.dose_adherence_monthly TO service_role;
+ALTER TABLE public.dose_adherence_monthly ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS dose_adherence_monthly_owner ON public.dose_adherence_monthly;
+CREATE POLICY dose_adherence_monthly_owner ON public.dose_adherence_monthly
+  FOR ALL
+  TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+-- ============================================================================
+-- 3. medicine_logs — elo para a instância (nullable: avulsas/PRN ficam null)
+-- ============================================================================
+ALTER TABLE public.medicine_logs
+  ADD COLUMN IF NOT EXISTS dose_instance_id uuid REFERENCES public.dose_instances(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.medicine_logs.dose_instance_id IS 'FK para dose_instances quando a tomada ancora num slot agendado. NULL para doses avulsas/PRN ou fora da janela de tolerância.';
+
+-- ============================================================================
+-- 4. protocols — high-water-mark de geração + marca de pausa
+-- ============================================================================
+ALTER TABLE public.protocols
+  ADD COLUMN IF NOT EXISTS generated_through timestamptz;
+ALTER TABLE public.protocols
+  ADD COLUMN IF NOT EXISTS paused_at timestamptz;
+
+COMMENT ON COLUMN public.protocols.generated_through IS 'High-water-mark: até quando dose_instances já foram materializadas para este protocolo (ADR-048). NULL = nada gerado ainda.';
+COMMENT ON COLUMN public.protocols.paused_at IS 'Timestamp da última pausa (active=false). Cron detecta pausa > 1 dia para wipe das pendentes futuras.';

--- a/docs/migrations/20260528_create_dose_instances.sql
+++ b/docs/migrations/20260528_create_dose_instances.sql
@@ -62,7 +62,7 @@ CREATE POLICY dose_instances_owner ON public.dose_instances
 CREATE TABLE IF NOT EXISTS public.dose_adherence_monthly (
   user_id      uuid NOT NULL,
   protocol_id  uuid NOT NULL REFERENCES public.protocols(id) ON DELETE CASCADE,
-  month        date NOT NULL,            -- 1º dia do mês
+  month        date NOT NULL CHECK (extract(day from month) = 1),  -- sempre o 1º dia do mês (evita linhas duplicadas do mesmo mês sob PKs distintas)
   expected     int NOT NULL,
   taken        int NOT NULL,
   missed       int NOT NULL,

--- a/packages/core/src/repositories/__tests__/createDoseInstanceRepository.test.js
+++ b/packages/core/src/repositories/__tests__/createDoseInstanceRepository.test.js
@@ -1,0 +1,153 @@
+// Tests — createDoseInstanceRepository (ADR-048, Fase 2 PR-F2.1)
+//
+// Foco: idempotência do upsert (ON CONFLICT DO NOTHING) e a regra inviolável do
+// wipe (nunca toca taken/missed/skipped nem o passado). Mock builder fluente —
+// não toca no Supabase real (espelha createProtocolRepository.test.js).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createDoseInstanceRepository } from '../createDoseInstanceRepository.js'
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.clearAllTimers()
+})
+
+function makeBuilder(result) {
+  const builder = {
+    _calls: [],
+    select: vi.fn(function (...a) { this._calls.push(['select', a]); return this }),
+    insert: vi.fn(function (...a) { this._calls.push(['insert', a]); return this }),
+    upsert: vi.fn(function (...a) { this._calls.push(['upsert', a]); return this }),
+    update: vi.fn(function (...a) { this._calls.push(['update', a]); return this }),
+    delete: vi.fn(function (...a) { this._calls.push(['delete', a]); return this }),
+    eq:     vi.fn(function (...a) { this._calls.push(['eq', a]); return this }),
+    gt:     vi.fn(function (...a) { this._calls.push(['gt', a]); return this }),
+    gte:    vi.fn(function (...a) { this._calls.push(['gte', a]); return this }),
+    lte:    vi.fn(function (...a) { this._calls.push(['lte', a]); return this }),
+    order:  vi.fn(function (...a) { this._calls.push(['order', a]); return this }),
+    single: vi.fn(function ()     { this._calls.push(['single', []]); return Promise.resolve(result) }),
+    then:   (resolve) => resolve(result),
+  }
+  return builder
+}
+
+function makeClient(result) {
+  const builder = makeBuilder(result)
+  const client = {
+    _builder: builder,
+    _from: null,
+    from: vi.fn((table) => { client._from = table; return builder }),
+  }
+  return client
+}
+
+function callNames(builder) {
+  return builder._calls.map(([name]) => name)
+}
+
+describe('createDoseInstanceRepository', () => {
+  it('exige client', () => {
+    expect(() => createDoseInstanceRepository({})).toThrow(/client é obrigatório/)
+  })
+
+  describe('upsertMany — idempotência', () => {
+    let client, repo
+    beforeEach(() => {
+      client = makeClient({ data: [{ id: 'di-1' }], error: null })
+      repo = createDoseInstanceRepository({ client })
+    })
+
+    it('usa ON CONFLICT DO NOTHING (onConflict + ignoreDuplicates)', async () => {
+      await repo.upsertMany([{ protocol_id: 'p1', scheduled_for: '2026-05-10T11:00:00Z' }])
+      const upsertCall = client._builder._calls.find(([n]) => n === 'upsert')
+      expect(client._from).toBe('dose_instances')
+      expect(upsertCall[1][1]).toEqual({
+        onConflict: 'protocol_id,scheduled_for',
+        ignoreDuplicates: true,
+      })
+    })
+
+    it('array vazio → [] sem tocar no client', async () => {
+      const out = await repo.upsertMany([])
+      expect(out).toEqual([])
+      expect(client.from).not.toHaveBeenCalled()
+    })
+
+    it('propaga erro do Supabase', async () => {
+      client = makeClient({ data: null, error: new Error('boom') })
+      repo = createDoseInstanceRepository({ client })
+      await expect(repo.upsertMany([{ protocol_id: 'p1' }])).rejects.toThrow('boom')
+    })
+  })
+
+  describe('wipeFuturePending — regra inviolável', () => {
+    it('filtra status=pending E scheduled_for > now (nunca passado/taken/missed)', async () => {
+      const client = makeClient({ data: null, error: null })
+      const repo = createDoseInstanceRepository({ client })
+      const before = Date.now()
+      await repo.wipeFuturePending('p1')
+
+      const b = client._builder
+      expect(client._from).toBe('dose_instances')
+      expect(callNames(b)).toContain('delete')
+      // escopo por protocolo + status pending
+      expect(b.eq).toHaveBeenCalledWith('protocol_id', 'p1')
+      expect(b.eq).toHaveBeenCalledWith('status', 'pending')
+      // corte temporal estritamente futuro (gt, não gte)
+      const gtCall = b._calls.find(([n]) => n === 'gt')
+      expect(gtCall[1][0]).toBe('scheduled_for')
+      const cutoff = new Date(gtCall[1][1]).getTime()
+      expect(cutoff).toBeGreaterThanOrEqual(before)
+    })
+  })
+
+  describe('markSkippedPaused', () => {
+    it('marca pendentes futuras até untilTs como skipped_paused', async () => {
+      const client = makeClient({ data: null, error: null })
+      const repo = createDoseInstanceRepository({ client })
+      const until = '2026-05-11T00:00:00Z'
+      await repo.markSkippedPaused('p1', until)
+
+      const b = client._builder
+      expect(b.update).toHaveBeenCalledWith({ status: 'skipped_paused' })
+      expect(b.eq).toHaveBeenCalledWith('status', 'pending')
+      const lteCall = b._calls.find(([n]) => n === 'lte')
+      expect(new Date(lteCall[1][1]).toISOString()).toBe(new Date(until).toISOString())
+    })
+  })
+
+  describe('getWindow', () => {
+    it('escopa por userId e ordena por scheduled_for ascendente', async () => {
+      const client = makeClient({ data: [{ id: 'di-1' }], error: null })
+      const repo = createDoseInstanceRepository({ client })
+      const out = await repo.getWindow('u1', '2026-05-10T00:00:00Z', '2026-05-10T23:59:59Z')
+
+      const b = client._builder
+      expect(b.eq).toHaveBeenCalledWith('user_id', 'u1')
+      expect(b.gte).toHaveBeenCalled()
+      expect(b.lte).toHaveBeenCalled()
+      expect(b.order).toHaveBeenCalledWith('scheduled_for', { ascending: true })
+      expect(out).toEqual([{ id: 'di-1' }])
+    })
+  })
+
+  describe('generated_through high-water-mark', () => {
+    it('getGeneratedThrough lê de protocols e retorna o valor', async () => {
+      const client = makeClient({ data: { generated_through: '2026-06-01T00:00:00Z' }, error: null })
+      const repo = createDoseInstanceRepository({ client })
+      const out = await repo.getGeneratedThrough('p1')
+      expect(client._from).toBe('protocols')
+      expect(out).toBe('2026-06-01T00:00:00Z')
+    })
+
+    it('setGeneratedThrough atualiza protocols.generated_through', async () => {
+      const client = makeClient({ data: null, error: null })
+      const repo = createDoseInstanceRepository({ client })
+      await repo.setGeneratedThrough('p1', '2026-06-01T00:00:00Z')
+      const b = client._builder
+      expect(client._from).toBe('protocols')
+      expect(b.update).toHaveBeenCalledWith({ generated_through: '2026-06-01T00:00:00.000Z' })
+      expect(b.eq).toHaveBeenCalledWith('id', 'p1')
+    })
+  })
+})

--- a/packages/core/src/repositories/createDoseInstanceRepository.js
+++ b/packages/core/src/repositories/createDoseInstanceRepository.js
@@ -1,0 +1,139 @@
+// createDoseInstanceRepository.js — Factory de acesso a dose_instances (ADR-048, Fase 2).
+//
+// Espelha o pattern de createProtocolRepository. Web/mobile/server injetam o client
+// Supabase. Diferente dos repos CRUD de UI, os métodos escopam por `protocol_id`
+// (posse garantida pelo dono do protocolo) ou por `userId` explícito (getWindow) —
+// o motor de geração roda como service_role e itera múltiplos usuários, então não
+// depende de getUserId de sessão. RLS (user_id = auth.uid()) cobre o acesso client.
+//
+// Métodos:
+// - upsertMany(instances)            → INSERT ... ON CONFLICT (protocol_id, scheduled_for) DO NOTHING (idempotente)
+// - wipeFuturePending(protocolId)    → DELETE status='pending' AND scheduled_for > now() (nunca toca passado/taken/missed)
+// - getWindow(userId, fromTs, toTs)  → instâncias do usuário na janela, ordenadas
+// - getGeneratedThrough(protocolId)  → high-water-mark (protocols.generated_through)
+// - setGeneratedThrough(protocolId, ts)
+// - markSkippedPaused(protocolId, untilTs) → pendentes futuras até untilTs viram skipped_paused
+
+import { getServerTimestamp, parseISO } from '../utils/dateUtils.js'
+
+const TABLE = 'dose_instances'
+const PROTOCOLS = 'protocols'
+
+/** Converte Date|ISO em ISO string (R-020: sem `new Date()` fora de dateUtils). */
+const toIso = (value) => parseISO(value).toISOString()
+
+/**
+ * @param {Object} deps
+ * @param {Object} deps.client - Cliente Supabase.
+ */
+export function createDoseInstanceRepository({ client }) {
+  if (!client) throw new Error('createDoseInstanceRepository: client é obrigatório')
+
+  return {
+    /**
+     * Insere instâncias ignorando conflitos no índice único (protocol_id, scheduled_for).
+     * Idempotente: rodar 2x não duplica nem sobrescreve instâncias já materializadas.
+     * @param {Array<Object>} instances - linhas prontas (user_id, protocol_id, scheduled_for, expected_dose, tolerance_minutes)
+     * @returns {Promise<Array>} linhas efetivamente inseridas
+     */
+    async upsertMany(instances) {
+      if (!Array.isArray(instances) || instances.length === 0) return []
+      const { data, error } = await client
+        .from(TABLE)
+        .upsert(instances, {
+          onConflict: 'protocol_id,scheduled_for',
+          ignoreDuplicates: true,
+        })
+        .select()
+
+      if (error) throw error
+      return data ?? []
+    },
+
+    /**
+     * Remove APENAS instâncias pendentes futuras de um protocolo.
+     * Regra inviolável (§4 MASTER_PLAN): nunca toca taken/missed/skipped nem o passado.
+     * @param {string} protocolId
+     * @returns {Promise<void>}
+     */
+    async wipeFuturePending(protocolId) {
+      const { error } = await client
+        .from(TABLE)
+        .delete()
+        .eq('protocol_id', protocolId)
+        .eq('status', 'pending')
+        .gt('scheduled_for', getServerTimestamp())
+
+      if (error) throw error
+    },
+
+    /**
+     * Instâncias de um usuário dentro de [fromTs, toTs], ordenadas por scheduled_for.
+     * @param {string} userId
+     * @param {Date|string} fromTs
+     * @param {Date|string} toTs
+     * @returns {Promise<Array>}
+     */
+    async getWindow(userId, fromTs, toTs) {
+      const { data, error } = await client
+        .from(TABLE)
+        .select('*')
+        .eq('user_id', userId)
+        .gte('scheduled_for', toIso(fromTs))
+        .lte('scheduled_for', toIso(toTs))
+        .order('scheduled_for', { ascending: true })
+
+      if (error) throw error
+      return data ?? []
+    },
+
+    /**
+     * High-water-mark de geração do protocolo.
+     * @param {string} protocolId
+     * @returns {Promise<string|null>} ISO timestamptz ou null
+     */
+    async getGeneratedThrough(protocolId) {
+      const { data, error } = await client
+        .from(PROTOCOLS)
+        .select('generated_through')
+        .eq('id', protocolId)
+        .single()
+
+      if (error) throw error
+      return data?.generated_through ?? null
+    },
+
+    /**
+     * Atualiza o high-water-mark de geração.
+     * @param {string} protocolId
+     * @param {Date|string} ts
+     * @returns {Promise<void>}
+     */
+    async setGeneratedThrough(protocolId, ts) {
+      const { error } = await client
+        .from(PROTOCOLS)
+        .update({ generated_through: toIso(ts) })
+        .eq('id', protocolId)
+
+      if (error) throw error
+    },
+
+    /**
+     * Marca instâncias pendentes futuras até `untilTs` como skipped_paused (pausa não penaliza).
+     * @param {string} protocolId
+     * @param {Date|string} untilTs
+     * @returns {Promise<void>}
+     */
+    async markSkippedPaused(protocolId, untilTs) {
+      const { error } = await client
+        .from(TABLE)
+        .update({ status: 'skipped_paused' })
+        .eq('protocol_id', protocolId)
+        .eq('status', 'pending')
+        .gt('scheduled_for', getServerTimestamp())
+        .lte('scheduled_for', toIso(untilTs))
+
+      if (error) throw error
+    },
+  }
+}

--- a/packages/core/src/repositories/index.js
+++ b/packages/core/src/repositories/index.js
@@ -4,3 +4,4 @@ export { createTreatmentPlanRepository } from './createTreatmentPlanRepository.j
 export { createStockRepository } from './createStockRepository.js'
 export { createPurchaseRepository } from './createPurchaseRepository.js'
 export { createProfileRepository } from './createProfileRepository.js'
+export { createDoseInstanceRepository } from './createDoseInstanceRepository.js'

--- a/packages/core/src/utils/__tests__/doseInstanceGenerator.test.js
+++ b/packages/core/src/utils/__tests__/doseInstanceGenerator.test.js
@@ -1,0 +1,218 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { generateInstances } from '../doseInstanceGenerator.js'
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.clearAllTimers()
+})
+
+// Helpers ------------------------------------------------------------------
+const baseProtocol = {
+  id: 'p1',
+  user_id: 'u1',
+  frequency: 'diário',
+  time_schedule: ['08:00', '22:30'],
+  dosage_per_intake: 2,
+  start_date: '2026-01-01',
+  end_date: null,
+  active: true,
+}
+
+/** Extrai wall-clock HH:MM no fuso a partir do ISO gerado. */
+function wallClock(iso, tz) {
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone: tz,
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(iso))
+}
+
+describe('generateInstances — recorrência diária', () => {
+  it('gera 2 slots/dia para janela de 1 dia (SP)', () => {
+    const out = generateInstances(
+      baseProtocol,
+      '2026-05-10T00:00:00-03:00',
+      '2026-05-10T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out).toHaveLength(2)
+    expect(out.map((i) => wallClock(i.scheduled_for, 'America/Sao_Paulo'))).toEqual(['08:00', '22:30'])
+    expect(out.every((i) => i.expected_dose === 2)).toBe(true)
+    expect(out.every((i) => i.protocol_id === 'p1' && i.user_id === 'u1')).toBe(true)
+  })
+
+  it('ordena por scheduled_for absoluto', () => {
+    const out = generateInstances(
+      baseProtocol,
+      '2026-05-10T00:00:00-03:00',
+      '2026-05-12T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    const sorted = [...out].sort((a, b) => a.scheduled_for.localeCompare(b.scheduled_for))
+    expect(out).toEqual(sorted)
+    expect(out).toHaveLength(6) // 3 dias × 2 slots
+  })
+
+  it('respeita os limites da janela (exclui fora de [from,to])', () => {
+    // janela começa 09:00 → exclui o slot das 08:00 do dia 1
+    const out = generateInstances(
+      baseProtocol,
+      '2026-05-10T09:00:00-03:00',
+      '2026-05-10T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out).toHaveLength(1)
+    expect(wallClock(out[0].scheduled_for, 'America/Sao_Paulo')).toBe('22:30')
+  })
+})
+
+describe('generateInstances — timezone (multi-fuso)', () => {
+  it('grava o mesmo wall-clock em fusos diferentes como instantes absolutos distintos', () => {
+    const sp = generateInstances(
+      { ...baseProtocol, time_schedule: ['08:00'] },
+      '2026-05-10T00:00:00-03:00',
+      '2026-05-10T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    const manaus = generateInstances(
+      { ...baseProtocol, time_schedule: ['08:00'] },
+      '2026-05-10T00:00:00-04:00',
+      '2026-05-10T23:59:59-04:00',
+      'America/Manaus'
+    )
+    expect(wallClock(sp[0].scheduled_for, 'America/Sao_Paulo')).toBe('08:00')
+    expect(wallClock(manaus[0].scheduled_for, 'America/Manaus')).toBe('08:00')
+    // 08:00 SP (GMT-3) = 11:00Z; 08:00 Manaus (GMT-4) = 12:00Z → instantes distintos
+    expect(sp[0].scheduled_for).not.toBe(manaus[0].scheduled_for)
+    expect(new Date(manaus[0].scheduled_for).getTime()).toBeGreaterThan(
+      new Date(sp[0].scheduled_for).getTime()
+    )
+  })
+
+  it('dose das 22:30 cruza a meia-noite sem perder âncora ao dia correto', () => {
+    // janela cobre dia 10 22:30 até dia 11 00:30 — o slot pertence ao dia 10
+    const out = generateInstances(
+      { ...baseProtocol, time_schedule: ['22:30'] },
+      '2026-05-10T22:00:00-03:00',
+      '2026-05-11T00:30:00-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out).toHaveLength(1)
+    expect(wallClock(out[0].scheduled_for, 'America/Sao_Paulo')).toBe('22:30')
+    // confirma data local = 10, não 11
+    const localDate = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Sao_Paulo' }).format(
+      new Date(out[0].scheduled_for)
+    )
+    expect(localDate).toBe('2026-05-10')
+  })
+})
+
+describe('generateInstances — tolerância dinâmica (§6)', () => {
+  it('diário multi-dose: metade do menor intervalo adjacente, teto 120', () => {
+    // slots 08:00 e 22:30 → gap 870min → metade 435 → teto 120
+    const out = generateInstances(
+      baseProtocol,
+      '2026-05-10T00:00:00-03:00',
+      '2026-05-10T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out.every((i) => i.tolerance_minutes === 120)).toBe(true)
+  })
+
+  it('slots próximos reduzem tolerância para não sobrepor janelas', () => {
+    // 08:00 e 09:00 → gap 60 → metade 30
+    const out = generateInstances(
+      { ...baseProtocol, time_schedule: ['08:00', '09:00'] },
+      '2026-05-10T00:00:00-03:00',
+      '2026-05-10T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out.map((i) => i.tolerance_minutes)).toEqual([30, 30])
+    // janelas não se sobrepõem: 08:00+30 = 08:30 <= 09:00-30 = 08:30 (toca, não sobrepõe)
+  })
+
+  it('três slots: cada um usa o menor adjacente', () => {
+    // 08:00, 09:00 (gap 60→30), 12:00 (gap 180→90). slot do meio = min(30,90)=15? não:
+    // 09:00 prev gap 60/2=30, next gap 180/2=90 → min=30
+    const out = generateInstances(
+      { ...baseProtocol, time_schedule: ['08:00', '09:00', '12:00'] },
+      '2026-05-10T00:00:00-03:00',
+      '2026-05-10T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out.map((i) => i.tolerance_minutes)).toEqual([30, 30, 90])
+  })
+
+  it('dose única diária: 120 fixo', () => {
+    const out = generateInstances(
+      { ...baseProtocol, time_schedule: ['08:00'] },
+      '2026-05-10T00:00:00-03:00',
+      '2026-05-10T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out[0].tolerance_minutes).toBe(120)
+  })
+
+  it('semanal multi-dose: 120 fixo (não-diário não usa janela dinâmica)', () => {
+    const out = generateInstances(
+      {
+        ...baseProtocol,
+        frequency: 'semanal',
+        weekdays: ['domingo', 'segunda', 'terça', 'quarta', 'quinta', 'sexta', 'sábado'],
+        time_schedule: ['08:00', '09:00'],
+      },
+      '2026-05-10T00:00:00-03:00',
+      '2026-05-10T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out.every((i) => i.tolerance_minutes === 120)).toBe(true)
+  })
+})
+
+describe('generateInstances — casos de borda', () => {
+  it('PRN (quando_necessário) não gera instâncias', () => {
+    const out = generateInstances(
+      { ...baseProtocol, frequency: 'quando_necessário' },
+      '2026-05-10T00:00:00-03:00',
+      '2026-05-12T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out).toEqual([])
+  })
+
+  it('respeita end_date (não gera após o fim)', () => {
+    const out = generateInstances(
+      { ...baseProtocol, end_date: '2026-05-10', time_schedule: ['08:00'] },
+      '2026-05-09T00:00:00-03:00',
+      '2026-05-15T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    const dates = out.map((i) =>
+      new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Sao_Paulo' }).format(new Date(i.scheduled_for))
+    )
+    expect(dates).toEqual(['2026-05-09', '2026-05-10'])
+  })
+
+  it('time_schedule vazio → []', () => {
+    expect(generateInstances({ ...baseProtocol, time_schedule: [] }, '2026-05-10T00:00:00-03:00', '2026-05-10T23:59:59-03:00')).toEqual([])
+  })
+
+  it('protocolo nulo ou janela invertida → []', () => {
+    expect(generateInstances(null, '2026-05-10', '2026-05-11')).toEqual([])
+    expect(
+      generateInstances(baseProtocol, '2026-05-12T00:00:00-03:00', '2026-05-10T00:00:00-03:00')
+    ).toEqual([])
+  })
+
+  it('ignora horários malformados no time_schedule', () => {
+    const out = generateInstances(
+      { ...baseProtocol, time_schedule: ['08:00', 'xx:yy', null] },
+      '2026-05-10T00:00:00-03:00',
+      '2026-05-10T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out).toHaveLength(1)
+    expect(wallClock(out[0].scheduled_for, 'America/Sao_Paulo')).toBe('08:00')
+  })
+})

--- a/packages/core/src/utils/__tests__/doseInstanceGenerator.test.js
+++ b/packages/core/src/utils/__tests__/doseInstanceGenerator.test.js
@@ -144,6 +144,17 @@ describe('generateInstances — tolerância dinâmica (§6)', () => {
     expect(out.map((i) => i.tolerance_minutes)).toEqual([30, 30, 90])
   })
 
+  it('considera wrap-around da meia-noite (00:30 e 23:30 → janela real 60min → tol 30)', () => {
+    // mesmo dia o gap parece 1380min, mas na virada são 60min → tolerância 30, sem sobrepor
+    const out = generateInstances(
+      { ...baseProtocol, time_schedule: ['00:30', '23:30'] },
+      '2026-05-10T00:00:00-03:00',
+      '2026-05-10T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out.map((i) => i.tolerance_minutes)).toEqual([30, 30])
+  })
+
   it('dose única diária: 120 fixo', () => {
     const out = generateInstances(
       { ...baseProtocol, time_schedule: ['08:00'] },

--- a/packages/core/src/utils/doseInstanceGenerator.js
+++ b/packages/core/src/utils/doseInstanceGenerator.js
@@ -1,0 +1,179 @@
+/**
+ * doseInstanceGenerator — motor de geração de ocorrências de dose (ADR-048, Fase 2).
+ *
+ * Funções PURAS (sem I/O): dado um protocolo + janela [fromTs, toTs] + fuso do
+ * usuário, produz as linhas a materializar em `dose_instances`.
+ *
+ * Princípios:
+ * - REUSA `isProtocolActiveOnDate` (adherenceLogic) como fonte única de recorrência.
+ *   Não reimplementa frequência → gerador e adesão enxergam os mesmos dias.
+ *   ⚠️ Gap conhecido (AP futuro): o matcher de `isProtocolActiveOnDate` ainda não
+ *   cobre `dias_alternados`/`personalizado` corretamente (vide adherenceLogic
+ *   FREQUENCY_MATCHERS). Como nenhum protocolo em prod usa essas frequências hoje
+ *   e o fix muda comportamento de adesão (fora do escopo F2.1), o gerador herda o
+ *   comportamento atual — consistente com o que o dashboard mostra. Corrigir na Fase 3.
+ * - `scheduled_for` é instante absoluto (ISO/UTC). O `tz` só governa o wall-clock de
+ *   origem (que horas o relógio do usuário marcava). Leitura/ordenação é tz-agnóstica
+ *   por ser timestamptz. Brasil não tem DST → offset constante dentro do dia.
+ * - PRN (`quando_necessário`) nunca gera instâncias.
+ */
+
+import {
+  getStartOfDayISO,
+  getUserTime,
+  formatLocalDate,
+  parseLocalDate,
+  parseISO,
+  parseTimestamp,
+} from './dateUtils.js'
+import { isProtocolActiveOnDate } from './adherenceLogic.js'
+
+/**
+ * Converte Date | ISO string | timestamp(ms) num Date absoluto.
+ * Usa helpers de dateUtils (R-020: nunca `new Date()` direto fora de dateUtils).
+ * @param {Date|string|number} value
+ * @returns {Date}
+ */
+function toInstant(value) {
+  if (value instanceof Date) return value
+  if (typeof value === 'number') return parseTimestamp(value)
+  return parseISO(value)
+}
+
+/** Frequências que não materializam ocorrências (sob demanda). */
+const PRN_FREQUENCIES = new Set(['quando_necessário', 'when_needed', 'prn'])
+
+/** Frequências "diárias" elegíveis a janela de tolerância dinâmica (§6). */
+const DAILY_FREQUENCIES = new Set(['diário', 'diariamente', 'daily'])
+
+const MAX_TOLERANCE_MINUTES = 120
+
+/**
+ * Converte "HH:MM" em minutos desde a meia-noite. Retorna null se inválido.
+ * @param {string} time
+ * @returns {number|null}
+ */
+function timeToMinutes(time) {
+  if (typeof time !== 'string') return null
+  const [h, m] = time.split(':').map(Number)
+  if (Number.isNaN(h) || Number.isNaN(m)) return null
+  return h * 60 + m
+}
+
+/**
+ * Calcula a tolerância (minutos) de cada slot do dia.
+ *
+ * - Diário multi-dose: por slot, metade do menor intervalo adjacente (anterior/próximo),
+ *   com teto de 120 — garante que janelas de slots vizinhos não se sobreponham.
+ * - Não-diário ou dose única: 120 fixo (§6 MASTER_PLAN).
+ *
+ * @param {number[]} sortedMinutes - minutos dos slots, ordenados ascendente
+ * @param {boolean} isDaily
+ * @returns {number[]} tolerância por slot (mesma ordem de sortedMinutes)
+ */
+function computeTolerances(sortedMinutes, isDaily) {
+  if (!isDaily || sortedMinutes.length < 2) {
+    return sortedMinutes.map(() => MAX_TOLERANCE_MINUTES)
+  }
+  return sortedMinutes.map((minute, i) => {
+    const prevGap = i > 0 ? minute - sortedMinutes[i - 1] : Infinity
+    const nextGap = i < sortedMinutes.length - 1 ? sortedMinutes[i + 1] - minute : Infinity
+    const smallestAdjacent = Math.min(prevGap, nextGap)
+    // metade do menor intervalo adjacente (arredonda p/ baixo), teto 120
+    return Math.min(Math.floor(smallestAdjacent / 2), MAX_TOLERANCE_MINUTES)
+  })
+}
+
+/**
+ * Constrói o instante absoluto (ISO UTC) para uma data local + minutos do dia, no fuso.
+ * Reusa getStartOfDayISO (offset do fuso descoberto via Intl, Hermes-safe) e soma os
+ * minutos do wall-clock. Brasil sem DST → soma linear é exata.
+ * @param {string} dateStr - YYYY-MM-DD (data local no fuso)
+ * @param {number} minutesOfDay
+ * @param {string} tz
+ * @returns {string} ISO 8601 UTC
+ */
+function buildScheduledFor(dateStr, minutesOfDay, tz) {
+  const startOfDayMs = parseISO(getStartOfDayISO(dateStr, tz)).getTime()
+  return parseTimestamp(startOfDayMs + minutesOfDay * 60 * 1000).toISOString()
+}
+
+/**
+ * Itera as datas locais (YYYY-MM-DD, no fuso) entre dois instantes, inclusive.
+ * @param {Date} fromDate
+ * @param {Date} toDate
+ * @param {string} tz
+ * @returns {string[]}
+ */
+function localDateRange(fromDate, toDate, tz) {
+  const dates = []
+  // Cursor caminha por dia local; parseLocalDate dá aritmética estável de datas.
+  const cursor = parseLocalDate(formatLocalDate(getUserTime(fromDate, tz)))
+  const last = parseLocalDate(formatLocalDate(getUserTime(toDate, tz)))
+  while (cursor <= last) {
+    dates.push(formatLocalDate(cursor))
+    cursor.setDate(cursor.getDate() + 1)
+  }
+  return dates
+}
+
+/**
+ * Gera as ocorrências de dose de um protocolo na janela [fromTs, toTs].
+ *
+ * @param {Object} protocol - linha de `protocols` (id, user_id, frequency, time_schedule,
+ *                            dosage_per_intake, start_date, end_date, weekdays, active)
+ * @param {Date|string|number} fromTs - início da janela (instante absoluto)
+ * @param {Date|string|number} toTs - fim da janela (instante absoluto, inclusive)
+ * @param {string} [tz='America/Sao_Paulo'] - fuso do usuário (user_settings.timezone)
+ * @returns {Array<{user_id: string, protocol_id: string, scheduled_for: string,
+ *                  expected_dose: number, tolerance_minutes: number}>}
+ *          Ordenadas por scheduled_for; só dentro de [fromTs, toTs].
+ */
+export function generateInstances(protocol, fromTs, toTs, tz = 'America/Sao_Paulo') {
+  if (!protocol || !protocol.id) return []
+
+  const frequency = (protocol.frequency || 'diário').toLowerCase()
+  if (PRN_FREQUENCIES.has(frequency)) return []
+
+  const schedule = Array.isArray(protocol.time_schedule) ? protocol.time_schedule : []
+  if (schedule.length === 0) return []
+
+  const fromDate = toInstant(fromTs)
+  const toDate = toInstant(toTs)
+  if (Number.isNaN(fromDate.getTime()) || Number.isNaN(toDate.getTime())) return []
+  if (toDate < fromDate) return []
+
+  const fromMs = fromDate.getTime()
+  const toMs = toDate.getTime()
+  const isDaily = DAILY_FREQUENCIES.has(frequency)
+  const expectedDose = protocol.dosage_per_intake ?? 1
+
+  // Slots do dia, ordenados, com tolerância pré-computada (estável dia a dia).
+  const slots = schedule
+    .map((t) => ({ time: t, minutes: timeToMinutes(t) }))
+    .filter((s) => s.minutes !== null)
+    .sort((a, b) => a.minutes - b.minutes)
+  if (slots.length === 0) return []
+
+  const tolerances = computeTolerances(slots.map((s) => s.minutes), isDaily)
+
+  const instances = []
+  for (const dateStr of localDateRange(fromDate, toDate, tz)) {
+    if (!isProtocolActiveOnDate(protocol, dateStr)) continue
+    slots.forEach((slot, i) => {
+      const scheduledForIso = buildScheduledFor(dateStr, slot.minutes, tz)
+      const scheduledMs = parseISO(scheduledForIso).getTime()
+      if (scheduledMs < fromMs || scheduledMs > toMs) return
+      instances.push({
+        user_id: protocol.user_id,
+        protocol_id: protocol.id,
+        scheduled_for: scheduledForIso,
+        expected_dose: expectedDose,
+        tolerance_minutes: tolerances[i],
+      })
+    })
+  }
+
+  instances.sort((a, b) => a.scheduled_for.localeCompare(b.scheduled_for))
+  return instances
+}

--- a/packages/core/src/utils/doseInstanceGenerator.js
+++ b/packages/core/src/utils/doseInstanceGenerator.js
@@ -22,7 +22,6 @@ import {
   getStartOfDayISO,
   getUserTime,
   formatLocalDate,
-  parseLocalDate,
   parseISO,
   parseTimestamp,
 } from './dateUtils.js'
@@ -65,6 +64,9 @@ function timeToMinutes(time) {
  *
  * - Diário multi-dose: por slot, metade do menor intervalo adjacente (anterior/próximo),
  *   com teto de 120 — garante que janelas de slots vizinhos não se sobreponham.
+ *   ⚠️ Considera o wrap-around da meia-noite: como o protocolo diário repete os mesmos
+ *   slots todo dia, a última dose do dia N e a primeira do dia N+1 são adjacentes no
+ *   tempo real. Sem isso, doses tipo 23:30/00:30 teriam janelas de 120min sobrepostas.
  * - Não-diário ou dose única: 120 fixo (§6 MASTER_PLAN).
  *
  * @param {number[]} sortedMinutes - minutos dos slots, ordenados ascendente
@@ -75,9 +77,16 @@ function computeTolerances(sortedMinutes, isDaily) {
   if (!isDaily || sortedMinutes.length < 2) {
     return sortedMinutes.map(() => MAX_TOLERANCE_MINUTES)
   }
+  const len = sortedMinutes.length
+  const MINUTES_PER_DAY = 1440
   return sortedMinutes.map((minute, i) => {
-    const prevGap = i > 0 ? minute - sortedMinutes[i - 1] : Infinity
-    const nextGap = i < sortedMinutes.length - 1 ? sortedMinutes[i + 1] - minute : Infinity
+    // Para o 1º/último slot, o intervalo adjacente cruza a meia-noite (wrap-around).
+    const prevGap = i > 0
+      ? minute - sortedMinutes[i - 1]
+      : (MINUTES_PER_DAY - sortedMinutes[len - 1]) + minute
+    const nextGap = i < len - 1
+      ? sortedMinutes[i + 1] - minute
+      : (MINUTES_PER_DAY - minute) + sortedMinutes[0]
     const smallestAdjacent = Math.min(prevGap, nextGap)
     // metade do menor intervalo adjacente (arredonda p/ baixo), teto 120
     return Math.min(Math.floor(smallestAdjacent / 2), MAX_TOLERANCE_MINUTES)
@@ -107,12 +116,17 @@ function buildScheduledFor(dateStr, minutesOfDay, tz) {
  */
 function localDateRange(fromDate, toDate, tz) {
   const dates = []
-  // Cursor caminha por dia local; parseLocalDate dá aritmética estável de datas.
-  const cursor = parseLocalDate(formatLocalDate(getUserTime(fromDate, tz)))
-  const last = parseLocalDate(formatLocalDate(getUserTime(toDate, tz)))
+  // Itera em UTC (T00:00:00Z + setUTCDate): imune a DST e ao fuso do ambiente de
+  // execução (servidor Vercel ou device móvel em fuso arbitrário). UTC não tem
+  // transições, então cada incremento é exatamente 24h. parseISO mantém R-020.
+  const cursor = parseISO(formatLocalDate(getUserTime(fromDate, tz)) + 'T00:00:00Z')
+  const last = parseISO(formatLocalDate(getUserTime(toDate, tz)) + 'T00:00:00Z')
   while (cursor <= last) {
-    dates.push(formatLocalDate(cursor))
-    cursor.setDate(cursor.getDate() + 1)
+    const y = cursor.getUTCFullYear()
+    const m = String(cursor.getUTCMonth() + 1).padStart(2, '0')
+    const d = String(cursor.getUTCDate()).padStart(2, '0')
+    dates.push(`${y}-${m}-${d}`)
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
   }
   return dates
 }

--- a/packages/core/src/utils/index.js
+++ b/packages/core/src/utils/index.js
@@ -53,6 +53,11 @@ export {
   getDailyDoseRate,
 } from './adherenceLogic.js'
 
+// Dose instance generation engine (ADR-048, Fase 2)
+export {
+  generateInstances,
+} from './doseInstanceGenerator.js'
+
 // Form utilities
 export {
   getFieldDescribedBy,

--- a/plans/dose_instances_refactor/EXEC_SPECS_PHASE_1_2.md
+++ b/plans/dose_instances_refactor/EXEC_SPECS_PHASE_1_2.md
@@ -11,7 +11,7 @@
 |----|---------|--------|-----|
 | **PR-F1.1** tz core | S1.0, S1.1, S1.2, S1.3, S1.6 | ✅ **MERGED** | PR #597 (squash `6816ee99`) · migration aplicada em prod · ADR-049 accepted · CON-022 |
 | **PR-F1.2** tz UI | S1.4, S1.5 | 🔄 **em smoke PO** (código verde, pré-commit) | branch `feature/dose-instances-f1-tz-ui` |
-| PR-F2.1 schema+lógica | S2.0–S2.3 | ⬜ pendente (Fase 2) | bloqueado: promover ADR-048 → accepted |
+| **PR-F2.1** schema+lógica | S2.0–S2.3 | 🔄 **código verde** (G1+G2 ok; 24 testes novos; validate:agent 895/895) | branch `feature/dose-instances-f2-schema-engine`; aguarda migration preview→prod (humano) + Gemini + merge |
 | PR-F2.2 motor+lifecycle | S2.4, S2.5 | ⬜ pendente | |
 | PR-F2.3 âncora log | S2.6 | ⬜ pendente | |
 | PR-F2.4 backfill | S2.7 | ⬜ pendente | |
@@ -228,7 +228,8 @@ Testes (S1.6/S2.8) **viajam dentro do PR do código que cobrem** — não viram 
 
 ### S2.5 — Lifecycle hooks de protocolo
 - **Agent:** `claude` · **Model:** sonnet
-- **Files:** `apps/web/.../protocolService.js` + `apps/mobile/.../protocolService.js` (espelhados)
+- ⚠️ **P1 finding (verificar antes):** o write-path de protocolo pode estar no **factory `createProtocolRepository` (`@dosiq/core/repositories/`)** (ADR-045/R-231), não em `protocolService.js` de feature. C1 da S2.5 DEVE localizar o caminho canônico de create/update/delete/pause (grep `from('protocols')` + `createProtocolRepository`) antes de editar — pode ser 1 ponto no core (compartilhado web+mobile) em vez de 2 espelhados.
+- **Files:** ponto(s) de escrita de protocolo (a confirmar: core repository factory OU `protocolService` web+mobile)
 - **Spec:**
   - create c/ `end_date` → gera tudo até fim; contínuo → até `now+30d` + set `generated_through`.
   - update (time_schedule/dosage/frequency) → `wipeFuturePending` + regenera.


### PR DESCRIPTION
## Objetivo
Primeira PR da **Fase 2** (ADR-048): materializa ocorrências de dose ancoradas ao schedule (`dose_instances`), resolvendo a raiz do bug da dose 22:30 que deixa de ser registrável após meia-noite. **Zero mudança de comportamento** — schema + gerador + repository entregues sem wiring; nada consome ainda. Merge seguro.

## Escopo (S2.0–S2.3)
- **S2.1 Migration** `20260528_create_dose_instances.sql`
  - `dose_instances` (status `pending|taken|missed|skipped_paused|skipped_user`, `tolerance_minutes`, `UNIQUE(protocol_id, scheduled_for)`)
  - `dose_adherence_monthly` (rollup mensal — retenção)
  - `ALTER medicine_logs ADD dose_instance_id`; `ALTER protocols ADD generated_through, paused_at`
  - Índices `(user_id, scheduled_for)` e `(protocol_id, status)`; grants + RLS (`user_id = auth.uid()`) + `REVOKE anon`
- **S2.2 Motor** `packages/core/src/utils/doseInstanceGenerator.js` (puro)
  - Reusa `isProtocolActiveOnDate` (fonte única de recorrência)
  - `scheduled_for` = instante absoluto (timestamptz) computado no tz do usuário via `getStartOfDayISO` + offset de minutos (Brasil sem DST → soma linear exata)
  - Tolerância dinâmica §6: `min(½ menor intervalo adjacente, 120)` só p/ diário multi-dose; 120 fixo p/ não-diário/dose-única
  - PRN (`quando_necessário`) não gera
- **S2.3 Repository** `packages/core/src/repositories/createDoseInstanceRepository.js`
  - `upsertMany` (ON CONFLICT DO NOTHING — idempotente), `wipeFuturePending` (só `pending` + futuro), `getWindow`, `get/setGeneratedThrough`, `markSkippedPaused`

## Testes
- 24 novos (15 gerador + 9 repository) — multi-fuso, cruzamento meia-noite, tolerância, PRN, end_date, idempotência, wipe cirúrgico
- `validate:agent`: **895/895** ✅ · lint: arquivos novos limpos

## ⚠️ Ordem de merge (migration primeiro)
1. Revisar/aprovar PR
2. **Humano** aplica migration em preview Supabase → valida → prod
3. **Só então** merge (defaults preservam comportamento → migration pode preceder o código)

## Notas
- **AP-181**: `FREQUENCY_MATCHERS` desatualizado vs DB (`dias_alternados`/`personalizado`) — latente (0 protocolos afetados em prod), fix na Fase 3. Gerador herda comportamento atual → consistente com adesão.
- Decisão S2.3: repository vai pro `@dosiq/core/repositories` (factory ADR-045/R-231), não `apps/web` — confirmado via preflight (write-path canônico de protocolo é factory no core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AI Review Response

| Sugestão | Prio | Decisão | Commit |
|---|---|---|---|
| Wrap-around tolerância meia-noite | High | Aplicada | ae5cbfb6 |
| localDateRange iteração UTC (DST-safe) | Medium | Aplicada | ae5cbfb6 |
| CHECK month dia=1 | Medium | Aplicada | ae5cbfb6 |
