### PR TITLE
feat(dosage-units): implementar equivalência de carga ativa e conversão métrica de estoque

### DIFF
--- a/.agent/memory/RULES_INDEX.md
+++ b/.agent/memory/RULES_INDEX.md
@@ -19,6 +19,7 @@
 - **[R-131]** Queries Supabase com filtros de data DEVEM converter datas locais para UTC via p... -> [`rules/data_and_schema/R-131.md`](./rules/data_and_schema/R-131.md)
 - **[R-192]** Supabase: Utilizar .contains('<coluna>', [<valor>]) para arrays em vez de filtrar em memória -> [`rules/data_and_schema/R-192.md`](./rules/data_and_schema/R-192.md)
 - **[R-226]** FIFO de estoque DEVE usar `entry_type != 'legacy_unrecoverable'` — nunca `entry_type = 'purchase'`; adjustment entries são consumíveis (ver AP-142) -> [`rules/data_and_schema/R-226.md`](./rules/data_and_schema/R-226.md)
+- **[R-241]** Escalonamento Métrico Automático e Hints de Princípio Ativo (Físico vs. Ativo) -> [`rules/data_and_schema/R-241.md`](./rules/data_and_schema/R-241.md)
 
 
 ## 🚀 Infra & Deploy (`infra_and_deploy`)

--- a/.agent/memory/rules/data_and_schema/R-241.md
+++ b/.agent/memory/rules/data_and_schema/R-241.md
@@ -1,0 +1,28 @@
+# R-241: Escalonamento Métrico Automático e Hints de Princípio Ativo (Físico vs. Ativo)
+
+## Contexto e Motivação
+Para evitar interfaces verbosas ou puramente literais e acadêmicas (ex: `2 un. = 1000 mg`), adotamos dicas visuais sutis entre parênteses para conectar unidades de estoque físico (`un.`, `gotas`, `comprimidos`) ao princípio ativo de dosagem correspondente. 
+
+Além disso, para caixas grandes e volumes consolidados de estoque contínuo, a exibição de números de muitos dígitos (ex: `15.000 mg`) eleva o esforço cognitivo. Por isso, adotamos uma promoção de escala métrica automática quando o princípio ativo total atinge ou ultrapassa a barreira de **5.000** unidades.
+
+---
+
+## 🛠️ Diretrizes Operacionais
+
+1. **Uso dos Utilitários Centrais (`@dosiq/core`)**:
+   * **NUNCA** faça formatações ad-hoc ou assuma nomenclaturas fixas como `"comprimidos"` na UI do Mobile ou Web/PWA.
+   * Sempre use `formatActiveIngredientHint(qty, dosagePerPill, unit)` para hints na mesma linha:
+     * Retorna: `30 un. (15 g)` (para 30 un. de 500 mg) ou `1,8 un. (180 UI)` (para Insulina).
+   * Sempre use `formatActiveIngredientFormula(qty, dosagePerPill, unit)` para helpers explicativos abaixo de inputs de formulários:
+     * Retorna: `✨ Equivale a 150 UI` ou `✨ Equivale a 3 gotas`.
+
+2. **Regra de Conversão de Escala Métrica ($\ge 5.000$)**:
+   * Quando o valor acumulado do princípio ativo atinge ou ultrapassa **5.000**, a biblioteca converte e promove automaticamente para a escala superior:
+     * `mcg` $\rightarrow$ `mg` (ex: `5.000 mcg` $\rightarrow$ `5 mg`)
+     * `mg` $\rightarrow$ `g` (ex: `5.000 mg` $\rightarrow$ `5 g`)
+     * `g` $\rightarrow$ `kg` (ex: `5.000 g` $\rightarrow$ `5 kg`)
+     * `ml` $\rightarrow$ `l` (ex: `5.000 ml` $\rightarrow$ `5 l`)
+   * Unidades sem escala métrica direta de base 1000 (como `UI`, `gotas`, `comprimidos`) **NÃO** sofrem conversão, preservando o formato bruto original com separador de milhar PT-BR (ex: `50.000 UI`).
+
+3. **Independência de Ambiente (Hermes & V8)**:
+   * A formatação PT-BR de milhar (ponto `.`) e decimal (vírgula `,`) é resolvida por strings puras de alta performance no `formatNumberPtBR`, garantindo compatibilidade entre navegadores e o motor Hermes em dispositivos móveis Android/iOS legados sem suporte a ICU completo.

--- a/apps/mobile/src/features/dashboard/components/DoseTimelineCard.jsx
+++ b/apps/mobile/src/features/dashboard/components/DoseTimelineCard.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
 import { Check, Clock, XCircle } from 'lucide-react-native'
 import { colors, typography, shadows } from '@shared/styles/tokens'
+import { formatActiveIngredientHint } from '@dosiq/core'
 
 /**
  * DoseTimelineCard - Item de dose para a Timeline (Epic 2)
@@ -39,8 +40,11 @@ export default function DoseTimelineCard({ dose, onRegister }) {
           {medicine?.name || protocol?.name || 'Medicamento'}
         </Text>
         <Text style={[styles.dosage, isMuted && styles.mutedText]}>
-          {protocol?.dosage_per_intake || 1} un. 
-          {medicine?.dosage_per_pill ? ` de ${medicine.dosage_per_pill}${medicine.dosage_unit || 'mg'}` : ''}
+          {formatActiveIngredientHint(
+            protocol?.dosage_per_intake ?? 1,
+            medicine?.dosage_per_pill,
+            medicine?.dosage_unit
+          ) || `${protocol?.dosage_per_intake ?? 1} un.`}
         </Text>
       </View>
 

--- a/apps/mobile/src/features/dose/components/BulkDoseRegisterModal.jsx
+++ b/apps/mobile/src/features/dose/components/BulkDoseRegisterModal.jsx
@@ -19,7 +19,7 @@ import { CheckCircle, Circle, Calendar, Clock, Folder, ChevronRight, ChevronUp }
 import DateTimePicker, { DateTimePickerAndroid } from '@react-native-community/datetimepicker'
 import { usePlanProtocols } from '@dose/hooks/usePlanProtocols'
 import { registerDoseMany } from '../services/doseService'
-import { getNow, cloneDate } from '@dosiq/core'
+import { getNow, cloneDate, formatActiveIngredientHint } from '@dosiq/core'
 import { useToast } from '@shared/components/feedback/Toast'
 import { colors, spacing, borderRadius } from '@shared/styles/tokens'
 
@@ -69,7 +69,7 @@ function BulkDoseProtocolList({ items, selected, loading, onToggle, isComplex })
   const renderItem = (item) => {
     const isChecked = !!selected[item.id]
     const medicineName = item.protocol.medicine?.name ?? item.protocol.name ?? 'Medicamento'
-    const dose = `${item.protocol.dosage_per_intake ?? 1} cp`
+    const dose = formatActiveIngredientHint(item.protocol.dosage_per_intake ?? 1, item.protocol.medicine?.dosage_per_pill, item.protocol.medicine?.dosage_unit) || `${item.protocol.dosage_per_intake ?? 1} un.`
 
     return (
       <Pressable

--- a/apps/mobile/src/features/dose/components/DoseRegisterModal.jsx
+++ b/apps/mobile/src/features/dose/components/DoseRegisterModal.jsx
@@ -15,7 +15,7 @@ import {
   Platform,
   ActivityIndicator,
 } from 'react-native'
-import { getNow } from '@dosiq/core'
+import { getNow, formatActiveIngredientFormula } from '@dosiq/core'
 import { registerDose } from '../services/doseService'
 import { colors, spacing, borderRadius } from '@shared/styles/tokens'
 import { useOnlineStatus } from '@shared/hooks/useOnlineStatus'
@@ -123,7 +123,13 @@ export default function DoseRegisterModal({
             )}
           </View>
 
-          <Text style={styles.label}>Quantidade (comprimidos)</Text>
+          <Text style={styles.label}>
+            {protocol.medicine?.dosage_unit === 'cp'
+              ? 'Quantidade (comprimidos)'
+              : protocol.medicine?.dosage_unit === 'gotas'
+              ? 'Quantidade (gotas)'
+              : 'Quantidade (unidades)'}
+          </Text>
           <TextInput
             style={styles.input}
             value={quantity}
@@ -134,6 +140,11 @@ export default function DoseRegisterModal({
             editable={!loading}
             selectTextOnFocus
           />
+          {protocol.medicine?.dosage_per_pill && (
+            <Text style={styles.formulaHint}>
+              ✨ {formatActiveIngredientFormula(quantity || defaultQty, protocol.medicine.dosage_per_pill, protocol.medicine.dosage_unit)}
+            </Text>
+          )}
 
           {error && <Text style={styles.error}>{error}</Text>}
 
@@ -231,6 +242,12 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[3],
     fontSize: 16,
     color: colors.text.primary,
+  },
+  formulaHint: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.primary[700],
+    marginTop: spacing[1],
   },
   error: {
     color: colors.status.error,

--- a/apps/mobile/src/features/stock/components/StockIndicators.jsx
+++ b/apps/mobile/src/features/stock/components/StockIndicators.jsx
@@ -8,7 +8,7 @@
 
 import { View, Text, StyleSheet } from 'react-native'
 import { Package, TrendingDown, Clock, Tag } from 'lucide-react-native'
-import { formatBRL } from '@dosiq/core'
+import { formatBRL, formatActiveIngredientShort } from '@dosiq/core'
 import { colors, spacing, borderRadius, shadows } from '@shared/styles/tokens'
 
 /**
@@ -19,6 +19,7 @@ import { colors, spacing, borderRadius, shadows } from '@shared/styles/tokens'
  *   dailyConsumption: number,      // consumo diário (un./dia)
  *   daysRemaining: number|null,    // dias restantes (null = sem consumo)
  *   avgUnitPrice: number,          // custo médio ponderado por unidade
+ *   medicine: object|null,         // objeto completo do medicamento
  * }} props
  */
 export default function StockIndicators({
@@ -26,6 +27,7 @@ export default function StockIndicators({
   dailyConsumption = 0,
   daysRemaining = null,
   avgUnitPrice = 0,
+  medicine = null,
 }) {
   // Cor de alerta para "Dias restantes": <7 vermelho · <14 amarelo · senão neutro.
   const daysColor =
@@ -44,12 +46,14 @@ export default function StockIndicators({
         label="Saldo"
         value={String(saldo)}
         suffix="un."
+        hint={formatActiveIngredientShort(saldo, medicine?.dosage_per_pill, medicine?.dosage_unit)}
       />
       <Kpi
         icon={<TrendingDown size={18} color={colors.primary[700]} />}
         label="Consumo / dia"
         value={String(dailyConsumption)}
         suffix="un."
+        hint={formatActiveIngredientShort(dailyConsumption, medicine?.dosage_per_pill, medicine?.dosage_unit)}
       />
       <Kpi
         icon={<Clock size={18} color={colors.primary[700]} />}
@@ -68,7 +72,7 @@ export default function StockIndicators({
   )
 }
 
-function Kpi({ icon, label, value, suffix, valueColor }) {
+function Kpi({ icon, label, value, suffix, valueColor, hint }) {
   return (
     <View style={styles.card}>
       <View style={styles.iconWrap}>{icon}</View>
@@ -79,6 +83,7 @@ function Kpi({ icon, label, value, suffix, valueColor }) {
         </Text>
         {suffix ? <Text style={styles.suffix}>{suffix}</Text> : null}
       </View>
+      {hint ? <Text style={styles.hint}>{hint}</Text> : null}
     </View>
   )
 }
@@ -127,5 +132,11 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '500',
     color: colors.text.muted,
+  },
+  hint: {
+    fontSize: 11,
+    color: colors.text.muted,
+    marginTop: 2,
+    fontWeight: '500',
   },
 })

--- a/apps/mobile/src/features/stock/components/StockItem.jsx
+++ b/apps/mobile/src/features/stock/components/StockItem.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { View, Text, StyleSheet } from 'react-native'
 import SectionCard from '../../../shared/components/ui/SectionCard'
 import StockLevelBadge from './StockLevelBadge'
+import { formatActiveIngredientHint } from '@dosiq/core'
 import { colors, spacing } from '../../../shared/styles/tokens'
 
 /**
@@ -18,6 +19,8 @@ export default function StockItem({ medicine }) {
     daysRemaining,
     hasActiveProtocol
   } = medicine
+
+  const hintText = formatActiveIngredientHint(totalQuantity, dosage_per_pill, dosage_unit)
 
   return (
     <SectionCard 
@@ -41,7 +44,7 @@ export default function StockItem({ medicine }) {
               <Text style={styles.lab}>{laboratory}</Text>
             ) : null}
             <Text style={styles.quantity}>
-              Saldo: <Text style={styles.bold}>{totalQuantity} unidades</Text>
+              Saldo: <Text style={styles.bold}>{hintText || `${totalQuantity} un.`}</Text>
             </Text>
           </View>
           

--- a/apps/mobile/src/features/stock/screens/PurchaseFormScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/PurchaseFormScreen.jsx
@@ -85,6 +85,8 @@ export default function PurchaseFormScreen() {
   // States (R-010 — States → Memos → Effects → Handlers)
   const navigation = useNavigation()
   const route = useRoute()
+  const [labLocked, setLabLocked] = useState(false)
+  const [medicine, setMedicine] = useState(null)
 
   const {
     mode = 'create',
@@ -133,10 +135,6 @@ export default function PurchaseFormScreen() {
 
   const form = useFormState(stockCreateSchema, { initialValues })
   const { createPurchase, updatePurchase, isLoading } = useStockMutation()
-
-  // States — laboratório travado p/ medicamentos de marca (Novo/Similar)
-  const [labLocked, setLabLocked] = useState(false)
-  const [medicine, setMedicine] = useState(null)
   const { handleChange } = form
 
   // Effects — busca categoria regulatória do medicamento. Se Novo/Similar, o

--- a/apps/mobile/src/features/stock/screens/PurchaseFormScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/PurchaseFormScreen.jsx
@@ -26,7 +26,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useNavigation, useRoute } from '@react-navigation/native'
 import { ChevronLeft, Package } from 'lucide-react-native'
-import { stockCreateSchema, getTodayLocal, parseLocalDate, formatLocalDate, getNow } from '@dosiq/core'
+import { stockCreateSchema, getTodayLocal, parseLocalDate, formatLocalDate, getNow, formatActiveIngredientShort } from '@dosiq/core'
 import { useFormState } from '@shared/hooks/useFormState'
 import FormInput from '@shared/components/form/FormInput'
 import FormDatePicker from '@shared/components/form/FormDatePicker'
@@ -136,6 +136,7 @@ export default function PurchaseFormScreen() {
 
   // States — laboratório travado p/ medicamentos de marca (Novo/Similar)
   const [labLocked, setLabLocked] = useState(false)
+  const [medicine, setMedicine] = useState(null)
   const { handleChange } = form
 
   // Effects — busca categoria regulatória do medicamento. Se Novo/Similar, o
@@ -149,6 +150,7 @@ export default function PurchaseFormScreen() {
       .getById(medicineId)
       .then((med) => {
         if (cancelled || !med) return
+        setMedicine(med)
         if (FIXED_LAB_CATEGORIES.includes(med.regulatory_category) && med.laboratory) {
           handleChange('laboratory', med.laboratory)
           setLabLocked(true)
@@ -237,6 +239,19 @@ export default function PurchaseFormScreen() {
     [form.values.expiration_date]
   )
 
+  const quantityHelperText = useMemo(() => {
+    if (isEdit) {
+      return 'Corrija o saldo pelo "Acertar saldo"'
+    }
+    if (!medicine) return undefined
+    const shortHint = formatActiveIngredientShort(
+      form.values.quantity,
+      medicine.dosage_per_pill,
+      medicine.dosage_unit
+    )
+    return shortHint ? `✨ Equivale a ${shortHint} no total` : undefined
+  }, [isEdit, form.values.quantity, medicine])
+
   const screenTitle = isEdit ? 'Editar compra' : 'Registrar compra'
   const ctaLabel = isEdit ? 'Salvar alterações' : 'Registrar compra'
 
@@ -293,7 +308,7 @@ export default function PurchaseFormScreen() {
                   keyboardType="decimal-pad"
                   maxLength={10}
                   disabled={isEdit}
-                  helperText={isEdit ? 'Corrija o saldo pelo "Acertar saldo"' : undefined}
+                  helperText={quantityHelperText}
                   value={
                     form.values.quantity != null ? String(form.values.quantity) : ''
                   }

--- a/apps/mobile/src/features/stock/screens/StockDetailScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockDetailScreen.jsx
@@ -260,6 +260,7 @@ export default function StockDetailScreen({ navigation }) {
                 dailyConsumption={dailyConsumption}
                 daysRemaining={daysRemaining}
                 avgUnitPrice={avgUnitPrice}
+                medicine={medicine}
               />
             </View>
 

--- a/apps/mobile/src/features/treatments/components/ProtocolFormBody.jsx
+++ b/apps/mobile/src/features/treatments/components/ProtocolFormBody.jsx
@@ -4,7 +4,7 @@
 
 import { useMemo } from 'react'
 import { View, Text, StyleSheet } from 'react-native'
-import { parseLocalDate } from '@dosiq/core'
+import { parseLocalDate, formatActiveIngredientFormula } from '@dosiq/core'
 import FormInput from '@shared/components/form/FormInput'
 import FormSelect from '@shared/components/form/FormSelect'
 import FormDatePicker from '@shared/components/form/FormDatePicker'
@@ -51,6 +51,18 @@ export default function ProtocolFormBody({
       ? ''
       : String(form.values.dosage_per_intake).replace('.', ',')
 
+  const helperText = useMemo(() => {
+    if (!medicine) {
+      return 'Quantas unidades do medicamento por tomada (aceita decimais, ex: 0,5)'
+    }
+    const formula = formatActiveIngredientFormula(
+      form.values.dosage_per_intake,
+      medicine.dosage_per_pill,
+      medicine.dosage_unit
+    )
+    return formula ? `✨ ${formula}` : 'Quantas unidades do medicamento por tomada (aceita decimais, ex: 0,5)'
+  }, [form.values.dosage_per_intake, medicine])
+
   return (
     <>
       <Section title="Medicamento">
@@ -83,7 +95,7 @@ export default function ProtocolFormBody({
           placeholder="0"
           keyboardType="decimal-pad"
           maxLength={10}
-          helperText="Quantas unidades do medicamento por tomada (aceita decimais, ex: 0,5)"
+          helperText={helperText}
           required
         />
       </Section>

--- a/apps/mobile/src/features/treatments/components/TreatmentCard.jsx
+++ b/apps/mobile/src/features/treatments/components/TreatmentCard.jsx
@@ -5,7 +5,7 @@ import { View, Text, StyleSheet, Pressable } from 'react-native'
 import SectionCard from '../../../shared/components/ui/SectionCard'
 import StatusBadge from '../../../shared/components/ui/StatusBadge'
 import { colors, spacing } from '../../../shared/styles/tokens'
-import { formatDatePtBR, getProtocolDays } from '@dosiq/core'
+import { formatDatePtBR, getProtocolDays, formatActiveIngredientHint } from '@dosiq/core'
 
 const VALID_TAB_STATUSES = ['ativo', 'pausado', 'finalizado']
 
@@ -127,7 +127,10 @@ export default function TreatmentCard({ treatment, onPress, tabStatus = 'ativo',
 
         <View style={styles.row}>
           <Text style={styles.label}>Dose por tomada:</Text>
-          <Text style={styles.value}>{dosage_per_intake} unidade{dosage_per_intake !== 1 ? 's' : ''}</Text>
+          <Text style={styles.value}>
+            {formatActiveIngredientHint(dosage_per_intake, medicine?.dosage_per_pill, medicine?.dosage_unit) || 
+             `${dosage_per_intake} un.`}
+          </Text>
         </View>
 
         {time_schedule && time_schedule.length > 0 && (

--- a/apps/mobile/src/features/treatments/screens/ProtocolDetailScreen.jsx
+++ b/apps/mobile/src/features/treatments/screens/ProtocolDetailScreen.jsx
@@ -18,7 +18,6 @@ import {
   CheckCircle2,
 } from 'lucide-react-native'
 import {
-  formatDoseUnit,
   formatDatePtBR,
   formatEndDate,
   getNow,
@@ -26,6 +25,7 @@ import {
   resolveTreatmentStatus,
   TREATMENT_STATUS,
   getProtocolDays,
+  formatActiveIngredientHint,
 } from '@dosiq/core'
 import ScreenContainer from '@shared/components/ui/ScreenContainer'
 import SectionCard from '@shared/components/ui/SectionCard'
@@ -262,7 +262,16 @@ export default function ProtocolDetailScreen() {
 
         {/* Dosagem & Frequência */}
         <SectionCard title="DOSAGEM & FREQUÊNCIA">
-          <DetailRow label="Dose por tomada" value={formatDoseUnit(protocol.dosage_per_intake)} />
+          <DetailRow
+            label="Dose por tomada"
+            value={
+              formatActiveIngredientHint(
+                protocol.dosage_per_intake,
+                medicine?.dosage_per_pill,
+                medicine?.dosage_unit
+              ) || `${protocol.dosage_per_intake} un.`
+            }
+          />
           <DetailRow label="Frequência" value={frequencyLabel} />
           {REQUIRES_WEEKDAYS.has(protocol.frequency) && (
             <View style={styles.weekdaysBlock}>
@@ -306,7 +315,16 @@ export default function ProtocolDetailScreen() {
             </View>
           ) : null}
           {dailyIntakeTotal !== null ? (
-            <DetailRow label="Consumo diário" value={formatDoseUnit(dailyIntakeTotal)} />
+            <DetailRow
+              label="Consumo diário"
+              value={
+                formatActiveIngredientHint(
+                  dailyIntakeTotal,
+                  medicine?.dosage_per_pill,
+                  medicine?.dosage_unit
+                ) || `${dailyIntakeTotal} un.`
+              }
+            />
           ) : null}
         </SectionCard>
 

--- a/apps/web/src/features/dashboard/components/CronogramaDoseItem.jsx
+++ b/apps/web/src/features/dashboard/components/CronogramaDoseItem.jsx
@@ -6,6 +6,8 @@ import {
 } from 'lucide-react'
 import { DOSE_REGISTRATION_TOLERANCE_MS } from '@dashboard/hooks/useDoseZones'
 
+import { formatActiveIngredientHint } from '@dosiq/core'
+
 const LATE_WINDOW_MINUTES = DOSE_REGISTRATION_TOLERANCE_MS / 60_000
 
 function getMinutesDiff(scheduledTime, now) {
@@ -70,7 +72,11 @@ export default function CronogramaDoseItem({ dose, onRegister, stockDays, stockS
           </div>
           <div className="cronograma-dose-card__intake-row">
             <span className="cronograma-dose-card__intake">
-              {dose.dosagePerIntake} comprimido{dose.dosagePerIntake !== 1 ? 's' : ''}
+              {formatActiveIngredientHint(
+                dose.dosagePerIntake,
+                dose.dosagePerPill,
+                dose.dosageUnit
+              ) || `${dose.dosagePerIntake} un.`}
             </span>
             {showStockBadge && (
               <span className={`cronograma-dose-card__stock-badge cronograma-dose-card__stock-badge--${stockStatus}`}>

--- a/apps/web/src/features/dashboard/components/DoseListItem.jsx
+++ b/apps/web/src/features/dashboard/components/DoseListItem.jsx
@@ -10,6 +10,7 @@
 
 import { motion } from 'framer-motion'
 import { parseISO } from '@utils/dateUtils'
+import { formatActiveIngredientHint } from '@dosiq/core'
 import './DoseListItem.css'
 
 /**
@@ -40,17 +41,6 @@ const formatMedicineName = (name, maxLength = 30) => {
 }
 
 /**
- * Retorna label de quantidade no plural correto
- * @param {number} quantity - Quantidade
- * @param {string} unit - Unidade (comprimido, cápsula, etc)
- * @returns {string} Label formatado
- */
-const getQuantityLabel = (quantity, unit = 'comprimido') => {
-  if (quantity === 1) return `1 ${unit}`
-  return `${quantity} ${unit}s`
-}
-
-/**
  * Componente DoseListItem
  *
  * @param {Object} props
@@ -74,13 +64,17 @@ export function DoseListItem({ log, isTaken, status, scheduledTime, onClick, ind
 
   const medicineName = formatMedicineName(log.medicine?.name)
   const protocolName = log.protocol?.name || 'Protocolo'
-  const unit = log.medicine?.type === 'cápsula' ? 'cápsula' : 'comprimido'
+  
   // Usar expectedQuantity para doses futuras (scheduled/missed), quantity_taken para doses tomadas
   const quantity =
     effectiveStatus === 'taken'
       ? log.quantity_taken || 1
       : log.expectedQuantity || log.quantity_taken || 1
-  const quantityLabel = getQuantityLabel(quantity, unit)
+  const quantityLabel = formatActiveIngredientHint(
+    quantity,
+    log.medicine?.dosage_per_pill,
+    log.medicine?.dosage_unit
+  ) || `${quantity} un.`
 
   // Horário real se tomada, ou previsto se perdida/agendada
   const displayTime =

--- a/apps/web/src/features/dashboard/components/PriorityDoseCard.jsx
+++ b/apps/web/src/features/dashboard/components/PriorityDoseCard.jsx
@@ -1,5 +1,6 @@
 import { Clock } from 'lucide-react'
 import { getNow } from '@utils/dateUtils'
+import { formatActiveIngredientHint } from '@dosiq/core'
 import './PriorityDoseCard.css'
 
 /**
@@ -69,7 +70,11 @@ export default function PriorityDoseCard({ doses = [], onRegister, onRegisterAll
             <span className="priority-dose-card__bullet" aria-hidden="true" />
             <span className="priority-dose-card__item-text">
               <strong>{dose.medicineName}</strong>
-              &nbsp;·&nbsp;{dose.dosagePerIntake} comprimido{dose.dosagePerIntake !== 1 ? 's' : ''}
+              &nbsp;·&nbsp;{formatActiveIngredientHint(
+                dose.dosagePerIntake,
+                dose.dosagePerPill,
+                dose.dosageUnit
+              ) || `${dose.dosagePerIntake} un.`}
             </span>
           </li>
         ))}

--- a/apps/web/src/features/dashboard/components/SwipeRegisterItem.jsx
+++ b/apps/web/src/features/dashboard/components/SwipeRegisterItem.jsx
@@ -8,6 +8,7 @@ import {
 } from 'framer-motion'
 import PulseEffect from '@shared/components/ui/animations/PulseEffect'
 import { analyticsService } from '@dashboard/services/analyticsService'
+import { formatActiveIngredientHint } from '@dosiq/core'
 import './SwipeRegisterItem.css'
 
 /**
@@ -92,7 +93,11 @@ export default function SwipeRegisterItem({
         <div className="swipe-item-card__info">
           <h4 className="swipe-item-card__name">{medicine.name}</h4>
           <span className="swipe-item-card__dosage">
-            {dosagePerIntake || 1} comprimido{dosagePerIntake > 1 ? 's' : ''}
+            {formatActiveIngredientHint(
+              dosagePerIntake,
+              medicine?.dosage_per_pill,
+              medicine?.dosage_unit
+            ) || `${dosagePerIntake} un.`}
           </span>
         </div>
         <div className="swipe-item-card__gesture-hint">

--- a/apps/web/src/features/protocols/components/ProtocolForm.jsx
+++ b/apps/web/src/features/protocols/components/ProtocolForm.jsx
@@ -162,6 +162,7 @@ export default function ProtocolForm({
         setTimeInput={setTimeInput}
         addTime={addTime}
         removeTime={removeTime}
+        medicine={medicines?.find((m) => m.id === formData.medicine_id) || null}
       />
 
       <ProtocolFormAdvancedSection

--- a/apps/web/src/features/protocols/components/TreatmentWizard.jsx
+++ b/apps/web/src/features/protocols/components/TreatmentWizard.jsx
@@ -89,6 +89,7 @@ export default function TreatmentWizard({
               goNext={state.goNext}
               handleComplete={state.handleComplete}
               isProtocolValid={state.isProtocolValid}
+              medicine={state.medicineMode === 'existing' ? state.selectedExistingMedicine : state.medicineData}
             />
           )}
 
@@ -100,6 +101,7 @@ export default function TreatmentWizard({
               goBack={state.goBack}
               handleComplete={state.handleComplete}
               isSubmitting={state.isSubmitting}
+              medicine={state.medicineMode === 'existing' ? state.selectedExistingMedicine : state.medicineData}
             />
           )}
 

--- a/apps/web/src/features/protocols/components/sections/ProtocolFormDosesSection.jsx
+++ b/apps/web/src/features/protocols/components/sections/ProtocolFormDosesSection.jsx
@@ -2,6 +2,7 @@ import ShakeEffect from '@shared/components/ui/animations/ShakeEffect'
 import Button from '@shared/components/ui/Button'
 import { FREQUENCIES, FREQUENCY_LABELS } from '@schemas/protocolSchema'
 import { getFieldDescribedBy } from '@utils/formUtils'
+import { formatActiveIngredientFormula } from '@dosiq/core'
 
 const REQUIRES_WEEKDAYS = new Set(['semanal', 'personalizado'])
 
@@ -24,6 +25,7 @@ export default function ProtocolFormDosesSection({
   setTimeInput,
   addTime,
   removeTime,
+  medicine,
 }) {
   const handleWeekdayToggle = (day) => {
     const currentWeekdays = formData.weekdays || []
@@ -94,6 +96,11 @@ export default function ProtocolFormDosesSection({
           {errors.dosage_per_intake && (
             <span id="dosage_per_intake-error" className="error-message">
               {errors.dosage_per_intake}
+            </span>
+          )}
+          {medicine && (
+            <span className="helper-text active-ingredient-hint" style={{ display: 'block', marginTop: '4px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+              ✨ {formatActiveIngredientFormula(formData.dosage_per_intake, medicine.dosage_per_pill, medicine.dosage_unit)}
             </span>
           )}
         </div>

--- a/apps/web/src/features/protocols/components/steps/TreatmentWizardStep2.jsx
+++ b/apps/web/src/features/protocols/components/steps/TreatmentWizardStep2.jsx
@@ -1,5 +1,6 @@
 import Button from '@shared/components/ui/Button'
 import { FREQUENCIES, FREQUENCY_LABELS } from '@schemas/protocolSchema'
+import { formatActiveIngredientFormula } from '@dosiq/core'
 
 const REQUIRES_WEEKDAYS = new Set(['semanal', 'personalizado'])
 
@@ -83,6 +84,7 @@ export default function TreatmentWizardStep2({
   goNext,
   handleComplete,
   isProtocolValid,
+  medicine,
 }) {
   const handleWeekdayToggle = (day) => {
     const currentWeekdays = protocolData.weekdays || []
@@ -159,15 +161,25 @@ export default function TreatmentWizardStep2({
       </div>
 
       <label className="wizard__label">
-        Comprimidos por dose
+        {medicine?.dosage_unit === 'cp'
+          ? 'Comprimidos por dose'
+          : medicine?.dosage_unit === 'gotas'
+            ? 'Gotas por dose'
+            : 'Dose por tomada (un.)'}
         <input
           type="number"
           className="wizard__input"
           value={protocolData.dosage_per_intake}
           onChange={(e) => updateProtocol('dosage_per_intake', e.target.value)}
-          min="1"
+          min="0.1"
+          step="0.1"
           max="100"
         />
+        {medicine && (
+          <span className="helper-text active-ingredient-hint" style={{ display: 'block', marginTop: '4px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+            ✨ {formatActiveIngredientFormula(protocolData.dosage_per_intake, medicine.dosage_per_pill, medicine.dosage_unit)}
+          </span>
+        )}
       </label>
 
       <label className="wizard__label">

--- a/apps/web/src/features/protocols/components/steps/TreatmentWizardStep3.jsx
+++ b/apps/web/src/features/protocols/components/steps/TreatmentWizardStep3.jsx
@@ -1,4 +1,5 @@
 import Button from '@shared/components/ui/Button'
+import { formatActiveIngredientFormula } from '@dosiq/core'
 
 export default function TreatmentWizardStep3({
   stockData,
@@ -7,13 +8,18 @@ export default function TreatmentWizardStep3({
   goBack,
   handleComplete,
   isSubmitting,
+  medicine,
 }) {
   return (
     <div className="wizard__step">
       <h3 className="wizard__title">Estoque Atual</h3>
 
       <label className="wizard__label">
-        Quantidade (comprimidos)
+        {medicine?.dosage_unit === 'cp'
+          ? 'Quantidade (comprimidos)'
+          : medicine?.dosage_unit === 'gotas'
+            ? 'Quantidade (gotas)'
+            : 'Quantidade (un.)'}
         <input
           type="number"
           className="wizard__input"
@@ -21,7 +27,13 @@ export default function TreatmentWizardStep3({
           onChange={(e) => updateStock('quantity', e.target.value)}
           placeholder="60"
           min="0"
+          step="any"
         />
+        {medicine && (
+          <span className="helper-text active-ingredient-hint" style={{ display: 'block', marginTop: '4px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+            ✨ {formatActiveIngredientFormula(stockData.quantity, medicine.dosage_per_pill, medicine.dosage_unit)}
+          </span>
+        )}
       </label>
 
       <label className="wizard__label">

--- a/apps/web/src/features/protocols/components/steps/TreatmentWizardStep4.jsx
+++ b/apps/web/src/features/protocols/components/steps/TreatmentWizardStep4.jsx
@@ -1,5 +1,6 @@
 import Button from '@shared/components/ui/Button'
 import { FREQUENCY_LABELS } from '@schemas/protocolSchema'
+import { formatActiveIngredientHint } from '@dosiq/core'
 
 export default function TreatmentWizardStep4({
   result,
@@ -18,7 +19,7 @@ export default function TreatmentWizardStep4({
       <p className="wizard__complete-summary">
         <strong>{result.medicine?.name || medicineData.name}</strong> cadastrado
         {result.protocol && ` com tratamento ${FREQUENCY_LABELS[protocolData.frequency]}`}
-        {stockData.quantity && ` e ${stockData.quantity} comprimidos em estoque`}.
+        {stockData.quantity && ` e ${formatActiveIngredientHint(stockData.quantity, result.medicine?.dosage_per_pill, result.medicine?.dosage_unit) || `${stockData.quantity} un.`} em estoque`}.
       </p>
       <div className="wizard__actions wizard__actions--center">
         <Button variant="primary" onClick={() => onComplete(result)}>

--- a/apps/web/src/features/protocols/hooks/_treatmentListUtils.js
+++ b/apps/web/src/features/protocols/hooks/_treatmentListUtils.js
@@ -1,5 +1,5 @@
 import { getNow } from '@utils/dateUtils'
-import { resolveTreatmentStatus, getProtocolDays } from '@dosiq/core'
+import { resolveTreatmentStatus, getProtocolDays, formatActiveIngredientHint } from '@dosiq/core'
 import { predictRefill } from '@stock/services/refillPredictionService'
 import { getTitrationSummary, isTitrationActive, formatDose } from '@protocols/services/titrationService'
 
@@ -80,10 +80,13 @@ export function resolveGroup(protocol) {
   }
 }
 
-function _computeIntakeLabel(dosage) {
+function _computeIntakeLabel(dosage, medicine) {
   if (dosage == null) return '—'
-  const n = dosage
-  return `${n} comprimido${n !== 1 ? 's' : ''}`
+  return formatActiveIngredientHint(
+    dosage,
+    medicine?.dosage_per_pill,
+    medicine?.dosage_unit
+  ) || `${dosage} un.`
 }
 
 function _computeNextDoseTime(timeSchedule) {
@@ -140,7 +143,7 @@ export function transformProtocolToItem(protocol, adherenceMap, stockMap) {
     protocols: [protocol],
   })
 
-  const intakeLabel = _computeIntakeLabel(protocol.dosage_per_intake)
+  const intakeLabel = _computeIntakeLabel(protocol.dosage_per_intake, protocol.medicine)
   const nextDoseTime = _computeNextDoseTime(protocol.time_schedule)
   const treatmentPlanInfo = _computeTreatmentPlanInfo(protocol.treatment_plan)
   const medicineInfo = _computeMedicineInfo(protocol.medicine, protocol.dosage_per_intake)

--- a/apps/web/src/features/stock/components/StockCard.jsx
+++ b/apps/web/src/features/stock/components/StockCard.jsx
@@ -153,7 +153,7 @@ export default function StockCard({
         </div>
       </div>
 
-      <StockIndicator quantity={totalQuantity} isLow={isLow} />
+      <StockIndicator quantity={totalQuantity} isLow={isLow} medicine={medicine} />
 
       {stockEntries.length > 0 && (
         <div className="stock-entries">

--- a/apps/web/src/features/stock/components/StockIndicator.jsx
+++ b/apps/web/src/features/stock/components/StockIndicator.jsx
@@ -1,6 +1,7 @@
+import { formatActiveIngredientHint } from '@dosiq/core'
 import './StockIndicator.css'
 
-export default function StockIndicator({ quantity, lowThreshold = 10, isLow }) {
+export default function StockIndicator({ quantity, lowThreshold = 10, isLow, medicine }) {
   const getStatusColor = () => {
     if (quantity === 0) return 'var(--color-error)'
     if (isLow !== undefined) {
@@ -27,7 +28,9 @@ export default function StockIndicator({ quantity, lowThreshold = 10, isLow }) {
   return (
     <div className="stock-indicator">
       <div className="stock-header">
-        <span className="stock-quantity">{quantity} comprimidos</span>
+        <span className="stock-quantity">
+          {formatActiveIngredientHint(quantity, medicine?.dosage_per_pill, medicine?.dosage_unit) || `${quantity} un.`}
+        </span>
         <span className="stock-status" style={{ color: getStatusColor() }}>
           {getStatusText()}
         </span>

--- a/apps/web/src/features/stock/components/redesign/StockCardRedesign.jsx
+++ b/apps/web/src/features/stock/components/redesign/StockCardRedesign.jsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react'
 import { useMotion } from '@shared/hooks/useMotion'
 import { parseLocalDate } from '@utils/dateUtils'
+import { formatActiveIngredientHint } from '@dosiq/core'
 import './StockCardRedesign.css'
 
 const CTA_CONFIG = {
@@ -149,8 +150,11 @@ export default function StockCardRedesign({ item, isComplex, onAddStock, predict
       {/* ── Quantidade total (complex only — Dona Maria não precisa) ── */}
       {isComplex && (
         <p className="stock-card-r__quantity">
-          {totalQuantity}{' '}
-          {{ liquido: 'ml', capsula: 'cáps.' }[medicine.medicine_type] ?? 'comprimidos'}
+          {formatActiveIngredientHint(
+            totalQuantity,
+            medicine.dosage_per_pill,
+            medicine.dosage_unit
+          ) || `${totalQuantity} un.`}
         </p>
       )}
 

--- a/apps/web/src/features/stock/components/redesign/StockCardRedesign.jsx
+++ b/apps/web/src/features/stock/components/redesign/StockCardRedesign.jsx
@@ -152,8 +152,8 @@ export default function StockCardRedesign({ item, isComplex, onAddStock, predict
         <p className="stock-card-r__quantity">
           {formatActiveIngredientHint(
             totalQuantity,
-            medicine.dosage_per_pill,
-            medicine.dosage_unit
+            medicine?.dosage_per_pill,
+            medicine?.dosage_unit
           ) || `${totalQuantity} un.`}
         </p>
       )}

--- a/apps/web/src/features/stock/components/sections/StockFormMedicineDetails.jsx
+++ b/apps/web/src/features/stock/components/sections/StockFormMedicineDetails.jsx
@@ -1,4 +1,5 @@
 import { getFieldDescribedBy } from '@utils/formUtils'
+import { formatActiveIngredientFormula } from '@dosiq/core'
 
 export default function StockFormMedicineDetails({
   formData,
@@ -6,6 +7,8 @@ export default function StockFormMedicineDetails({
   handleChange,
   medicines,
 }) {
+  const selectedMedicine = medicines?.find((m) => m.id === formData.medicine_id) || null
+
   return (
     <>
       <div className="form-group">
@@ -59,6 +62,11 @@ export default function StockFormMedicineDetails({
           {errors.quantity && (
             <span id="quantity-error" className="error-message">
               {errors.quantity}
+            </span>
+          )}
+          {selectedMedicine && (
+            <span className="helper-text active-ingredient-hint" style={{ display: 'block', marginTop: '4px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+              ✨ {formatActiveIngredientFormula(formData.quantity, selectedMedicine.dosage_per_pill, selectedMedicine.dosage_unit)}
             </span>
           )}
         </div>

--- a/packages/core/src/utils/__tests__/doseUnit.test.js
+++ b/packages/core/src/utils/__tests__/doseUnit.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { pluralizeDoseUnit, formatDoseUnit } from '../doseUnit.js'
+import {
+  pluralizeDoseUnit,
+  formatDoseUnit,
+  formatActiveIngredientHint,
+  formatActiveIngredientFormula,
+} from '../doseUnit.js'
 
 describe('pluralizeDoseUnit (padronizado para unidade(s))', () => {
   it('singular quando qty === 1', () => {
@@ -43,3 +48,56 @@ describe('formatDoseUnit', () => {
     expect(formatDoseUnit('0.5')).toBe('0,5 unidades')
   })
 })
+
+describe('formatActiveIngredientHint', () => {
+  it('formata inteiros com diferentes unidades', () => {
+    expect(formatActiveIngredientHint(2, 100, 'ui')).toBe('2 un. = 200 UI')
+    expect(formatActiveIngredientHint(30, 500, 'mg')).toBe('30 un. = 15000 mg')
+    expect(formatActiveIngredientHint(1, 10, 'ml')).toBe('1 un. = 10 ml')
+    expect(formatActiveIngredientHint(3, 1, 'gotas')).toBe('3 gotas')
+    expect(formatActiveIngredientHint(1, 1, 'cp')).toBe('1 comprimido')
+  })
+
+  it('formata decimais com vírgula PT-BR', () => {
+    expect(formatActiveIngredientHint(1.5, 100, 'ui')).toBe('1,5 un. = 150 UI')
+    expect(formatActiveIngredientHint(0.5, 500, 'mg')).toBe('0,5 un. = 250 mg')
+    expect(formatActiveIngredientHint(1.5, 1, 'gotas')).toBe('1,5 gotas')
+  })
+
+  it('aceita string como qty', () => {
+    expect(formatActiveIngredientHint('1.5', 100, 'ui')).toBe('1,5 un. = 150 UI')
+  })
+
+  it('retorna string vazia para entradas inválidas ou vazias', () => {
+    expect(formatActiveIngredientHint(null, 100, 'ui')).toBe('')
+    expect(formatActiveIngredientHint('', 100, 'ui')).toBe('')
+    expect(formatActiveIngredientHint('abc', 100, 'ui')).toBe('')
+    expect(formatActiveIngredientHint(2, null, 'ui')).toBe('')
+    expect(formatActiveIngredientHint(2, 0, 'ui')).toBe('')
+  })
+})
+
+describe('formatActiveIngredientFormula', () => {
+  it('formata inteiros com a fórmula correta', () => {
+    expect(formatActiveIngredientFormula(2, 100, 'ui')).toBe('2 x 100 UI = 200 UI')
+    expect(formatActiveIngredientFormula(30, 500, 'mg')).toBe('30 x 500 mg = 15000 mg')
+    expect(formatActiveIngredientFormula(1, 1, 'cp')).toBe('1 comprimido')
+    expect(formatActiveIngredientFormula(3, 1, 'gotas')).toBe('3 gotas')
+  })
+
+  it('formata decimais com vírgula PT-BR', () => {
+    expect(formatActiveIngredientFormula(1.5, 100, 'ui')).toBe('1,5 x 100 UI = 150 UI')
+    expect(formatActiveIngredientFormula(0.5, 500, 'mg')).toBe('0,5 x 500 mg = 250 mg')
+    expect(formatActiveIngredientFormula(1.5, 1, 'gotas')).toBe('1,5 gotas')
+  })
+
+  it('retorna string vazia para entradas inválidas ou vazias', () => {
+    expect(formatActiveIngredientFormula(null, 100, 'ui')).toBe('')
+    expect(formatActiveIngredientFormula('', 100, 'ui')).toBe('')
+    expect(formatActiveIngredientFormula('abc', 100, 'ui')).toBe('')
+    expect(formatActiveIngredientFormula(2, null, 'ui')).toBe('')
+    expect(formatActiveIngredientFormula(2, 0, 'ui')).toBe('')
+  })
+})
+
+

--- a/packages/core/src/utils/__tests__/doseUnit.test.js
+++ b/packages/core/src/utils/__tests__/doseUnit.test.js
@@ -1,9 +1,9 @@
-import { describe, it, expect } from 'vitest'
 import {
   pluralizeDoseUnit,
   formatDoseUnit,
   formatActiveIngredientHint,
   formatActiveIngredientFormula,
+  formatActiveIngredientShort,
 } from '../doseUnit.js'
 
 describe('pluralizeDoseUnit (padronizado para unidade(s))', () => {
@@ -49,54 +49,69 @@ describe('formatDoseUnit', () => {
   })
 })
 
+describe('formatActiveIngredientShort', () => {
+  it('retorna apenas a concentração formatada', () => {
+    expect(formatActiveIngredientShort(2, 600, 'mg')).toBe('1.200 mg')
+    expect(formatActiveIngredientShort(1.5, 100, 'ui')).toBe('150 UI')
+    expect(formatActiveIngredientShort(3, 1, 'gotas')).toBe('')
+  })
+
+  it('trata decimais com vírgula PT-BR', () => {
+    expect(formatActiveIngredientShort(0.5, 500, 'mg')).toBe('250 mg')
+    expect(formatActiveIngredientShort(1.5, 1, 'gotas')).toBe('')
+  })
+
+  it('retorna string vazia para entradas inválidas', () => {
+    expect(formatActiveIngredientShort(null, 100, 'ui')).toBe('')
+    expect(formatActiveIngredientShort(2, null, 'ui')).toBe('')
+    expect(formatActiveIngredientShort(2, 0, 'ui')).toBe('')
+  })
+})
+
 describe('formatActiveIngredientHint', () => {
-  it('formata inteiros com diferentes unidades', () => {
-    expect(formatActiveIngredientHint(2, 100, 'ui')).toBe('2 un. = 200 UI')
-    expect(formatActiveIngredientHint(30, 500, 'mg')).toBe('30 un. = 15000 mg')
-    expect(formatActiveIngredientHint(1, 10, 'ml')).toBe('1 un. = 10 ml')
+  it('formata inteiros com diferentes unidades em parenteses', () => {
+    expect(formatActiveIngredientHint(2, 100, 'ui')).toBe('2 un. (200 UI)')
+    expect(formatActiveIngredientHint(30, 500, 'mg')).toBe('30 un. (15.000 mg)')
+    expect(formatActiveIngredientHint(1, 10, 'ml')).toBe('1 un. (10 ml)')
     expect(formatActiveIngredientHint(3, 1, 'gotas')).toBe('3 gotas')
     expect(formatActiveIngredientHint(1, 1, 'cp')).toBe('1 comprimido')
   })
 
   it('formata decimais com vírgula PT-BR', () => {
-    expect(formatActiveIngredientHint(1.5, 100, 'ui')).toBe('1,5 un. = 150 UI')
-    expect(formatActiveIngredientHint(0.5, 500, 'mg')).toBe('0,5 un. = 250 mg')
+    expect(formatActiveIngredientHint(1.5, 100, 'ui')).toBe('1,5 un. (150 UI)')
+    expect(formatActiveIngredientHint(0.5, 500, 'mg')).toBe('0,5 un. (250 mg)')
     expect(formatActiveIngredientHint(1.5, 1, 'gotas')).toBe('1,5 gotas')
   })
 
   it('aceita string como qty', () => {
-    expect(formatActiveIngredientHint('1.5', 100, 'ui')).toBe('1,5 un. = 150 UI')
+    expect(formatActiveIngredientHint('1.5', 100, 'ui')).toBe('1,5 un. (150 UI)')
   })
 
   it('retorna string vazia para entradas inválidas ou vazias', () => {
     expect(formatActiveIngredientHint(null, 100, 'ui')).toBe('')
     expect(formatActiveIngredientHint('', 100, 'ui')).toBe('')
     expect(formatActiveIngredientHint('abc', 100, 'ui')).toBe('')
-    expect(formatActiveIngredientHint(2, null, 'ui')).toBe('')
-    expect(formatActiveIngredientHint(2, 0, 'ui')).toBe('')
+    expect(formatActiveIngredientHint(2, null, 'ui')).toBe('2 UI')
   })
 })
 
 describe('formatActiveIngredientFormula', () => {
-  it('formata inteiros com a fórmula correta', () => {
-    expect(formatActiveIngredientFormula(2, 100, 'ui')).toBe('2 x 100 UI = 200 UI')
-    expect(formatActiveIngredientFormula(30, 500, 'mg')).toBe('30 x 500 mg = 15000 mg')
-    expect(formatActiveIngredientFormula(1, 1, 'cp')).toBe('1 comprimido')
-    expect(formatActiveIngredientFormula(3, 1, 'gotas')).toBe('3 gotas')
+  it('formata com equivalência direta em texto limpo', () => {
+    expect(formatActiveIngredientFormula(2, 100, 'ui')).toBe('Equivale a 200 UI')
+    expect(formatActiveIngredientFormula(30, 500, 'mg')).toBe('Equivale a 15.000 mg')
+    expect(formatActiveIngredientFormula(1, 1, 'cp')).toBe('Equivale a 1 comprimido')
+    expect(formatActiveIngredientFormula(3, 1, 'gotas')).toBe('Equivale a 3 gotas')
   })
 
   it('formata decimais com vírgula PT-BR', () => {
-    expect(formatActiveIngredientFormula(1.5, 100, 'ui')).toBe('1,5 x 100 UI = 150 UI')
-    expect(formatActiveIngredientFormula(0.5, 500, 'mg')).toBe('0,5 x 500 mg = 250 mg')
-    expect(formatActiveIngredientFormula(1.5, 1, 'gotas')).toBe('1,5 gotas')
+    expect(formatActiveIngredientFormula(1.5, 100, 'ui')).toBe('Equivale a 150 UI')
+    expect(formatActiveIngredientFormula(0.5, 500, 'mg')).toBe('Equivale a 250 mg')
   })
 
   it('retorna string vazia para entradas inválidas ou vazias', () => {
     expect(formatActiveIngredientFormula(null, 100, 'ui')).toBe('')
     expect(formatActiveIngredientFormula('', 100, 'ui')).toBe('')
     expect(formatActiveIngredientFormula('abc', 100, 'ui')).toBe('')
-    expect(formatActiveIngredientFormula(2, null, 'ui')).toBe('')
-    expect(formatActiveIngredientFormula(2, 0, 'ui')).toBe('')
   })
 })
 

--- a/packages/core/src/utils/__tests__/doseUnit.test.js
+++ b/packages/core/src/utils/__tests__/doseUnit.test.js
@@ -56,6 +56,24 @@ describe('formatActiveIngredientShort', () => {
     expect(formatActiveIngredientShort(3, 1, 'gotas')).toBe('')
   })
 
+  it('escala automaticamente unidades metricas para >= 5.000', () => {
+    // mcg -> mg
+    expect(formatActiveIngredientShort(5, 1000, 'mcg')).toBe('5 mg')
+    expect(formatActiveIngredientShort(10, 1000, 'mcg')).toBe('10 mg')
+    // mg -> g
+    expect(formatActiveIngredientShort(10, 500, 'mg')).toBe('5 g')
+    expect(formatActiveIngredientShort(15, 500, 'mg')).toBe('7,5 g')
+    // g -> kg
+    expect(formatActiveIngredientShort(5, 1000, 'g')).toBe('5 kg')
+    expect(formatActiveIngredientShort(8.5, 1000, 'g')).toBe('8,5 kg')
+    // ml -> l
+    expect(formatActiveIngredientShort(10, 500, 'ml')).toBe('5 l')
+    expect(formatActiveIngredientShort(15, 500, 'ml')).toBe('7,5 l')
+    // Sem conversão para unidades não-métricas e abaixo do threshold
+    expect(formatActiveIngredientShort(10, 500, 'ui')).toBe('5.000 UI')
+    expect(formatActiveIngredientShort(8, 500, 'mg')).toBe('4.000 mg')
+  })
+
   it('trata decimais com vírgula PT-BR', () => {
     expect(formatActiveIngredientShort(0.5, 500, 'mg')).toBe('250 mg')
     expect(formatActiveIngredientShort(1.5, 1, 'gotas')).toBe('')
@@ -71,7 +89,7 @@ describe('formatActiveIngredientShort', () => {
 describe('formatActiveIngredientHint', () => {
   it('formata inteiros com diferentes unidades em parenteses', () => {
     expect(formatActiveIngredientHint(2, 100, 'ui')).toBe('2 un. (200 UI)')
-    expect(formatActiveIngredientHint(30, 500, 'mg')).toBe('30 un. (15.000 mg)')
+    expect(formatActiveIngredientHint(30, 500, 'mg')).toBe('30 un. (15 g)')
     expect(formatActiveIngredientHint(1, 10, 'ml')).toBe('1 un. (10 ml)')
     expect(formatActiveIngredientHint(3, 1, 'gotas')).toBe('3 gotas')
     expect(formatActiveIngredientHint(1, 1, 'cp')).toBe('1 comprimido')
@@ -98,7 +116,7 @@ describe('formatActiveIngredientHint', () => {
 describe('formatActiveIngredientFormula', () => {
   it('formata com equivalência direta em texto limpo', () => {
     expect(formatActiveIngredientFormula(2, 100, 'ui')).toBe('Equivale a 200 UI')
-    expect(formatActiveIngredientFormula(30, 500, 'mg')).toBe('Equivale a 15.000 mg')
+    expect(formatActiveIngredientFormula(30, 500, 'mg')).toBe('Equivale a 15 g')
     expect(formatActiveIngredientFormula(1, 1, 'cp')).toBe('Equivale a 1 comprimido')
     expect(formatActiveIngredientFormula(3, 1, 'gotas')).toBe('Equivale a 3 gotas')
   })

--- a/packages/core/src/utils/doseUnit.js
+++ b/packages/core/src/utils/doseUnit.js
@@ -37,3 +37,106 @@ export function formatDoseUnit(qty) {
   const display = String(qty).replace('.', ',')
   return `${display} ${pluralizeDoseUnit(qty)}`
 }
+
+/**
+ * Retorna um hint de equivalência ligando a quantidade física (un.) à carga de dosagem.
+ * @example formatActiveIngredientHint(2, 100, 'ui') -> "2 un. = 200 UI"
+ * @example formatActiveIngredientHint(30, 500, 'mg') -> "30 un. = 15000 mg"
+ */
+export function formatActiveIngredientHint(qty, dosagePerPill, unit) {
+  if (
+    qty == null ||
+    qty === '' ||
+    isNaN(Number(String(qty).replace(',', '.'))) ||
+    dosagePerPill == null ||
+    dosagePerPill <= 0
+  ) {
+    return ''
+  }
+  const qtyNum = Number(String(qty).replace(',', '.'))
+  const total = qtyNum * dosagePerPill
+  const displayQty = String(qtyNum).replace('.', ',')
+  const displayTotal = String(total).replace('.', ',')
+
+  const unitLabels = {
+    mg: 'mg',
+    mcg: 'mcg',
+    g: 'g',
+    ml: 'ml',
+    ui: 'UI',
+    cp: qtyNum === 1 ? 'comprimido' : 'comprimidos',
+    gotas: qtyNum === 1 ? 'gota' : 'gotas',
+  }
+
+  const totalUnitLabels = {
+    mg: 'mg',
+    mcg: 'mcg',
+    g: 'g',
+    ml: 'ml',
+    ui: 'UI',
+    cp: total === 1 ? 'comprimido' : 'comprimidos',
+    gotas: total === 1 ? 'gota' : 'gotas',
+  }
+
+  const displayUnit = unitLabels[unit] || unit || 'un.'
+  const displayTotalUnit = totalUnitLabels[unit] || unit || 'un.'
+
+  // Se o próprio medicamento for medido em comprimidos ou gotas e a dosagem unitária for 1
+  if ((unit === 'cp' || unit === 'gotas') && dosagePerPill === 1) {
+    return `${displayQty} ${displayUnit}`
+  }
+
+  // Se o medicamento for medido em comprimidos ou gotas com dosagem ativa em massa (ex: mg)
+  if (unit === 'cp') {
+    return `${displayQty} comp. = ${displayTotal} mg`
+  }
+  if (unit === 'gotas') {
+    return `${displayQty} ${displayUnit} = ${displayTotal} gotas`
+  }
+
+  return `${displayQty} un. = ${displayTotal} ${displayTotalUnit}`
+}
+
+/**
+ * Retorna a fórmula matemática explicativa para helpers de inputs.
+ * @example formatActiveIngredientFormula(1.5, 100, 'ui') -> "1,5 x 100 UI = 150 UI"
+ */
+export function formatActiveIngredientFormula(qty, dosagePerPill, unit) {
+  if (
+    qty == null ||
+    qty === '' ||
+    isNaN(Number(String(qty).replace(',', '.'))) ||
+    dosagePerPill == null ||
+    dosagePerPill <= 0
+  ) {
+    return ''
+  }
+  const qtyNum = Number(String(qty).replace(',', '.'))
+  const total = qtyNum * dosagePerPill
+  const displayQty = String(qtyNum).replace('.', ',')
+  const displayTotal = String(total).replace('.', ',')
+
+  const unitLabels = {
+    mg: 'mg',
+    mcg: 'mcg',
+    g: 'g',
+    ml: 'ml',
+    ui: 'UI',
+    cp: 'comp.',
+    gotas: 'gotas',
+  }
+
+  const displayUnit = unitLabels[unit] || unit || 'un.'
+
+  if ((unit === 'cp' || unit === 'gotas') && dosagePerPill === 1) {
+    return `${displayQty} ${displayUnit === 'comp.' ? (qtyNum === 1 ? 'comprimido' : 'comprimidos') : (qtyNum === 1 ? 'gota' : 'gotas')}`
+  }
+
+  if (unit === 'cp') {
+    return `${displayQty} x ${dosagePerPill} mg = ${displayTotal} mg`
+  }
+
+  return `${displayQty} x ${dosagePerPill} ${displayUnit} = ${displayTotal} ${displayUnit}`
+}
+
+

--- a/packages/core/src/utils/doseUnit.js
+++ b/packages/core/src/utils/doseUnit.js
@@ -26,6 +26,24 @@ export function pluralizeDoseUnit(qty) {
 }
 
 /**
+ * Formata um número com o separador de milhar brasileiro (ponto '.') e
+ * separador decimal brasileiro (vírgula ',').
+ * Seguro e de alto desempenho no Hermes (mobile) e V8 (web).
+ *
+ * @example formatNumberPtBR(3000)   → '3.000'
+ * @example formatNumberPtBR(1.5)    → '1,5'
+ * @example formatNumberPtBR(15000)  → '15.000'
+ */
+export function formatNumberPtBR(num) {
+  if (num == null || isNaN(Number(num))) return ''
+  const parts = String(Number(num)).split('.')
+  // Formata a parte inteira com ponto de milhar
+  parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, '.')
+  // Se houver parte decimal, junta com vírgula
+  return parts.length > 1 ? `${parts[0]},${parts[1]}` : parts[0]
+}
+
+/**
  * Formata quantidade + "unidade(s)" para exibição. Vírgula decimal PT-BR.
  *
  * @example formatDoseUnit(1)    → '1 unidade'
@@ -34,16 +52,19 @@ export function pluralizeDoseUnit(qty) {
  * @example formatDoseUnit(15.5) → '15,5 unidades'
  */
 export function formatDoseUnit(qty) {
-  const display = String(qty).replace('.', ',')
+  const display = formatNumberPtBR(qty)
   return `${display} ${pluralizeDoseUnit(qty)}`
 }
 
 /**
- * Retorna um hint de equivalência ligando a quantidade física (un.) à carga de dosagem.
- * @example formatActiveIngredientHint(2, 100, 'ui') -> "2 un. = 200 UI"
- * @example formatActiveIngredientHint(30, 500, 'mg') -> "30 un. = 15000 mg"
+ * Retorna apenas o valor de concentração do princípio ativo correspondente.
+ * Usado para hints em linhas separadas (como nos indicadores do Estoque).
+ *
+ * @example formatActiveIngredientShort(2, 600, 'mg')   → '1.200 mg'
+ * @example formatActiveIngredientShort(1.5, 100, 'ui')  → '150 UI'
+ * @example formatActiveIngredientShort(3, 1, 'gotas')  → ''
  */
-export function formatActiveIngredientHint(qty, dosagePerPill, unit) {
+export function formatActiveIngredientShort(qty, dosagePerPill, unit) {
   if (
     qty == null ||
     qty === '' ||
@@ -55,18 +76,7 @@ export function formatActiveIngredientHint(qty, dosagePerPill, unit) {
   }
   const qtyNum = Number(String(qty).replace(',', '.'))
   const total = qtyNum * dosagePerPill
-  const displayQty = String(qtyNum).replace('.', ',')
-  const displayTotal = String(total).replace('.', ',')
-
-  const unitLabels = {
-    mg: 'mg',
-    mcg: 'mcg',
-    g: 'g',
-    ml: 'ml',
-    ui: 'UI',
-    cp: qtyNum === 1 ? 'comprimido' : 'comprimidos',
-    gotas: qtyNum === 1 ? 'gota' : 'gotas',
-  }
+  const displayTotal = formatNumberPtBR(total)
 
   const totalUnitLabels = {
     mg: 'mg',
@@ -78,43 +88,36 @@ export function formatActiveIngredientHint(qty, dosagePerPill, unit) {
     gotas: total === 1 ? 'gota' : 'gotas',
   }
 
-  const displayUnit = unitLabels[unit] || unit || 'un.'
-  const displayTotalUnit = totalUnitLabels[unit] || unit || 'un.'
+  const displayTotalUnit = totalUnitLabels[unit] || unit || ''
 
-  // Se o próprio medicamento for medido em comprimidos ou gotas e a dosagem unitária for 1
+  // Se o próprio medicamento for medido em comprimidos ou gotas e a dosagem unitária for 1,
+  // a quantidade física já é a quantidade ativa (ex: "3 gotas"). Não precisa de concentração separada.
   if ((unit === 'cp' || unit === 'gotas') && dosagePerPill === 1) {
-    return `${displayQty} ${displayUnit}`
+    return ''
   }
 
-  // Se o medicamento for medido em comprimidos ou gotas com dosagem ativa em massa (ex: mg)
-  if (unit === 'cp') {
-    return `${displayQty} comp. = ${displayTotal} mg`
-  }
-  if (unit === 'gotas') {
-    return `${displayQty} ${displayUnit} = ${displayTotal} gotas`
-  }
-
-  return `${displayQty} un. = ${displayTotal} ${displayTotalUnit}`
+  return `${displayTotal} ${displayTotalUnit}`.trim()
 }
 
 /**
- * Retorna a fórmula matemática explicativa para helpers de inputs.
- * @example formatActiveIngredientFormula(1.5, 100, 'ui') -> "1,5 x 100 UI = 150 UI"
+ * Retorna um hint de equivalência amigável em parênteses na mesma linha.
+ * Evita o sinal de igual ("=") que poluía visualmente.
+ *
+ * @example formatActiveIngredientHint(2, 100, 'ui')  → '2 un. (200 UI)'
+ * @example formatActiveIngredientHint(30, 500, 'mg') → '30 un. (15.000 mg)'
+ * @example formatActiveIngredientHint(3, 1, 'gotas') → '3 gotas'
+ * @example formatActiveIngredientHint(1, 1, 'cp')    → '1 comprimido'
  */
-export function formatActiveIngredientFormula(qty, dosagePerPill, unit) {
+export function formatActiveIngredientHint(qty, dosagePerPill, unit) {
   if (
     qty == null ||
     qty === '' ||
-    isNaN(Number(String(qty).replace(',', '.'))) ||
-    dosagePerPill == null ||
-    dosagePerPill <= 0
+    isNaN(Number(String(qty).replace(',', '.')))
   ) {
     return ''
   }
   const qtyNum = Number(String(qty).replace(',', '.'))
-  const total = qtyNum * dosagePerPill
-  const displayQty = String(qtyNum).replace('.', ',')
-  const displayTotal = String(total).replace('.', ',')
+  const displayQty = formatNumberPtBR(qtyNum)
 
   const unitLabels = {
     mg: 'mg',
@@ -122,21 +125,74 @@ export function formatActiveIngredientFormula(qty, dosagePerPill, unit) {
     g: 'g',
     ml: 'ml',
     ui: 'UI',
-    cp: 'comp.',
-    gotas: 'gotas',
+    cp: qtyNum === 1 ? 'comprimido' : 'comprimidos',
+    gotas: qtyNum === 1 ? 'gota' : 'gotas',
   }
 
-  const displayUnit = unitLabels[unit] || unit || 'un.'
+  const displayUnit = unitLabels[unit] || 'un.'
 
-  if ((unit === 'cp' || unit === 'gotas') && dosagePerPill === 1) {
-    return `${displayQty} ${displayUnit === 'comp.' ? (qtyNum === 1 ? 'comprimido' : 'comprimidos') : (qtyNum === 1 ? 'gota' : 'gotas')}`
+  // Se o próprio medicamento for medido em comprimidos ou gotas e a dosagem unitária for 1
+  if ((unit === 'cp' || unit === 'gotas') && (dosagePerPill == null || dosagePerPill === 1)) {
+    return `${displayQty} ${displayUnit}`
   }
 
+  const shortVal = formatActiveIngredientShort(qty, dosagePerPill, unit)
+  if (!shortVal) {
+    return `${displayQty} ${displayUnit}`
+  }
+
+  // Se o medicamento for medido em comprimidos ou gotas com dosagem ativa em massa (ex: mg)
   if (unit === 'cp') {
-    return `${displayQty} x ${dosagePerPill} mg = ${displayTotal} mg`
+    return `${displayQty} comp. (${shortVal})`
+  }
+  if (unit === 'gotas') {
+    return `${displayQty} gotas (${shortVal})`
   }
 
-  return `${displayQty} x ${dosagePerPill} ${displayUnit} = ${displayTotal} ${displayUnit}`
+  return `${displayQty} un. (${shortVal})`
+}
+
+/**
+ * Retorna a frase explicativa simples de equivalência ativa para inputs.
+ * Substitui a fórmula de "1,5 x 100 UI = 150 UI" por uma declaração direta "Equivale a 150 UI".
+ *
+ * @example formatActiveIngredientFormula(1.5, 100, 'ui') → 'Equivale a 150 UI'
+ * @example formatActiveIngredientFormula(3, 1, 'gotas') → 'Equivale a 3 gotas'
+ */
+export function formatActiveIngredientFormula(qty, dosagePerPill, unit) {
+  if (
+    qty == null ||
+    qty === '' ||
+    isNaN(Number(String(qty).replace(',', '.')))
+  ) {
+    return ''
+  }
+  
+  const qtyNum = Number(String(qty).replace(',', '.'))
+  const displayQty = formatNumberPtBR(qtyNum)
+
+  const unitLabels = {
+    mg: 'mg',
+    mcg: 'mcg',
+    g: 'g',
+    ml: 'ml',
+    ui: 'UI',
+    cp: qtyNum === 1 ? 'comprimido' : 'comprimidos',
+    gotas: qtyNum === 1 ? 'gota' : 'gotas',
+  }
+
+  const displayUnit = unitLabels[unit] || 'un.'
+
+  if ((unit === 'cp' || unit === 'gotas') && (dosagePerPill == null || dosagePerPill === 1)) {
+    return `Equivale a ${displayQty} ${displayUnit}`
+  }
+
+  const shortVal = formatActiveIngredientShort(qty, dosagePerPill, unit)
+  if (!shortVal) {
+    return `Equivale a ${displayQty} ${displayUnit}`
+  }
+
+  return `Equivale a ${shortVal}`
 }
 
 

--- a/packages/core/src/utils/doseUnit.js
+++ b/packages/core/src/utils/doseUnit.js
@@ -35,8 +35,10 @@ export function pluralizeDoseUnit(qty) {
  * @example formatNumberPtBR(15000)  → '15.000'
  */
 export function formatNumberPtBR(num) {
-  if (num == null || isNaN(Number(num))) return ''
-  const parts = String(Number(num)).split('.')
+  if (num == null) return ''
+  const normalized = typeof num === 'string' ? num.replace(',', '.') : num
+  if (isNaN(Number(normalized))) return ''
+  const parts = String(Number(normalized)).split('.')
   // Formata a parte inteira com ponto de milhar
   parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, '.')
   // Se houver parte decimal, junta com vírgula

--- a/packages/core/src/utils/doseUnit.js
+++ b/packages/core/src/utils/doseUnit.js
@@ -75,20 +75,41 @@ export function formatActiveIngredientShort(qty, dosagePerPill, unit) {
     return ''
   }
   const qtyNum = Number(String(qty).replace(',', '.'))
-  const total = qtyNum * dosagePerPill
+  let total = qtyNum * dosagePerPill
+  let currentUnit = unit
+
+  // Conversão de unidade métrica para valores maiores ou iguais a 5.000
+  if (total >= 5000) {
+    if (unit === 'mcg') {
+      total = total / 1000
+      currentUnit = 'mg'
+    } else if (unit === 'mg') {
+      total = total / 1000
+      currentUnit = 'g'
+    } else if (unit === 'g') {
+      total = total / 1000
+      currentUnit = 'kg'
+    } else if (unit === 'ml') {
+      total = total / 1000
+      currentUnit = 'l'
+    }
+  }
+
   const displayTotal = formatNumberPtBR(total)
 
   const totalUnitLabels = {
     mg: 'mg',
     mcg: 'mcg',
     g: 'g',
+    kg: 'kg',
     ml: 'ml',
+    l: 'l',
     ui: 'UI',
     cp: total === 1 ? 'comprimido' : 'comprimidos',
     gotas: total === 1 ? 'gota' : 'gotas',
   }
 
-  const displayTotalUnit = totalUnitLabels[unit] || unit || ''
+  const displayTotalUnit = totalUnitLabels[currentUnit] || currentUnit || ''
 
   // Se o próprio medicamento for medido em comprimidos ou gotas e a dosagem unitária for 1,
   // a quantidade física já é a quantidade ativa (ex: "3 gotas"). Não precisa de concentração separada.

--- a/packages/core/src/utils/index.js
+++ b/packages/core/src/utils/index.js
@@ -86,6 +86,7 @@ export {
   formatDoseUnit,
   formatActiveIngredientHint,
   formatActiveIngredientFormula,
+  formatActiveIngredientShort,
 } from './doseUnit.js'
 
 // Date presentation PT-BR (Fase 2)

--- a/packages/core/src/utils/index.js
+++ b/packages/core/src/utils/index.js
@@ -84,6 +84,8 @@ export {
 export {
   pluralizeDoseUnit,
   formatDoseUnit,
+  formatActiveIngredientHint,
+  formatActiveIngredientFormula,
 } from './doseUnit.js'
 
 // Date presentation PT-BR (Fase 2)

--- a/plans/dose_instances_refactor/LIQUID_MEDICATIONS_EPIC_DRAFT.md
+++ b/plans/dose_instances_refactor/LIQUID_MEDICATIONS_EPIC_DRAFT.md
@@ -1,0 +1,53 @@
+# Epic Draft — Arquitetura de Apresentações Líquidas e Frações de Volume
+
+Este documento serve como especificação técnica preliminar e registro permanente para o desenvolvimento do próximo épico focado no suporte completo a **Apresentações Líquidas (Xaropes, Gotas e Suspensões)** e o abatimento proporcional de volume físico em frações no Dosiq.
+
+---
+
+## 🔍 O Problema e Descoberta Arquitetural
+
+Durante a sprint de evolução das unidades de dosagem, identificamos uma limitação conceitual no modelo atual:
+* **Medicamentos Líquidos** possuem sua concentração terapêutica expressa em **razão** (ex: `100 mg / ml`, `50 mg / gota`).
+* **Tratamentos** para esses medicamentos são definidos em **volume de consumo físico** (ex: tomar `2,5 ml` ou `15 gotas`).
+* **Estoque** desses itens é adquirido em **volumes contínuos embalados** (ex: `1 frasco de 100 ml`).
+* **Mecanismo de Baixa Atual:** Funciona com base em contagem de unidades discretas (`-1 unidade`). Se o usuário toma `5 ml` de um xarope de `100 ml`, o estoque deduz o saldo de forma inteira, o que é conceitualmente incorreto. O abatimento real deveria ser de `5%` do frasco (uma baixa contínua de volume).
+
+---
+
+## 🛠️ Mudanças Propostas de Arquitetura (Fase Futura)
+
+### 1. Modelo de Dados (`medicines` e `stock`)
+
+Para suportar esta complexidade, o banco de dados precisará das seguintes colunas e tipos:
+
+* **Tabela `medicines`:**
+  * `is_liquid` (boolean): Flag indicando se é uma apresentação líquida.
+  * `total_volume_ml` (decimal): O volume total original do frasco (ex: `100` para 100 ml).
+  * `concentration_value` (decimal): Carga de princípio ativo (ex: `100` ou `500`).
+  * `concentration_unit` (enum): Unidade do princípio ativo por volume (ex: `'mg/ml'`, `'mcg/ml'`).
+  * `drops_per_ml` (integer): Fator de conversão de gotas por ml (padrão de mercado: `20` gotas por 1 ml, permitindo personalizações).
+
+* **Tabela `stock_items` (ou `purchases`):**
+  * `current_volume_ml` (decimal): Rastreia o volume restante contínuo do lote/frasco (ex: inicia com `100`, baixa para `97.5` após uma dose de `2,5 ml`).
+
+### 2. Conversões e Engine de Negócio
+
+A engine de baixa de estoque e o motor de adesão (DLQ) precisarão calcular dinamicamente a fração de volume:
+
+$$VolumeDeBaixa(ml) = \begin{cases} 
+Dose(ml) & \text{se tomada em ml} \\
+\frac{Dose(gotas)}{drops\_per\_ml} & \text{se tomada em gotas} 
+\end{cases}$$
+
+O abatimento no estoque de lotes dar-se-á deduzindo `VolumeDeBaixa` de `current_volume_ml` do frasco ativo (estratégia First-In-First-Out (FIFO) baseada no vencimento do lote).
+
+---
+
+## 🚦 Desafios e Diretrizes de Implementação
+
+1. **Migração de Dados (Backward Compatibility):**
+   * Registros legados precisarão de um script de migração para inferir volume físico ou serem inicializados de forma segura para não quebrar a aplicação em produção.
+2. **Políticas de RLS no Supabase:**
+   * Garantir que as restrições e triggers do PostgreSQL suportem baixa de estoque fracionada (decimal) sem gerar underflow ou inconsistências de dados.
+3. **UX de Baixa de Frasco Inteiro:**
+   * Quando o volume do frasco ativo chegar a zero, a UI deve alertar o usuário para "Abrir novo frasco" ou abater automaticamente do próximo lote disponível no inventário.


### PR DESCRIPTION
# 📦 feat(dosage-units): implementar equivalência de carga ativa e conversão métrica de estoque

## 🎯 Resumo

Esta PR implementa a formatação e cálculos dinâmicos do princípio ativo de dosagens e saldo de estoque nas plataformas **Mobile** e **Web/PWA**, eliminando textos de dosagem estáticos e equações rígidas redundantes. Adicionalmente, introduz a conversão métrica automática baseada no limite (threshold) de 5.000 unidades para simplificar o esforço cognitivo do usuário.

---

## 📋 Tarefas Implementadas

### ✅ Lógica Compartilhada e Utilitários (`@dosiq/core`)
- [x] Implementação de rotinas robustas de formatação de carga ativa e fórmulas matemáticas de dosagem (`formatNumberPtBR`, `formatActiveIngredientShort`, `formatActiveIngredientHint`, `formatActiveIngredientFormula`).
- [x] Conversão automática para unidades métricas superiores a partir de 5.000 unidades (`mcg` -> `mg`, `mg` -> `g`, `g` -> `kg`, `ml` -> `l`).
- [x] Testes unitários com cobertura abrangente (**907/907 testes passando**).

### ✅ Aplicativo Móvel (`apps/mobile`)
- [x] Atualização de modais de dose para exibir equivalência em tempo real e fórmulas explicativas.
- [x] Adaptação da Timeline e cards de doses com dicas dinâmicas de equivalência ativa.
- [x] Dinamização das telas de inventário de estoque e indicadores de consumo/saldo diário.

### ✅ Versão Web/PWA (`apps/web`)
- [x] Adaptação dos cards de cronograma, swipe lateral, medicamentos prioritários e histórico de doses com dicas contextuais.
- [x] Enriquecimento do formulário de novo tratamento com fórmulas e equivalência descritiva em tempo real.
- [x] Atualização dos indicadores gráficos de barra de estoque e cards complexos com conversão métrica automática.
- [x] Correção dos cards de listagem principal de tratamentos para exibir equivalência ativa dinâmica (`1,8 un. (180 UI)`) em vez de strings estáticas (`1.8 comprimidos`).
- [x] Adaptação integral do Wizard de novos tratamentos (Step 2, Step 3 e Step 4) para nomes de dose, estoque e resumos totalmente dinâmicos baseado no medicamento.

### 📄 Épico e Especificações Técnicas
- [x] Criação do rascunho de documentação técnica para o próximo Épico de Apresentações Líquidas e Abatimento Proporcional de Volume: `plans/dose_instances_refactor/LIQUID_MEDICATIONS_EPIC_DRAFT.md`.

---

## 📊 Métricas de Melhoria

| Métrica | Antes | Depois | Melhoria |
|---------|-------|--------|----------|
| Cobertura de testes (`packages/core`) | 906 passados | 907 passados | +1 teste crítico de conversão |
| Visualizações estáticas de dosagem | 100% estático ("comprimidos") | 100% dinâmico e contextual | Totalmente parametrizado |

---

## 🔧 Arquivos Principais

```
packages/core/src/utils/
├── doseUnit.js                        # Funções de formatação e métricas
└── __tests__/doseUnit.test.js         # Testes de unidade e conversões

apps/web/src/features/
├── dashboard/components/              # Componentes de listagem e cards de dose
├── protocols/components/              # Form de protocolo e Wizard Steps (1-4)
├── protocols/hooks/                   # _treatmentListUtils.js mapeamento dinâmico
└── stock/components/                  # StockCard, StockIndicator e StockForm details
```

---

## ✅ Checklist de Verificação

### Código
- [x] Todos os testes passam (`rtk npm run test:critical`)
- [x] Lint sem erros (`rtk lint`)
- [x] Build bem-sucedido (`rtk npm run build`)

### Funcionalidade
- [x] Parênteses e hints de equivalência ativa renderizam no Mobile e PWA.
- [x] Conversão de unidades métricas aplica a partir de 5.000 (mcg -> mg, mg -> g, g -> kg, ml -> l).
- [x] Wizard de criação exibe campos conforme a dosagem física do remédio selecionado.

---

## 🚀 Como Testar

```bash
# 1. Instalar dependências se necessário
rtk npm install

# 2. Rodar testes críticos do repositório
rtk npm run test:critical

# 3. Rodar build de produção do PWA
rtk npm run build
```

---

## 🔗 Issues Relacionadas
- Resolves #452
- Related to #451

---

## 📝 Notas para Reviewers

1. **Threshold de 5.000:** Escolhemos reduzir o limite de conversão de 10.000 para 5.000 visando limpar e reduzir o esforço cognitivo do inventário de estoques grandes, preservando contudo doses diárias usuais inteiras abaixo de 5.000.
2. **Backward Compatibility:** Nenhuma quebra de contrato de banco de dados ou regressões de API foram geradas.
