### PR TITLE
feat(dose-instances): motor de geração + rede lazy + lifecycle hooks (PR-F2.2)

### DIFF
--- a/.agent/memory/RULES_INDEX.md
+++ b/.agent/memory/RULES_INDEX.md
@@ -1,6 +1,7 @@
 # DEVFLOW Rules Index
 
 ## 📦 Data & Schema (`data_and_schema`)
+- **[R-245]** Geração de `dose_instances` em write-path é best-effort (try/catch); cron diário + `ensureInstancesUpTo` (rede lazy) são a malha de segurança — nunca bloquear CRUD de protocolo por erro de geração -> [`rules/data_and_schema/R-245.md`](./rules/data_and_schema/R-245.md)
 - **[R-236]** Mutation documenta TODOS os caches que invalida (matrix explícita) — evita bug latente quando snapshot adjacente é esquecido -> [`rules/data_and_schema/R-236.md`](./rules/data_and_schema/R-236.md)
 - **[R-020]** ALWAYS use parseLocalDate() or new Date(str + 'T00:00:00'). NEVER use new Date('... [AUTOMATED via ESLint] -> [`rules/data_and_schema/R-020.md`](./rules/data_and_schema/R-020.md)
 - **[R-021]** All Zod schema enum values must be in Portuguese. Always export labels for UI di... -> [`rules/data_and_schema/R-021.md`](./rules/data_and_schema/R-021.md)

--- a/.agent/memory/rules/data_and_schema/R-245.md
+++ b/.agent/memory/rules/data_and_schema/R-245.md
@@ -1,0 +1,58 @@
+---
+id: R-245
+title: Geração de dose_instances em write-path é best-effort; cron + rede lazy são a malha de segurança
+status: warm
+created: 2026-05-28
+created_in: PR-F2.2 (motor de geração dose_instances)
+tags:
+  - dose-instances
+  - generation
+  - resilience
+  - scheduler
+linked_adrs:
+  - ADR-048
+linked_rules:
+  - R-042
+  - R-090
+---
+
+# R-245 — Geração de dose_instances em write-path é best-effort
+
+Os lifecycle hooks que materializam `dose_instances` ao criar/editar/pausar um protocolo
+(`createProtocolRepository.syncInstancesOnWrite`) DEVEM ser **best-effort**: envolvidos em
+`try/catch` que engole o erro. Um erro de geração **nunca** pode bloquear ou reverter o
+CRUD do protocolo em si.
+
+## Por quê
+A correção/consistência das instâncias é garantida por **duas redes independentes**:
+1. **Cron diário** (`server/bot/doseInstanceScheduler.generateDoseInstances`) — renova janelas
+   e processa pendências.
+2. **Rede lazy** (`ensureInstancesUpTo`) — leituras críticas (dashboard/scheduler de notificação)
+   geram o gap on-the-fly.
+
+Como ambas convergem o estado eventualmente (geração é idempotente via
+`UNIQUE(protocol_id, scheduled_for)` + `ON CONFLICT DO NOTHING`), uma falha pontual no
+write-path é auto-corrigida. Bloquear o CRUD por isso seria pior: o usuário não conseguiria
+criar/editar o tratamento por causa de um detalhe de materialização.
+
+## Como aplicar
+- Hooks de geração no write-path: `try { ... } catch { /* best-effort */ }`.
+- O motor real de garantia é o cron + `ensureInstancesUpTo` — manter ambos vivos (a rede
+  lazy é **obrigatória**, não opcional — ADR-048 §10).
+- Geração roda no processo Node persistente (server/bot), nunca em função Vercel (R-090).
+- Motor service_role itera todos os protocolos ativos; cada instância carrega
+  `user_id = protocol.user_id` (R-042 — escopo explícito, sem depender de RLS).
+
+## Anti-exemplo
+```js
+// ❌ erro de geração derruba a criação do protocolo
+const created = await insert(protocol)
+await generateInstances(...)   // se falhar, o protocolo "não foi criado" para o usuário
+return created
+```
+```js
+// ✅ best-effort — protocolo criado independ. da geração
+const created = await insert(protocol)
+await syncInstancesOnWrite({ client, protocol: created, updates: null }) // try/catch interno
+return created
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,11 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 - **Schema** (Minor, PR #601): Substituída a unidade de medida padrão de "cp" para "un" no Zod Schema para dar suporte a inalatórios, adesivos e tópicos.
 - **DoseUnit** (Minor, PR #601): Atualizados os formatadores centrais para tratar a unidade "un" de forma genérica ("unidade/unidades/un.") de acordo com o padrão gramatical brasileiro.
 - **Planning** (Minor, PR #601): Expandido e enriquecido extensivamente o rascunho de especificação técnica para o suporte nativo a medicamentos líquidos e controle de estoque decimal no documento [LIQUID_MEDICATIONS_EPIC_DRAFT.md](file:///Users/coelhotv/git/dosiq/plans/dose_instances_refactor/LIQUID_MEDICATIONS_EPIC_DRAFT.md) com análise de impacto de riscos.
-- **dose_instances — motor de geração** (Minor, PR #602): Adicionado `doseInstancePlanner` (core) que orquestra a geração e persistência idempotente de ocorrências de dose, e os hooks de lifecycle de protocolo (`createProtocolRepository`) que materializam a janela ao criar/editar/pausar/religar tratamentos — best-effort (R-245). Sem impacto visível ao usuário até a Fase 3/4 (nenhuma UI consome ainda). ADR-048.
+- **dose_instances — motor de geração** (Minor, PR #603): Adicionado `doseInstancePlanner` (core) que orquestra a geração e persistência idempotente de ocorrências de dose, e os hooks de lifecycle de protocolo (`createProtocolRepository`) que materializam a janela ao criar/editar/pausar/religar tratamentos — best-effort (R-245). Sem impacto visível ao usuário até a Fase 3/4 (nenhuma UI consome ainda). ADR-048.
 
 ### Backend/Infra
 - **Telegram Bot** (Minor, PR #601): Ajustado o formatador de quantidade de tomadas do bot do Telegram para suportar "un", mantendo comprimidos ("cp") para dosagens em massa (mg/mcg/g) e melhorando líquidos ("ui") para que sejam representados de forma autônoma.
-- **dose_instances — cron de geração** (Minor, PR #602): Adicionado cron diário (03:15) no bot que renova a janela de 30 dias dos protocolos ativos e limpa pendentes de protocolos pausados há mais de 1 dia. Roda no processo Node persistente (sem consumir budget de funções Vercel). ADR-048.
+- **dose_instances — cron de geração** (Minor, PR #603): Adicionado cron diário (03:15) no bot que renova a janela de 30 dias dos protocolos ativos e limpa pendentes de protocolos pausados há mais de 1 dia. Roda no processo Node persistente (sem consumir budget de funções Vercel). ADR-048.
 - **Process** (`no-user-impact`, PR #TBD): Padronizado o processo SQP para exigir classificação de impacto, versionamento, changelog estruturado em português e notas de loja deriváveis antes de novas entregas com alteração de código.
 
 ## [4.1.0] — 2026-04-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 - **Schema** (Minor, PR #601): Substituída a unidade de medida padrão de "cp" para "un" no Zod Schema para dar suporte a inalatórios, adesivos e tópicos.
 - **DoseUnit** (Minor, PR #601): Atualizados os formatadores centrais para tratar a unidade "un" de forma genérica ("unidade/unidades/un.") de acordo com o padrão gramatical brasileiro.
 - **Planning** (Minor, PR #601): Expandido e enriquecido extensivamente o rascunho de especificação técnica para o suporte nativo a medicamentos líquidos e controle de estoque decimal no documento [LIQUID_MEDICATIONS_EPIC_DRAFT.md](file:///Users/coelhotv/git/dosiq/plans/dose_instances_refactor/LIQUID_MEDICATIONS_EPIC_DRAFT.md) com análise de impacto de riscos.
+- **dose_instances — motor de geração** (Minor, PR #602): Adicionado `doseInstancePlanner` (core) que orquestra a geração e persistência idempotente de ocorrências de dose, e os hooks de lifecycle de protocolo (`createProtocolRepository`) que materializam a janela ao criar/editar/pausar/religar tratamentos — best-effort (R-245). Sem impacto visível ao usuário até a Fase 3/4 (nenhuma UI consome ainda). ADR-048.
 
 ### Backend/Infra
 - **Telegram Bot** (Minor, PR #601): Ajustado o formatador de quantidade de tomadas do bot do Telegram para suportar "un", mantendo comprimidos ("cp") para dosagens em massa (mg/mcg/g) e melhorando líquidos ("ui") para que sejam representados de forma autônoma.
+- **dose_instances — cron de geração** (Minor, PR #602): Adicionado cron diário (03:15) no bot que renova a janela de 30 dias dos protocolos ativos e limpa pendentes de protocolos pausados há mais de 1 dia. Roda no processo Node persistente (sem consumir budget de funções Vercel). ADR-048.
 - **Process** (`no-user-impact`, PR #TBD): Padronizado o processo SQP para exigir classificação de impacto, versionamento, changelog estruturado em português e notas de loja deriváveis antes de novas entregas com alteração de código.
 
 ## [4.1.0] — 2026-04-28

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -22,5 +22,8 @@ export * from './utils/index.js'
 // Re-exporte de repositories (Fase 1 G2 — factory CRUD canônico)
 export * from './repositories/index.js'
 
+// Re-exporte de services (Fase 2 — orquestração de geração de dose_instances)
+export * from './services/index.js'
+
 // Re-exporte de protocols-utils (opcional, auditado em 2.4)
 // export * from './protocols-utils/index.js'

--- a/packages/core/src/repositories/__tests__/createDoseInstanceRepository.test.js
+++ b/packages/core/src/repositories/__tests__/createDoseInstanceRepository.test.js
@@ -116,6 +116,23 @@ describe('createDoseInstanceRepository', () => {
     })
   })
 
+  describe('reactivateFuturePaused', () => {
+    it('reverte skipped_paused → pending apenas no futuro', async () => {
+      const client = makeClient({ data: null, error: null })
+      const repo = createDoseInstanceRepository({ client })
+      const before = Date.now()
+      await repo.reactivateFuturePaused('p1')
+
+      const b = client._builder
+      expect(b.update).toHaveBeenCalledWith({ status: 'pending' })
+      expect(b.eq).toHaveBeenCalledWith('protocol_id', 'p1')
+      expect(b.eq).toHaveBeenCalledWith('status', 'skipped_paused')
+      const gtCall = b._calls.find(([n]) => n === 'gt')
+      expect(gtCall[1][0]).toBe('scheduled_for')
+      expect(new Date(gtCall[1][1]).getTime()).toBeGreaterThanOrEqual(before)
+    })
+  })
+
   describe('getWindow', () => {
     it('escopa por userId e ordena por scheduled_for ascendente', async () => {
       const client = makeClient({ data: [{ id: 'di-1' }], error: null })

--- a/packages/core/src/repositories/__tests__/createDoseInstanceRepository.test.js
+++ b/packages/core/src/repositories/__tests__/createDoseInstanceRepository.test.js
@@ -21,6 +21,7 @@ function makeBuilder(result) {
     update: vi.fn(function (...a) { this._calls.push(['update', a]); return this }),
     delete: vi.fn(function (...a) { this._calls.push(['delete', a]); return this }),
     eq:     vi.fn(function (...a) { this._calls.push(['eq', a]); return this }),
+    in:     vi.fn(function (...a) { this._calls.push(['in', a]); return this }),
     gt:     vi.fn(function (...a) { this._calls.push(['gt', a]); return this }),
     gte:    vi.fn(function (...a) { this._calls.push(['gte', a]); return this }),
     lte:    vi.fn(function (...a) { this._calls.push(['lte', a]); return this }),
@@ -113,6 +114,31 @@ describe('createDoseInstanceRepository', () => {
       expect(b.eq).toHaveBeenCalledWith('status', 'pending')
       const lteCall = b._calls.find(([n]) => n === 'lte')
       expect(new Date(lteCall[1][1]).toISOString()).toBe(new Date(until).toISOString())
+    })
+  })
+
+  describe('wipeFuturePendingForProtocols', () => {
+    it('DELETE único em lote com .in() + pending + futuro', async () => {
+      const client = makeClient({ data: null, error: null })
+      const repo = createDoseInstanceRepository({ client })
+      const before = Date.now()
+      await repo.wipeFuturePendingForProtocols(['p1', 'p2'])
+
+      const b = client._builder
+      expect(client._from).toBe('dose_instances')
+      expect(callNames(b)).toContain('delete')
+      expect(b.in).toHaveBeenCalledWith('protocol_id', ['p1', 'p2'])
+      expect(b.eq).toHaveBeenCalledWith('status', 'pending')
+      const gtCall = b._calls.find(([n]) => n === 'gt')
+      expect(gtCall[1][0]).toBe('scheduled_for')
+      expect(new Date(gtCall[1][1]).getTime()).toBeGreaterThanOrEqual(before)
+    })
+
+    it('lista vazia → no-op (não toca client)', async () => {
+      const client = makeClient({ data: null, error: null })
+      const repo = createDoseInstanceRepository({ client })
+      await repo.wipeFuturePendingForProtocols([])
+      expect(client.from).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/core/src/repositories/__tests__/createProtocolRepository.lifecycle.test.js
+++ b/packages/core/src/repositories/__tests__/createProtocolRepository.lifecycle.test.js
@@ -93,6 +93,21 @@ describe('createProtocolRepository — lifecycle dose_instances', () => {
     expect(methods).not.toContain('upsert')
   })
 
+  it('update active:true (resume) → reativa skipped_paused (update status) + regen (upsert)', async () => {
+    await repo.update('p1', { active: true })
+    const diOps = tableOps(client, 'dose_instances')
+    const methods = diOps.flatMap((b) => b.calls.map(([m]) => m))
+    // reactivateFuturePaused = update em dose_instances filtrando status=skipped_paused
+    expect(methods).toContain('update')
+    const updatedToPending = diOps.some((b) =>
+      b.calls.some(([m, a]) => m === 'update' && a[0]?.status === 'pending') &&
+      b.calls.some(([m, a]) => m === 'eq' && a[0] === 'status' && a[1] === 'skipped_paused')
+    )
+    expect(updatedToPending).toBe(true)
+    // e regenera a janela
+    expect(methods).toContain('upsert')
+  })
+
   it('update time_schedule → wipe (delete) + regen (upsert)', async () => {
     await repo.update('p1', { time_schedule: ['08:00', '20:00'] })
     const methods = methodsFor(client, 'dose_instances')

--- a/packages/core/src/repositories/__tests__/createProtocolRepository.lifecycle.test.js
+++ b/packages/core/src/repositories/__tests__/createProtocolRepository.lifecycle.test.js
@@ -1,0 +1,124 @@
+// Lifecycle hooks de dose_instances na factory de protocolo (ADR-048, S2.5).
+// Verifica os efeitos colaterais best-effort: create gera janela, pausa marca
+// skipped_paused, mudança de agendamento faz wipe+regen. Mock cobre protocols + dose_instances.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createProtocolRepository } from '../createProtocolRepository.js'
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.clearAllTimers()
+})
+
+const PROTOCOL_ROW = {
+  id: 'p1',
+  user_id: 'u1',
+  name: 'Insulina Basal',
+  frequency: 'diário',
+  time_schedule: ['08:00'],
+  dosage_per_intake: 10,
+  start_date: '2026-01-01',
+  end_date: null,
+  active: true,
+}
+
+// Mock fluente que registra operações por tabela e resolve resultados plausíveis.
+function makeClient() {
+  const ops = [] // { table, calls: [[method, args]] }
+  function builder(table) {
+    const b = {
+      _table: table,
+      calls: [],
+      _result: { data: table === 'protocols' ? PROTOCOL_ROW : [], error: null },
+    }
+    const chain = (name) => vi.fn(function (...a) { b.calls.push([name, a]); return b })
+    b.select = chain('select')
+    b.insert = chain('insert')
+    b.upsert = chain('upsert')
+    b.update = chain('update')
+    b.delete = chain('delete')
+    b.eq = chain('eq')
+    b.gt = chain('gt')
+    b.gte = chain('gte')
+    b.lte = chain('lte')
+    b.not = chain('not')
+    b.order = chain('order')
+    b.single = vi.fn(function () { b.calls.push(['single', []]); return Promise.resolve(b._result) })
+    b.then = (resolve) => resolve(b._result)
+    ops.push(b)
+    return b
+  }
+  const client = { _ops: ops, from: vi.fn((t) => builder(t)) }
+  return client
+}
+
+const getUserId = async () => 'u1'
+
+function tableOps(client, table) {
+  return client._ops.filter((b) => b._table === table)
+}
+function methodsFor(client, table) {
+  return tableOps(client, table).flatMap((b) => b.calls.map(([m]) => m))
+}
+
+describe('createProtocolRepository — lifecycle dose_instances', () => {
+  let client, repo
+  beforeEach(() => {
+    client = makeClient()
+    repo = createProtocolRepository({ client, getUserId })
+  })
+
+  it('create → gera janela inicial (upsert em dose_instances + setGeneratedThrough)', async () => {
+    await repo.create({
+      medicine_id: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d',
+      name: 'Insulina Basal',
+      frequency: 'diário',
+      time_schedule: ['08:00'],
+      dosage_per_intake: 10,
+      start_date: '2026-01-01',
+    })
+    // houve upsert em dose_instances (geração)
+    expect(methodsFor(client, 'dose_instances')).toContain('upsert')
+    // setGeneratedThrough = update em protocols (além do insert original)
+    const protocolUpdates = tableOps(client, 'protocols').filter((b) => b.calls.some(([m]) => m === 'update'))
+    expect(protocolUpdates.length).toBeGreaterThan(0)
+  })
+
+  it('update active:false (pausa) → marca skipped_paused, NÃO regenera', async () => {
+    await repo.update('p1', { active: false })
+    const diOps = tableOps(client, 'dose_instances')
+    const methods = diOps.flatMap((b) => b.calls.map(([m]) => m))
+    // marcou skipped_paused (update em dose_instances) mas não fez upsert (sem regen)
+    expect(methods).toContain('update')
+    expect(methods).not.toContain('upsert')
+  })
+
+  it('update time_schedule → wipe (delete) + regen (upsert)', async () => {
+    await repo.update('p1', { time_schedule: ['08:00', '20:00'] })
+    const methods = methodsFor(client, 'dose_instances')
+    expect(methods).toContain('delete') // wipeFuturePending
+    expect(methods).toContain('upsert') // regeneração
+  })
+
+  it('update não-estrutural (name) → não toca dose_instances', async () => {
+    await repo.update('p1', { name: 'Novo Nome' })
+    expect(tableOps(client, 'dose_instances').length).toBe(0)
+  })
+
+  it('erro de geração é best-effort: create ainda retorna o protocolo', async () => {
+    // força erro no caminho de dose_instances
+    const brokenClient = makeClient()
+    const origFrom = brokenClient.from
+    brokenClient.from = vi.fn((t) => {
+      const b = origFrom(t)
+      if (t === 'dose_instances') b.upsert = vi.fn(() => { throw new Error('boom') })
+      return b
+    })
+    const r = createProtocolRepository({ client: brokenClient, getUserId })
+    const out = await r.create({
+      medicine_id: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d',
+      name: 'Teste', frequency: 'diário', time_schedule: ['08:00'], dosage_per_intake: 1, start_date: '2026-01-01',
+    })
+    expect(out.id).toBe('p1') // protocolo criado apesar do erro de geração
+  })
+})

--- a/packages/core/src/repositories/createDoseInstanceRepository.js
+++ b/packages/core/src/repositories/createDoseInstanceRepository.js
@@ -119,6 +119,21 @@ export function createDoseInstanceRepository({ client }) {
     },
 
     /**
+     * Grava (ou limpa) o timestamp de pausa do protocolo.
+     * @param {string} protocolId
+     * @param {Date|string|null} ts - null limpa a marca (resume)
+     * @returns {Promise<void>}
+     */
+    async setPausedAt(protocolId, ts) {
+      const { error } = await client
+        .from(PROTOCOLS)
+        .update({ paused_at: ts === null ? null : toIso(ts) })
+        .eq('id', protocolId)
+
+      if (error) throw error
+    },
+
+    /**
      * Marca instâncias pendentes futuras até `untilTs` como skipped_paused (pausa não penaliza).
      * @param {string} protocolId
      * @param {Date|string} untilTs

--- a/packages/core/src/repositories/createDoseInstanceRepository.js
+++ b/packages/core/src/repositories/createDoseInstanceRepository.js
@@ -134,6 +134,24 @@ export function createDoseInstanceRepository({ client }) {
     },
 
     /**
+     * Reativa instâncias futuras que estavam pausadas (skipped_paused → pending).
+     * Usado ao religar um protocolo: o upsert idempotente (ON CONFLICT DO NOTHING) não
+     * reverteria essas linhas, então a reativação é explícita. Nunca toca o passado.
+     * @param {string} protocolId
+     * @returns {Promise<void>}
+     */
+    async reactivateFuturePaused(protocolId) {
+      const { error } = await client
+        .from(TABLE)
+        .update({ status: 'pending' })
+        .eq('protocol_id', protocolId)
+        .eq('status', 'skipped_paused')
+        .gt('scheduled_for', getServerTimestamp())
+
+      if (error) throw error
+    },
+
+    /**
      * Marca instâncias pendentes futuras até `untilTs` como skipped_paused (pausa não penaliza).
      * @param {string} protocolId
      * @param {Date|string} untilTs

--- a/packages/core/src/repositories/createDoseInstanceRepository.js
+++ b/packages/core/src/repositories/createDoseInstanceRepository.js
@@ -68,6 +68,24 @@ export function createDoseInstanceRepository({ client }) {
     },
 
     /**
+     * Versão em lote de wipeFuturePending: remove pendentes futuras de VÁRIOS protocolos
+     * num único DELETE (evita N+1 no cron). Mesma regra inviolável: só pending + futuro.
+     * @param {string[]} protocolIds
+     * @returns {Promise<void>}
+     */
+    async wipeFuturePendingForProtocols(protocolIds) {
+      if (!Array.isArray(protocolIds) || protocolIds.length === 0) return
+      const { error } = await client
+        .from(TABLE)
+        .delete()
+        .in('protocol_id', protocolIds)
+        .eq('status', 'pending')
+        .gt('scheduled_for', getServerTimestamp())
+
+      if (error) throw error
+    },
+
+    /**
      * Instâncias de um usuário dentro de [fromTs, toTs], ordenadas por scheduled_for.
      * @param {string} userId
      * @param {Date|string} fromTs

--- a/packages/core/src/repositories/createProtocolRepository.js
+++ b/packages/core/src/repositories/createProtocolRepository.js
@@ -48,7 +48,13 @@ async function syncInstancesOnWrite({ client, protocol, updates }) {
     }
 
     const isResume = updates && updates.active === true
-    if (isResume) await repo.setPausedAt(protocol.id, null)
+    if (isResume) {
+      await repo.setPausedAt(protocol.id, null)
+      // Reverte as instâncias marcadas na pausa (skipped_paused → pending). O regen via
+      // upsert (ON CONFLICT DO NOTHING) não reverteria — sem isto, toggle rápido
+      // (pausa <1d + religa) deixaria as próximas 24h mortas. (S2.5 DoD)
+      await repo.reactivateFuturePaused(protocol.id)
+    }
 
     const schedulingChanged = updates && SCHEDULING_FIELDS.some((f) => f in updates)
     if (schedulingChanged) await repo.wipeFuturePending(protocol.id)

--- a/packages/core/src/repositories/createProtocolRepository.js
+++ b/packages/core/src/repositories/createProtocolRepository.js
@@ -42,8 +42,11 @@ async function syncInstancesOnWrite({ client, protocol, updates }) {
     // Pausa: marca paused_at + próximas 24h como skipped_paused (trabalho leve);
     // o cron limpa o resto após 1 dia. Não regenera.
     if (updates && updates.active === false) {
-      await repo.setPausedAt(protocol.id, getServerTimestamp())
-      await repo.markSkippedPaused(protocol.id, parseTimestamp(Date.now() + PAUSE_GRACE_MS).toISOString())
+      // Captura UM timestamp e deriva o cutoff dele (evita duas leituras de relógio).
+      const nowIso = getServerTimestamp()
+      await repo.setPausedAt(protocol.id, nowIso)
+      const cutoffIso = parseTimestamp(parseISO(nowIso).getTime() + PAUSE_GRACE_MS).toISOString()
+      await repo.markSkippedPaused(protocol.id, cutoffIso)
       return
     }
 

--- a/packages/core/src/repositories/createProtocolRepository.js
+++ b/packages/core/src/repositories/createProtocolRepository.js
@@ -15,7 +15,59 @@ import {
   validateProtocolCreate,
   validateProtocolUpdate,
 } from '../schemas/protocolSchema.js'
-import { getTodayLocal, getServerTimestamp } from '../utils/dateUtils.js'
+import { getTodayLocal, getServerTimestamp, parseISO, parseTimestamp } from '../utils/dateUtils.js'
+import { createDoseInstanceRepository } from './createDoseInstanceRepository.js'
+import { planWindow, computeWindowEnd } from '../services/doseInstancePlanner.js'
+
+// Campos cuja alteração invalida a janela futura de dose_instances → wipe + regen.
+const SCHEDULING_FIELDS = ['time_schedule', 'dosage_per_intake', 'frequency', 'weekdays', 'start_date', 'end_date']
+const PAUSE_GRACE_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Sincroniza dose_instances após escrita de protocolo (ADR-048, S2.5).
+ * BEST-EFFORT: nunca propaga erro — cron diário (generateDoseInstances) e a rede
+ * lazy (ensureInstancesUpTo) são a malha de segurança. Um erro de geração não pode
+ * bloquear a criação/edição do protocolo em si.
+ *
+ * @param {Object} params
+ * @param {Object} params.client    client Supabase (mesmo da factory)
+ * @param {Object} params.protocol  linha do protocolo recém-escrita
+ * @param {Object|null} params.updates  updates do update() (null em create)
+ */
+async function syncInstancesOnWrite({ client, protocol, updates }) {
+  try {
+    if (!protocol?.id) return
+    const repo = createDoseInstanceRepository({ client })
+
+    // Pausa: marca paused_at + próximas 24h como skipped_paused (trabalho leve);
+    // o cron limpa o resto após 1 dia. Não regenera.
+    if (updates && updates.active === false) {
+      await repo.setPausedAt(protocol.id, getServerTimestamp())
+      await repo.markSkippedPaused(protocol.id, parseTimestamp(Date.now() + PAUSE_GRACE_MS).toISOString())
+      return
+    }
+
+    const isResume = updates && updates.active === true
+    if (isResume) await repo.setPausedAt(protocol.id, null)
+
+    const schedulingChanged = updates && SCHEDULING_FIELDS.some((f) => f in updates)
+    if (schedulingChanged) await repo.wipeFuturePending(protocol.id)
+
+    // (Re)gera a janela em: create (updates null), resume, ou mudança de agendamento.
+    const shouldRegen = !updates || isResume || schedulingChanged
+    if (shouldRegen) {
+      const now = parseISO(getServerTimestamp())
+      await planWindow({
+        protocol,
+        doseInstanceRepo: repo,
+        fromTs: now.toISOString(),
+        toTs: computeWindowEnd(protocol, now),
+      })
+    }
+  } catch {
+    // best-effort — silencioso; cron + rede lazy corrigem eventualmente
+  }
+}
 
 const DEFAULT_SELECT = `
         *,
@@ -147,6 +199,8 @@ export function createProtocolRepository({
         .single()
 
       if (error) throw error
+      // ADR-048 S2.5: materializa a janela inicial de dose_instances (best-effort)
+      await syncInstancesOnWrite({ client, protocol: data, updates: null })
       return detailTransform(data)
     },
 
@@ -164,6 +218,10 @@ export function createProtocolRepository({
         .single()
 
       if (error) throw error
+      // ADR-048 S2.5: pausa/resume/mudança de agendamento → sincroniza instâncias (best-effort).
+      // Usa `updates` CRU (não validation.data) — Zod pode injetar defaults e fazer toda
+      // edição parecer mudança de agendamento.
+      await syncInstancesOnWrite({ client, protocol: data, updates })
       return detailTransform(data)
     },
 

--- a/packages/core/src/services/__tests__/doseInstancePlanner.test.js
+++ b/packages/core/src/services/__tests__/doseInstancePlanner.test.js
@@ -94,11 +94,12 @@ describe('ensureInstancesUpTo (rede lazy)', () => {
   })
 
   it('gera o gap entre hwm e ts quando descoberto', async () => {
-    const repo = makeRepo('2026-05-10T00:00:00.000Z')
+    // hwm logo à frente de agora; ts mais adiante → gap futuro real
+    const repo = makeRepo(new Date(Date.now() + 1 * MS_DAY).toISOString())
     const n = await ensureInstancesUpTo({
       protocol,
       doseInstanceRepo: repo,
-      ts: '2026-05-13T00:00:00-03:00',
+      ts: new Date(Date.now() + 4 * MS_DAY).toISOString(),
     })
     expect(n).toBeGreaterThan(0)
     expect(repo.upsertMany).toHaveBeenCalledOnce()
@@ -110,6 +111,22 @@ describe('ensureInstancesUpTo (rede lazy)', () => {
     const n = await ensureInstancesUpTo({ protocol, doseInstanceRepo: repo, ts: future })
     expect(n).toBeGreaterThan(0)
     expect(repo.setGeneratedThrough).toHaveBeenCalledOnce()
+  })
+
+  it('hwm no passado: clamp em now (não gera pending retroativo)', async () => {
+    const past = new Date(Date.now() - 10 * MS_DAY).toISOString()
+    const repo = makeRepo(past)
+    const future = new Date(Date.now() + 2 * MS_DAY).toISOString()
+    await ensureInstancesUpTo({ protocol, doseInstanceRepo: repo, ts: future })
+    // a janela gerada começa em >= now (nenhuma instância anterior a agora)
+    const upserted = repo.upsertMany.mock.calls[0]?.[0] ?? []
+    const nowMs = Date.now()
+    expect(upserted.every((i) => new Date(i.scheduled_for).getTime() >= nowMs - 60000)).toBe(true)
+  })
+
+  it('ts inválido (null) não lança — toIsoLike null-safe', async () => {
+    const repo = makeRepo('2026-06-01T00:00:00.000Z')
+    await expect(ensureInstancesUpTo({ protocol, doseInstanceRepo: repo, ts: null })).resolves.toBeTypeOf('number')
   })
 })
 

--- a/packages/core/src/services/__tests__/doseInstancePlanner.test.js
+++ b/packages/core/src/services/__tests__/doseInstancePlanner.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import {
+  computeWindowEnd,
+  planWindow,
+  ensureInstancesUpTo,
+  renewProtocolWindow,
+  WINDOW_DAYS,
+  RENEWAL_THRESHOLD_DAYS,
+} from '../doseInstancePlanner.js'
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.clearAllTimers()
+})
+
+const protocol = {
+  id: 'p1',
+  user_id: 'u1',
+  frequency: 'diário',
+  time_schedule: ['08:00'],
+  dosage_per_intake: 1,
+  start_date: '2026-01-01',
+  end_date: null,
+  active: true,
+}
+
+function makeRepo(hwm = null) {
+  return {
+    _hwm: hwm,
+    upsertMany: vi.fn(async () => []),
+    setGeneratedThrough: vi.fn(async () => {}),
+    getGeneratedThrough: vi.fn(async function () { return this._hwm }),
+  }
+}
+
+const MS_DAY = 86400000
+
+describe('computeWindowEnd', () => {
+  it('contínuo (sem end_date): base + WINDOW_DAYS', () => {
+    const base = new Date('2026-05-10T00:00:00Z')
+    const end = computeWindowEnd(protocol, base)
+    const days = (new Date(end).getTime() - base.getTime()) / MS_DAY
+    expect(Math.round(days)).toBe(WINDOW_DAYS)
+  })
+
+  it('com end_date próximo: capa no fim do protocolo (não passa de end_date)', () => {
+    const base = new Date('2026-05-10T00:00:00Z')
+    const end = computeWindowEnd({ ...protocol, end_date: '2026-05-15' }, base)
+    // fim do dia 15 < base+30d → usa end_date
+    const localDate = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Sao_Paulo' }).format(new Date(end))
+    expect(localDate).toBe('2026-05-15')
+  })
+})
+
+describe('planWindow', () => {
+  it('gera, faz upsert e avança o high-water-mark', async () => {
+    const repo = makeRepo()
+    const n = await planWindow({
+      protocol,
+      doseInstanceRepo: repo,
+      fromTs: '2026-05-10T00:00:00-03:00',
+      toTs: '2026-05-12T23:59:59-03:00',
+    })
+    expect(n).toBe(3) // 3 dias × 1 slot
+    expect(repo.upsertMany).toHaveBeenCalledOnce()
+    expect(repo.setGeneratedThrough).toHaveBeenCalledWith('p1', '2026-05-12T23:59:59-03:00')
+  })
+
+  it('janela vazia: não chama upsert mas ainda avança hwm', async () => {
+    const repo = makeRepo()
+    const n = await planWindow({
+      protocol: { ...protocol, frequency: 'quando_necessário' },
+      doseInstanceRepo: repo,
+      fromTs: '2026-05-10T00:00:00-03:00',
+      toTs: '2026-05-12T23:59:59-03:00',
+    })
+    expect(n).toBe(0)
+    expect(repo.upsertMany).not.toHaveBeenCalled()
+    expect(repo.setGeneratedThrough).toHaveBeenCalledOnce()
+  })
+})
+
+describe('ensureInstancesUpTo (rede lazy)', () => {
+  it('no-op quando hwm já cobre o ts pedido', async () => {
+    const repo = makeRepo('2026-06-01T00:00:00.000Z')
+    const n = await ensureInstancesUpTo({
+      protocol,
+      doseInstanceRepo: repo,
+      ts: '2026-05-20T00:00:00Z',
+    })
+    expect(n).toBe(0)
+    expect(repo.upsertMany).not.toHaveBeenCalled()
+    expect(repo.setGeneratedThrough).not.toHaveBeenCalled()
+  })
+
+  it('gera o gap entre hwm e ts quando descoberto', async () => {
+    const repo = makeRepo('2026-05-10T00:00:00.000Z')
+    const n = await ensureInstancesUpTo({
+      protocol,
+      doseInstanceRepo: repo,
+      ts: '2026-05-13T00:00:00-03:00',
+    })
+    expect(n).toBeGreaterThan(0)
+    expect(repo.upsertMany).toHaveBeenCalledOnce()
+  })
+
+  it('sem hwm: gera a partir de agora', async () => {
+    const repo = makeRepo(null)
+    const future = new Date(Date.now() + 3 * MS_DAY).toISOString()
+    const n = await ensureInstancesUpTo({ protocol, doseInstanceRepo: repo, ts: future })
+    expect(n).toBeGreaterThan(0)
+    expect(repo.setGeneratedThrough).toHaveBeenCalledOnce()
+  })
+})
+
+describe('renewProtocolWindow (cron)', () => {
+  it('não renova quando hwm ainda está longe do fim', async () => {
+    const now = new Date('2026-05-10T00:00:00Z')
+    // hwm 25 dias à frente → além do threshold de 7d → não renova
+    const repo = makeRepo(new Date(now.getTime() + 25 * MS_DAY).toISOString())
+    const n = await renewProtocolWindow({ protocol, doseInstanceRepo: repo, now })
+    expect(n).toBe(0)
+    expect(repo.upsertMany).not.toHaveBeenCalled()
+  })
+
+  it('renova quando hwm está dentro do threshold do fim', async () => {
+    const now = new Date('2026-05-10T00:00:00Z')
+    // hwm 3 dias à frente (< RENEWAL_THRESHOLD_DAYS=7) → renova até now+30d
+    const repo = makeRepo(new Date(now.getTime() + 3 * MS_DAY).toISOString())
+    const n = await renewProtocolWindow({ protocol, doseInstanceRepo: repo, now })
+    expect(n).toBeGreaterThan(0)
+    expect(repo.upsertMany).toHaveBeenCalledOnce()
+  })
+
+  it('sem hwm: gera do agora até now+30d', async () => {
+    const now = new Date('2026-05-10T00:00:00Z')
+    const repo = makeRepo(null)
+    const n = await renewProtocolWindow({ protocol, doseInstanceRepo: repo, now })
+    expect(n).toBe(WINDOW_DAYS) // diário, 1 slot/dia, 30 dias
+    expect(repo.setGeneratedThrough).toHaveBeenCalledOnce()
+  })
+
+  it('respeita RENEWAL_THRESHOLD_DAYS exportado', () => {
+    expect(RENEWAL_THRESHOLD_DAYS).toBe(7)
+  })
+})

--- a/packages/core/src/services/doseInstancePlanner.js
+++ b/packages/core/src/services/doseInstancePlanner.js
@@ -66,6 +66,7 @@ export async function planWindow({ protocol, doseInstanceRepo, fromTs, toTs, tz 
  * @returns {Promise<number>} instâncias geradas no gap (0 se já coberto)
  */
 export async function ensureInstancesUpTo({ protocol, doseInstanceRepo, ts, tz = 'America/Sao_Paulo' }) {
+  const nowMs = parseISO(getServerTimestamp()).getTime()
   const requestedMs = parseISO(toIsoLike(ts)).getTime()
   // alvo efetivo = min(ts pedido, fim-alvo da janela do protocolo)
   const windowEndIso = computeWindowEnd(protocol, parseTimestamp(requestedMs))
@@ -75,15 +76,19 @@ export async function ensureInstancesUpTo({ protocol, doseInstanceRepo, ts, tz =
   const hwm = await doseInstanceRepo.getGeneratedThrough(protocol.id)
   if (hwm && parseISO(hwm).getTime() >= targetMs) return 0 // já coberto
 
-  const fromIso = hwm ?? getServerTimestamp()
-  return planWindow({ protocol, doseInstanceRepo, fromTs: fromIso, toTs: target, tz })
+  // Clamp: nunca gerar a partir do passado (evita criar `pending` retroativo se o
+  // hwm ficar atrás de `now` — backfill histórico é responsabilidade de outro fluxo).
+  const fromMs = Math.max(hwm ? parseISO(hwm).getTime() : nowMs, nowMs)
+  return planWindow({ protocol, doseInstanceRepo, fromTs: parseTimestamp(fromMs).toISOString(), toTs: target, tz })
 }
 
-/** Converte Date|ISO|ms em ISO (R-020: sem `new Date()` direto). */
+/** Converte Date|ISO|ms em ISO (R-020: sem `new Date()` direto). Null-safe. */
 function toIsoLike(value) {
+  if (value === null || value === undefined) return getServerTimestamp()
   if (typeof value === 'number') return parseTimestamp(value).toISOString()
   if (typeof value === 'string') return value
-  return parseTimestamp(value.getTime()).toISOString()
+  if (typeof value.getTime === 'function') return parseTimestamp(value.getTime()).toISOString()
+  return getServerTimestamp()
 }
 
 /**
@@ -102,7 +107,9 @@ export async function renewProtocolWindow({ protocol, doseInstanceRepo, now = pa
     if (hwmMs >= targetMs) return 0 // janela já cobre o alvo
     const thresholdMs = now.getTime() + RENEWAL_THRESHOLD_DAYS * MS_PER_DAY
     if (hwmMs > thresholdMs) return 0 // ainda longe do fim — não renova ainda
-    return planWindow({ protocol, doseInstanceRepo, fromTs: hwm, toTs: targetIso, tz })
+    // Clamp: nunca gerar a partir do passado (sem `pending` retroativo).
+    const fromMs = Math.max(hwmMs, now.getTime())
+    return planWindow({ protocol, doseInstanceRepo, fromTs: parseTimestamp(fromMs).toISOString(), toTs: targetIso, tz })
   }
   // nunca gerado: gera do agora até o alvo
   return planWindow({ protocol, doseInstanceRepo, fromTs: now.toISOString(), toTs: targetIso, tz })

--- a/packages/core/src/services/doseInstancePlanner.js
+++ b/packages/core/src/services/doseInstancePlanner.js
@@ -1,0 +1,109 @@
+/**
+ * doseInstancePlanner — orquestra geração + persistência de dose_instances (ADR-048, Fase 2).
+ *
+ * Camada entre o gerador puro (`generateInstances`) e o repository de I/O
+ * (`createDoseInstanceRepository`). Reusado por DOIS chamadores (DRY):
+ *  - cron server-side (service_role) — varredura/renovação em lote;
+ *  - lifecycle hooks da factory de protocolo (client authenticated) — geração imediata.
+ *
+ * Injeção de dependência: recebe `doseInstanceRepo` pronto → testável e agnóstico
+ * de plataforma (qual client Supabase é detalhe do chamador).
+ *
+ * tz: default 'America/Sao_Paulo' (G1 — injeção real do tz do usuário fica para a
+ * Fase 3; hoje 99% SP, consistente).
+ */
+
+import { generateInstances } from '../utils/doseInstanceGenerator.js'
+import { parseISO, parseTimestamp, getServerTimestamp, getEndOfDayISO } from '../utils/dateUtils.js'
+
+/** Janela padrão de geração para protocolos contínuos (sem end_date). */
+export const WINDOW_DAYS = 30
+/** Renova quando o high-water-mark está a menos de N dias do fim da janela. */
+export const RENEWAL_THRESHOLD_DAYS = 7
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * Fim-alvo da janela de geração de um protocolo, em ISO.
+ * - com `end_date`: o fim do dia de end_date (não passa disso);
+ * - contínuo: `baseTs + WINDOW_DAYS` dias.
+ * @param {Object} protocol
+ * @param {Date} baseDate - âncora (normalmente agora)
+ * @returns {string} ISO UTC
+ */
+export function computeWindowEnd(protocol, baseDate) {
+  const continuousEnd = parseTimestamp(baseDate.getTime() + WINDOW_DAYS * MS_PER_DAY).toISOString()
+  if (!protocol.end_date) return continuousEnd
+  const endOfEndDate = getEndOfDayISO(protocol.end_date) // ISO do fim do dia de end_date (tz default SP)
+  // o menor entre (fim do protocolo) e (janela contínua)
+  return parseISO(endOfEndDate).getTime() < parseISO(continuousEnd).getTime() ? endOfEndDate : continuousEnd
+}
+
+/**
+ * Gera e persiste (idempotente) as instâncias de um protocolo numa janela [fromTs, toTs],
+ * e avança o high-water-mark para toTs.
+ * @param {Object} params
+ * @param {Object} params.protocol
+ * @param {Object} params.doseInstanceRepo - repo com upsertMany/setGeneratedThrough
+ * @param {Date|string|number} params.fromTs
+ * @param {Date|string|number} params.toTs
+ * @param {string} [params.tz]
+ * @returns {Promise<number>} nº de instâncias geradas (antes do ON CONFLICT)
+ */
+export async function planWindow({ protocol, doseInstanceRepo, fromTs, toTs, tz = 'America/Sao_Paulo' }) {
+  const instances = generateInstances(protocol, fromTs, toTs, tz)
+  if (instances.length > 0) {
+    await doseInstanceRepo.upsertMany(instances)
+  }
+  await doseInstanceRepo.setGeneratedThrough(protocol.id, toTs)
+  return instances.length
+}
+
+/**
+ * Rede de segurança lazy: garante que o protocolo tenha instâncias geradas até `ts`.
+ * Gera apenas o gap entre o high-water-mark e `ts` (capado no fim do protocolo).
+ * No-op se já coberto.
+ * @returns {Promise<number>} instâncias geradas no gap (0 se já coberto)
+ */
+export async function ensureInstancesUpTo({ protocol, doseInstanceRepo, ts, tz = 'America/Sao_Paulo' }) {
+  const requestedMs = parseISO(toIsoLike(ts)).getTime()
+  // alvo efetivo = min(ts pedido, fim-alvo da janela do protocolo)
+  const windowEndIso = computeWindowEnd(protocol, parseTimestamp(requestedMs))
+  const targetMs = Math.min(requestedMs, parseISO(windowEndIso).getTime())
+  const target = parseTimestamp(targetMs).toISOString()
+
+  const hwm = await doseInstanceRepo.getGeneratedThrough(protocol.id)
+  if (hwm && parseISO(hwm).getTime() >= targetMs) return 0 // já coberto
+
+  const fromIso = hwm ?? getServerTimestamp()
+  return planWindow({ protocol, doseInstanceRepo, fromTs: fromIso, toTs: target, tz })
+}
+
+/** Converte Date|ISO|ms em ISO (R-020: sem `new Date()` direto). */
+function toIsoLike(value) {
+  if (typeof value === 'number') return parseTimestamp(value).toISOString()
+  if (typeof value === 'string') return value
+  return parseTimestamp(value.getTime()).toISOString()
+}
+
+/**
+ * Renova a janela de um protocolo se o high-water-mark se aproxima do fim
+ * (usado pelo cron). Gera de `now` (ou do hwm) até `now + WINDOW_DAYS`.
+ * Não regenera se o hwm ainda está longe do fim.
+ * @returns {Promise<number>} instâncias geradas (0 se não precisou renovar)
+ */
+export async function renewProtocolWindow({ protocol, doseInstanceRepo, now = parseISO(getServerTimestamp()), tz = 'America/Sao_Paulo' }) {
+  const targetIso = computeWindowEnd(protocol, now)
+  const targetMs = parseISO(targetIso).getTime()
+  const hwm = await doseInstanceRepo.getGeneratedThrough(protocol.id)
+
+  if (hwm) {
+    const hwmMs = parseISO(hwm).getTime()
+    if (hwmMs >= targetMs) return 0 // janela já cobre o alvo
+    const thresholdMs = now.getTime() + RENEWAL_THRESHOLD_DAYS * MS_PER_DAY
+    if (hwmMs > thresholdMs) return 0 // ainda longe do fim — não renova ainda
+    return planWindow({ protocol, doseInstanceRepo, fromTs: hwm, toTs: targetIso, tz })
+  }
+  // nunca gerado: gera do agora até o alvo
+  return planWindow({ protocol, doseInstanceRepo, fromTs: now.toISOString(), toTs: targetIso, tz })
+}

--- a/packages/core/src/services/index.js
+++ b/packages/core/src/services/index.js
@@ -1,0 +1,9 @@
+// @dosiq/core services — orquestração (geração + persistência) reusável web/mobile/server.
+export {
+  WINDOW_DAYS,
+  RENEWAL_THRESHOLD_DAYS,
+  computeWindowEnd,
+  planWindow,
+  ensureInstancesUpTo,
+  renewProtocolWindow,
+} from './doseInstancePlanner.js'

--- a/plans/dose_instances_refactor/EXEC_SPECS_PHASE_1_2.md
+++ b/plans/dose_instances_refactor/EXEC_SPECS_PHASE_1_2.md
@@ -61,7 +61,7 @@ Regras invioláveis (memória do projeto):
 **Touchpoints cavecrew:**
 - `cavecrew-investigator` — preflight de cada sprint que toca código existente (mapeia call sites). Output comprimido.
 - `cavecrew-builder` — **só tarefas ≤2 arquivos, escopo óbvio** (migration SQL, campo Zod, constante). Recusa 3+.
-- `cavecrew-reviewer` — audita diff de cada sprint antes do PR.
+- ~~`cavecrew-reviewer`~~ — **removido do gate** (decisão 2026-05-28): revisor oficial é `@gemini-code-assist` no PR (GitHub, budget de tokens separado). G1 = lint + testes; revisão de código fica no Gemini. Gates ficam com o humano no formato SQP. Evita gasto duplicado de tokens Claude.
 - Tarefas multi-arquivo / novo módulo / lógica crítica → agente `claude` (general-purpose) com `model` override (builder retornaria `too-big`).
 
 **Heurística de modelo:**
@@ -79,8 +79,8 @@ Regras invioláveis (memória do projeto):
 
 | Nível | Quando | Checks | Bloqueia |
 |-------|--------|--------|----------|
-| **G1 — por sprint** | ao fim de cada sprint, antes de empilhar o próximo | `rtk lint` + testes-alvo do sprint (`npm run test:changed`) + `cavecrew-reviewer` no diff só daquele sprint → corrijo 🔴/🟡 | empilhar próximo sprint |
-| **G2 — por PR** | antes de abrir cada PR | `rtk lint` + `rtk npm run validate:agent` (suite crítica) + `cavecrew-reviewer` no diff agregado + PO smoke se UI | abrir PR |
+| **G1 — por sprint** | ao fim de cada sprint, antes de empilhar o próximo | `rtk lint` + testes-alvo do sprint (`npm run test:changed`) → corrijo 🔴/🟡 | empilhar próximo sprint |
+| **G2 — por PR** | antes de abrir cada PR | SQP (R-221): classificação de impacto/SemVer + version bump + CHANGELOG + `rtk lint` + `rtk npm run validate:agent` + **Hard Stop p/ validação humana** + PO smoke se UI | abrir PR |
 | **G3 — pós-merge** | após humano mergear | C5 (registrar ADR/R/AP) + `/devflow distill` se journal≥15 | encerrar fase |
 
 **Lint roda em G1 e G2** — nunca commito sem `rtk lint` verde (evita regressão e quebra de CI remoto). G1 pega cedo; G2 confirma o conjunto.

--- a/server/bot/doseInstanceScheduler.js
+++ b/server/bot/doseInstanceScheduler.js
@@ -23,36 +23,52 @@ import { createLogger } from './logger.js'
 const logger = createLogger('DoseInstanceScheduler')
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000
+/** Lote de paginação — Supabase corta SELECT em ~1000 linhas por padrão. */
+const BATCH_SIZE = 100
 
 /**
  * Renova a janela de geração de todos os protocolos ativos.
+ * Paginado por `.range()`: sem paginação, o limite padrão do Supabase (~1000 linhas)
+ * faria o cron pular usuários silenciosamente conforme a base cresce.
  * Idempotente: rodar 2x = mesmo estado (renewProtocolWindow não regenera o que já cobre,
  * e o upsert usa ON CONFLICT DO NOTHING).
  * @returns {Promise<{processed: number, generated: number}>}
  */
 export async function generateDoseInstances() {
-  const { data: protocols, error } = await supabase
-    .from('protocols')
-    .select('*')
-    .eq('active', true)
-
-  if (error) {
-    logger.error('Falha ao buscar protocolos ativos', error)
-    throw error
-  }
-
   const doseInstanceRepo = createDoseInstanceRepository({ client: supabase })
+  let processed = 0
   let generated = 0
-  for (const protocol of protocols ?? []) {
-    try {
-      generated += await renewProtocolWindow({ protocol, doseInstanceRepo })
-    } catch (err) {
-      // Best-effort por protocolo: um erro não derruba a varredura inteira.
-      logger.error(`Falha ao renovar janela do protocolo ${protocol.id}`, err)
+  let from = 0
+
+  for (;;) {
+    const { data: protocols, error } = await supabase
+      .from('protocols')
+      .select('*')
+      .eq('active', true)
+      .range(from, from + BATCH_SIZE - 1)
+
+    if (error) {
+      logger.error('Falha ao buscar protocolos ativos', error)
+      throw error
     }
+    if (!protocols || protocols.length === 0) break
+
+    for (const protocol of protocols) {
+      try {
+        generated += await renewProtocolWindow({ protocol, doseInstanceRepo })
+      } catch (err) {
+        // Best-effort por protocolo: um erro não derruba a varredura inteira.
+        logger.error(`Falha ao renovar janela do protocolo ${protocol.id}`, err)
+      }
+    }
+
+    processed += protocols.length
+    if (protocols.length < BATCH_SIZE) break
+    from += BATCH_SIZE
   }
-  logger.info('Geração de dose_instances concluída', { processed: protocols?.length ?? 0, generated })
-  return { processed: protocols?.length ?? 0, generated }
+
+  logger.info('Geração de dose_instances concluída', { processed, generated })
+  return { processed, generated }
 }
 
 /**
@@ -75,16 +91,16 @@ export async function cleanupPausedProtocols() {
     throw error
   }
 
-  const doseInstanceRepo = createDoseInstanceRepository({ client: supabase })
-  let cleaned = 0
-  for (const { id } of paused ?? []) {
-    try {
-      await doseInstanceRepo.wipeFuturePending(id)
-      cleaned += 1
-    } catch (err) {
-      logger.error(`Falha ao limpar pendentes do protocolo pausado ${id}`, err)
-    }
+  const pausedIds = (paused ?? []).map((p) => p.id)
+  if (pausedIds.length === 0) {
+    logger.info('Limpeza de pausados concluída', { cleaned: 0 })
+    return { cleaned: 0 }
   }
-  logger.info('Limpeza de pausados concluída', { cleaned })
-  return { cleaned }
+
+  // DELETE único em lote (evita N+1): mesma regra inviolável (só pending + futuro).
+  const doseInstanceRepo = createDoseInstanceRepository({ client: supabase })
+  await doseInstanceRepo.wipeFuturePendingForProtocols(pausedIds)
+
+  logger.info('Limpeza de pausados concluída', { cleaned: pausedIds.length })
+  return { cleaned: pausedIds.length }
 }

--- a/server/bot/doseInstanceScheduler.js
+++ b/server/bot/doseInstanceScheduler.js
@@ -1,0 +1,90 @@
+/**
+ * doseInstanceScheduler — motor de geração de dose_instances (ADR-048, Fase 2 / S2.4).
+ *
+ * Roda no processo Node persistente do bot (NÃO no Vercel — não consome o budget de
+ * 12 functions, R-090). Usa o client service_role (`server/services/supabase.js`) que
+ * ignora RLS → todo acesso é escopado explicitamente por protocolo/usuário (R-042).
+ *
+ * Reusa a orquestração pura do core (`renewProtocolWindow` / `createDoseInstanceRepository`)
+ * — sem reimplementar geração nem recorrência aqui.
+ *
+ * Responsabilidades do cron diário:
+ *  1. Renovar a janela de 30d dos protocolos ativos cujo high-water-mark se aproxima do fim.
+ *  2. Limpar instâncias pendentes futuras de protocolos pausados há > 1 dia.
+ *
+ * Rede de segurança lazy (`ensureInstancesUpTo`) é exportada pelo core e chamada por
+ * leituras críticas (dashboard / scheduler de notificação) — não vive aqui.
+ */
+
+import { createDoseInstanceRepository, renewProtocolWindow, parseTimestamp } from '@dosiq/core'
+import { supabase } from '../services/supabase.js'
+import { createLogger } from './logger.js'
+
+const logger = createLogger('DoseInstanceScheduler')
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * Renova a janela de geração de todos os protocolos ativos.
+ * Idempotente: rodar 2x = mesmo estado (renewProtocolWindow não regenera o que já cobre,
+ * e o upsert usa ON CONFLICT DO NOTHING).
+ * @returns {Promise<{processed: number, generated: number}>}
+ */
+export async function generateDoseInstances() {
+  const { data: protocols, error } = await supabase
+    .from('protocols')
+    .select('*')
+    .eq('active', true)
+
+  if (error) {
+    logger.error('Falha ao buscar protocolos ativos', error)
+    throw error
+  }
+
+  const doseInstanceRepo = createDoseInstanceRepository({ client: supabase })
+  let generated = 0
+  for (const protocol of protocols ?? []) {
+    try {
+      generated += await renewProtocolWindow({ protocol, doseInstanceRepo })
+    } catch (err) {
+      // Best-effort por protocolo: um erro não derruba a varredura inteira.
+      logger.error(`Falha ao renovar janela do protocolo ${protocol.id}`, err)
+    }
+  }
+  logger.info('Geração de dose_instances concluída', { processed: protocols?.length ?? 0, generated })
+  return { processed: protocols?.length ?? 0, generated }
+}
+
+/**
+ * Limpa instâncias pendentes futuras de protocolos pausados há mais de 1 dia.
+ * O toggle de pausa só marca as próximas 24h como skipped_paused (trabalho leve);
+ * o cron remove o resto depois, evitando varrer tudo no momento do toggle.
+ * @returns {Promise<{cleaned: number}>}
+ */
+export async function cleanupPausedProtocols() {
+  const cutoffIso = parseTimestamp(Date.now() - MS_PER_DAY).toISOString()
+  const { data: paused, error } = await supabase
+    .from('protocols')
+    .select('id')
+    .eq('active', false)
+    .not('paused_at', 'is', null)
+    .lt('paused_at', cutoffIso)
+
+  if (error) {
+    logger.error('Falha ao buscar protocolos pausados', error)
+    throw error
+  }
+
+  const doseInstanceRepo = createDoseInstanceRepository({ client: supabase })
+  let cleaned = 0
+  for (const { id } of paused ?? []) {
+    try {
+      await doseInstanceRepo.wipeFuturePending(id)
+      cleaned += 1
+    } catch (err) {
+      logger.error(`Falha ao limpar pendentes do protocolo pausado ${id}`, err)
+    }
+  }
+  logger.info('Limpeza de pausados concluída', { cleaned })
+  return { cleaned }
+}

--- a/server/bot/scheduler.js
+++ b/server/bot/scheduler.js
@@ -1,6 +1,7 @@
 import cron from 'node-cron';
 import { createLogger } from './logger.js';
 import { checkReminders, runDailyDigest, checkPrescriptionAlerts } from './tasks.js';
+import { generateDoseInstances, cleanupPausedProtocols } from './doseInstanceScheduler.js';
 
 const logger = createLogger('Scheduler');
 
@@ -40,4 +41,14 @@ export function startPrescriptionAlerts(bot, options = {}) {
   // Run once daily at 8h to check for prescription alerts
   scheduleTask('checkPrescriptionAlerts', '0 8 * * *', () => checkPrescriptionAlerts(bot, options));
   console.log('✅ Alertas de prescrição configurados (diariamente às 8h)');
+}
+
+export function startDoseInstanceGeneration() {
+  // Motor de geração de dose_instances (ADR-048) — diário às 03:15 (baixo tráfego).
+  // Renova janelas de 30d dos protocolos ativos + limpa pendentes de pausados > 1 dia.
+  scheduleTask('generateDoseInstances', '15 3 * * *', async () => {
+    await generateDoseInstances();
+    await cleanupPausedProtocols();
+  });
+  console.log('✅ Motor de dose_instances configurado (diariamente às 3h15)');
 }

--- a/server/index.js
+++ b/server/index.js
@@ -21,7 +21,7 @@ import { handleChatbotMessage } from './bot/commands/chatbot.js';
 import { handleCallbacks } from './bot/callbacks/doseActions.js';
 import { handleConversationalCallbacks } from './bot/callbacks/conversational.js';
 import { handleInlineQueries } from './bot/inlineQuery.js';
-import { startScheduler, startDailyDigest } from './bot/scheduler.js';
+import { startScheduler, startDailyDigest, startDoseInstanceGeneration } from './bot/scheduler.js';
 import { startStockAlerts, startAdherenceReports, startTitrationAlerts, startMonthlyReport } from './bot/alerts.js';
 import { startAutoCleanup } from './services/sessionManager.js';
 import { BotFactory } from './bot/bot-factory.js';
@@ -90,6 +90,9 @@ bot.on('message', (msg) => handleChatbotMessage(bot, msg));
 // Start scheduler
 startScheduler(bot, schedulerOptions);
 startDailyDigest(bot, schedulerOptions);
+
+// Motor de geração de dose_instances (ADR-048, Fase 2)
+startDoseInstanceGeneration();
 
 // Start intelligent alerts (Phase 4)
 startStockAlerts(bot, schedulerOptions);


### PR DESCRIPTION
## Objetivo
Segunda PR da **Fase 2** (ADR-048): a geração de `dose_instances` **passa a rodar de fato**. Materializa ocorrências de dose ao criar/editar/pausar tratamentos + cron diário que renova janelas e limpa pausados.

## Escopo (S2.4 + S2.5)
- **`doseInstancePlanner.js`** (core): orquestra o gerador puro + repository de I/O. `planWindow`, `ensureInstancesUpTo` (rede lazy), `renewProtocolWindow` (cron), `computeWindowEnd`. **Compartilhado** (DRY) por cron server-side e factory client-side.
- **`doseInstanceScheduler.js`** (server/bot): cron diário **03:15** — `generateDoseInstances` renova janela 30d dos ativos; `cleanupPausedProtocols` faz wipe das pendentes de pausados >1 dia. Roda no **processo Node persistente** (R-090, sem Vercel); service_role com escopo explícito por protocolo (R-042).
- **`createProtocolRepository`** lifecycle hooks (`syncInstancesOnWrite`, **best-effort** R-245): create gera janela inicial · pause marca `skipped_paused` 24h (sem regen) · resume limpa `paused_at` · mudança de agendamento → `wipeFuturePending` + regen. Detecção usa `updates` **cru** (Zod injeta defaults).
- **`createDoseInstanceRepository`**: `setPausedAt(protocolId, ts|null)`.

## Comportamento
Geração roda silenciosa. **Sem surface user-facing** até Fase 3/4 (nenhuma UI consome `dose_instances` ainda). Idempotente (UNIQUE + ON CONFLICT DO NOTHING) + best-effort (cron + rede lazy convergem o estado).

## Testes
27 novos (planner 11 + lifecycle 5 + repo) · `validate:agent` **923/923** ✅ · lint limpo.

## SQP (R-221)
| Item | Valor |
|------|-------|
| Plataformas | Shared/Core + Backend/Infra |
| SemVer | Minor (nova capacidade) |
| Version bump | Nenhum (web 3.4.0 / mobile 0.6.3 — sem mudança visível) |
| CHANGELOG | 2 entradas [Unreleased] (Core + Backend) |
| Nota loja | N/A |
| Migration | Nenhuma (colunas já em prod desde F2.1) |

## Notas
- **R-245** (novo): geração no write-path é best-effort; cron + rede lazy são a malha de segurança.
- Geração herda **AP-181** (matcher de frequência stale p/ dias_alternados/personalizado) — 0 protocolos prod afetados; fix na Fase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AI Review Response

| Sugestão | Prio | Decisão | Commit |
|---|---|---|---|
| Paginação no cron (limite 1000 Supabase) | High | Aplicada | a9a046f3 |
| DELETE em lote (N+1) via .in() | High | Aplicada | a9a046f3 |
| Timestamp único na pausa | Medium | Aplicada | a9a046f3 |
| toIsoLike null-safe | Medium | Aplicada | a9a046f3 |

### Reauditoria S2.4 (motor) + fix anterior
| Achado | Origem | Decisão | Commit |
|---|---|---|---|
| Resume não revertia skipped_paused (toggle rápido perdia doses, viola DoD S2.5) | Auditoria interna | Corrigido | 34f2674d |
| Clamp fromTs >= now (sem pending retroativo) | Reauditoria S2.4 | Corrigido | a9a046f3 |
