### PR TITLE
feat(api): Web Push Dispatcher + PWA Deep Linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 ## [Unreleased]
 
 ### Web/PWA
+- **Push Routing** (Patch, Spec #2): Adicionado suporte a Deep Linking no PWA Web. O aplicativo agora intercepta parâmetros de busca (query params) e caminhos na inicialização para redirecionar o usuário para a view correspondente (como estoque, histórico ou tela principal) e abrir modais de tomadas individuais ou coletivas (planos/avulsos) pré-preenchidos.
 - **Wizard** (Minor, PR #601): Simplificados condicionais e labels de "comprimidos" para utilizar a unidade genérica "un." quando o medicamento for cadastrado como tal no Wizard (Steps 2 e 3).
 - **Form Wizard** (Minor, PR #601): Refatorada a label de `"Dosagem"` para `"Concentração"` no Passo 1 do wizard e formulário principal de medicamento para dirimir ambiguidades.
 - **Warning Alert** (Minor, PR #601): Adicionado alerta visual educativo condicional quando a unidade genérica `'un.'` for selecionada e a concentração for superior a `1`.
@@ -26,7 +27,8 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 - **dose_instances — motor de geração** (Minor, PR #603): Adicionado `doseInstancePlanner` (core) que orquestra a geração e persistência idempotente de ocorrências de dose, e os hooks de lifecycle de protocolo (`createProtocolRepository`) que materializam a janela ao criar/editar/pausar/religar tratamentos — best-effort (R-245). Sem impacto visível ao usuário até a Fase 3/4 (nenhuma UI consome ainda). ADR-048.
 
 ### Backend/Infra
-- **Serverless Consolidation** (Patch, PR #TBD): Refatoração para consolidação dos endpoints Vercel, combinando `api/beta-signup.js` e `api/register-webpush.js` dentro do roteador `api/users.js` para reduzir a contagem de funções consumidas do limite do plano Hobby (R-090). A rota sem uso `api/health/notifications.js` foi removida.
+- **Web Push Channel** (Patch, Spec #2): Implementado o canal de disparo `web_push` no Dispatcher Central de notificações usando chaves VAPID (`web-push` NPM). Suporta detecção proativa de erros 410 Gone / 404 Not Found para inativação instantânea de tokens inválidos na tabela `notification_devices`.
+- **Serverless Consolidation** (Patch, PR #606): Refatoração para consolidação dos endpoints Vercel, combinando `api/beta-signup.js` e `api/register-webpush.js` dentro do roteador `api/users.js` para reduzir a contagem de funções consumidas do limite do plano Hobby (R-090). A rota sem uso `api/health/notifications.js` foi removida.
 - **Telegram Bot** (Minor, PR #601): Ajustado o formatador de quantidade de tomadas do bot do Telegram para suportar "un", mantendo comprimidos ("cp") para dosagens em massa (mg/mcg/g) e melhorando líquidos ("ui") para que sejam representados de forma autônoma.
 - **dose_instances — cron de geração** (Minor, PR #603): Adicionado cron diário (03:15) no bot que renova a janela de 30 dias dos protocolos ativos e limpa pendentes de protocolos pausados há mais de 1 dia. Roda no processo Node persistente (sem consumir budget de funções Vercel). ADR-048.
 - **dose_instances — motor em produção** (Minor, PR #604): Endpoint serverless dedicado `api/generate-doses.js` (cron-job.org 1×/dia) executa o motor de geração em produção, isolado do invoke de notificações (ADR-051) — geração não compromete o caminho crítico de lembretes. Geração passa a buscar apenas protocolos "due" no banco (escala) e elimina SELECT redundante de high-water-mark. Corrige o motor que só rodava em dev via node-cron (AP-182).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dosiq/web",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -86,6 +86,50 @@ function AppInner() {
     return () => subscription.unsubscribe()
   }, [])
 
+  // Tratar navegação profunda via URL (clique em push notificações PWA)
+  // Justificativa: Precisamos de setState no useEffect para ler queries da URL no mount/auth e navegar a view
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    if (!session) return
+
+    const path = window.location.pathname
+    const params = new URLSearchParams(window.location.search)
+
+    if (path === '/stock') {
+      setCurrentView('stock')
+    } else if (path === '/history' || path === '/health-history') {
+      setCurrentView('history')
+    } else if (path === '/settings') {
+      setCurrentView('settings')
+    } else if (path === '/notifications') {
+      setCurrentView('notifications')
+    } else if (path === '/admin-dlq') {
+      setCurrentView('admin-dlq')
+    } else if (path === '/today' || path === '/') {
+      setCurrentView('dashboard')
+
+      const protocolId = params.get('protocolId')
+      if (protocolId) {
+        setDoseModalInitialValues({ protocol_id: protocolId, type: 'protocol' })
+        setIsDoseModalOpen(true)
+      } else if (params.get('bulkMode') === 'plan') {
+        const planId = params.get('planId')
+        if (planId) {
+          setDoseModalInitialValues({ treatment_plan_id: planId, type: 'plan' })
+          setIsDoseModalOpen(true)
+        }
+      } else if (params.get('bulkMode') === 'misc') {
+        const pids = params.get('protocolIds')
+        const protocolIds = pids ? pids.split(',') : []
+        if (protocolIds.length > 0) {
+          setDoseModalInitialValues({ protocol_id: protocolIds[0], type: 'protocol' })
+          setIsDoseModalOpen(true)
+        }
+      }
+    }
+  }, [session])
+  /* eslint-enable react-hooks/set-state-in-effect */
+
   if (isLoading) {
     return (
       <div className="app-container" style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -127,6 +127,11 @@ function AppInner() {
         }
       }
     }
+
+    // Limpar o caminho e query params da URL para evitar reprocessamento ou inconsistências de estado
+    if (path !== '/' || params.toString() !== '') {
+      window.history.replaceState({}, document.title, '/')
+    }
   }, [session])
   /* eslint-enable react-hooks/set-state-in-effect */
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-virtuoso": "^4.18.3",
+        "web-push": "^3.6.7",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -183,7 +184,7 @@
     },
     "apps/web": {
       "name": "@dosiq/web",
-      "version": "3.3.0",
+      "version": "3.4.1",
       "dependencies": {
         "@vercel/speed-insights": "^2.0.0",
         "vite-plugin-pwa": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-virtuoso": "^4.18.3",
+    "web-push": "^3.6.7",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/server/notifications/channels/webPushChannel.js
+++ b/server/notifications/channels/webPushChannel.js
@@ -1,0 +1,126 @@
+import webpush from 'web-push'
+
+const vapidPublicKey = process.env.VAPID_PUBLIC_KEY
+const vapidPrivateKey = process.env.VAPID_PRIVATE_KEY
+const vapidEmail = process.env.VAPID_EMAIL || 'mailto:admin@dosiq.app'
+
+if (vapidPublicKey && vapidPrivateKey) {
+  try {
+    webpush.setVapidDetails(vapidEmail, vapidPublicKey, vapidPrivateKey)
+  } catch (e) {
+    console.error('[webPushChannel] Falha ao configurar chaves VAPID:', e.message)
+  }
+}
+
+function mapDeeplinkToWebPath(deeplink) {
+  if (!deeplink) return '/'
+  let path = deeplink.replace('dosiq://', '/')
+  if (path.startsWith('/admin/dlq')) {
+    path = path.replace('/admin/dlq', '/admin-dlq')
+  }
+  return path
+}
+
+export async function sendWebPushNotification({ userId, payload, context, repositories }) {
+  const correlationId = context?.correlationId || 'unknown'
+
+  if (!vapidPublicKey || !vapidPrivateKey) {
+    console.warn('[webPushChannel] Chaves VAPID ausentes no ambiente. Ignorando envio.', { correlationId, userId })
+    return {
+      channel: 'web_push',
+      success: true, // Fail graceful
+      attempted: 0,
+      delivered: 0,
+      failed: 0,
+      deactivatedTokens: [],
+      errors: [{ message: 'VAPID keys not configured in environment' }]
+    }
+  }
+
+  const devices = await repositories.devices.listActiveByUser(userId, 'webpush')
+
+  if (devices.length === 0) {
+    console.info('[webPushChannel] sem devices ativos', { correlationId, userId })
+    return {
+      channel: 'web_push',
+      success: true,
+      attempted: 0,
+      delivered: 0,
+      failed: 0,
+      deactivatedTokens: [],
+      errors: [],
+    }
+  }
+
+  const pushPayload = JSON.stringify({
+    title: payload.title,
+    body: payload.pushBody || payload.body,
+    icon: '/app-icons/web/icon-512.png',
+    url: mapDeeplinkToWebPath(payload.deeplink)
+  })
+
+  const sendPromises = devices.map(async (device) => {
+    try {
+      const subscription = JSON.parse(device.push_token)
+      await webpush.sendNotification(subscription, pushPayload)
+      return { token: device.push_token, success: true }
+    } catch (error) {
+      console.error('[webPushChannel] Falha no push individual', { correlationId, userId, token: device.push_token, error: error.message })
+      return { token: device.push_token, success: false, error }
+    }
+  })
+
+  const settledResults = await Promise.allSettled(sendPromises)
+
+  let delivered = 0
+  let failed = 0
+  const errors = []
+  const tokensToDeactivate = []
+
+  for (const r of settledResults) {
+    if (r.status === 'rejected') {
+      failed++
+      errors.push({ message: r.reason?.message || 'Unknown settled error' })
+      continue
+    }
+
+    const { token, success, error } = r.value
+    if (success) {
+      delivered++
+    } else {
+      failed++
+      const statusCode = error.statusCode
+      errors.push({ token, code: statusCode, message: error.message })
+
+      // Se 410 (Gone) ou 404 (Not Found), o token não é mais válido
+      if (statusCode === 410 || statusCode === 404) {
+        tokensToDeactivate.push(token)
+      }
+    }
+  }
+
+  const deactivationResults = await Promise.allSettled(
+    tokensToDeactivate.map((token) => repositories.devices.deactivateByToken(token))
+  )
+
+  const deactivatedTokens = tokensToDeactivate.filter((_, i) => {
+    if (deactivationResults[i].status === 'rejected') {
+      console.error('[webPushChannel] falha ao desativar token', { correlationId, userId, token: tokensToDeactivate[i], error: deactivationResults[i].reason?.message })
+      return false
+    }
+    console.info('[webPushChannel] token desativado', { correlationId, userId, token: tokensToDeactivate[i] })
+    return true
+  })
+
+  console.info('[webPushChannel] resultado', { correlationId, userId, attempted: devices.length, delivered, failed, deactivatedTokens })
+
+  return {
+    channel: 'web_push',
+    success: failed === 0,
+    attempted: devices.length,
+    delivered,
+    failed,
+    deactivatedTokens,
+    errors
+  }
+}

--- a/server/notifications/channels/webPushChannel.js
+++ b/server/notifications/channels/webPushChannel.js
@@ -8,7 +8,7 @@ if (vapidPublicKey && vapidPrivateKey) {
   try {
     webpush.setVapidDetails(vapidEmail, vapidPublicKey, vapidPrivateKey)
   } catch (e) {
-    console.error('[webPushChannel] Falha ao configurar chaves VAPID:', e.message)
+    console.error('[webPushChannel] Falha ao configurar chaves VAPID:', e?.message || String(e))
   }
 }
 
@@ -61,12 +61,15 @@ export async function sendWebPushNotification({ userId, payload, context, reposi
 
   const sendPromises = devices.map(async (device) => {
     try {
+      if (!device?.push_token) {
+        throw new Error('Token de push ausente ou inválido')
+      }
       const subscription = JSON.parse(device.push_token)
       await webpush.sendNotification(subscription, pushPayload)
       return { token: device.push_token, success: true }
     } catch (error) {
-      console.error('[webPushChannel] Falha no push individual', { correlationId, userId, token: device.push_token, error: error.message })
-      return { token: device.push_token, success: false, error }
+      console.error('[webPushChannel] Falha no push individual', { correlationId, userId, token: device?.push_token, error: error?.message || String(error) })
+      return { token: device?.push_token, success: false, error }
     }
   })
 
@@ -89,12 +92,14 @@ export async function sendWebPushNotification({ userId, payload, context, reposi
       delivered++
     } else {
       failed++
-      const statusCode = error.statusCode
-      errors.push({ token, code: statusCode, message: error.message })
+      const statusCode = error?.statusCode
+      errors.push({ token, code: statusCode, message: error?.message || String(error) })
 
-      // Se 410 (Gone) ou 404 (Not Found), o token não é mais válido
-      if (statusCode === 410 || statusCode === 404) {
-        tokensToDeactivate.push(token)
+      // Se 410 (Gone), 404 (Not Found) ou erro de parse (SyntaxError), o token não é mais válido
+      if (statusCode === 410 || statusCode === 404 || error instanceof SyntaxError) {
+        if (token) {
+          tokensToDeactivate.push(token)
+        }
       }
     }
   }

--- a/server/notifications/dispatcher/_dispatchHelpers.js
+++ b/server/notifications/dispatcher/_dispatchHelpers.js
@@ -3,6 +3,7 @@ import { notificationLogRepository } from '../repositories/notificationLogReposi
 import { createLogger } from '../../bot/logger.js'
 import { sendTelegramNotification } from '../channels/telegramChannel.js'
 import { sendExpoPushNotification } from '../channels/expoPushChannel.js'
+import { sendWebPushNotification } from '../channels/webPushChannel.js'
 
 const logger = createLogger('DispatchHelpers')
 
@@ -13,6 +14,8 @@ export async function dispatchChannel({ channel, userId, payload, context, repos
       return await sendTelegramNotification({ userId, payload, context, bot })
     } else if (channel === 'mobile_push') {
       return await sendExpoPushNotification({ userId, payload, context, repositories, expoClient })
+    } else if (channel === 'web_push') {
+      return await sendWebPushNotification({ userId, payload, context, repositories })
     } else {
       logger.warn('canal desconhecido ignorado', { correlationId, channel })
       return null

--- a/server/notifications/dispatcher/dispatchNotification.test.js
+++ b/server/notifications/dispatcher/dispatchNotification.test.js
@@ -1,8 +1,16 @@
 // Testes para dispatchNotification
 // Cobre coexistência de canais, isolamento de falhas e casos-limite
 
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest'
 import { dispatchNotification } from './dispatchNotification.js'
+
+const mockSendNotification = vi.fn()
+vi.mock('web-push', () => ({
+  default: {
+    setVapidDetails: vi.fn(),
+    sendNotification: (...args) => mockSendNotification(...args)
+  }
+}))
 
 vi.mock('../repositories/notificationLogRepository.js', () => ({
   notificationLogRepository: {
@@ -59,8 +67,14 @@ vi.mock('../../services/supabase.js', () => ({
   },
 }))
 
+beforeAll(() => {
+  process.env.VAPID_PUBLIC_KEY = 'mock-public-key'
+  process.env.VAPID_PRIVATE_KEY = 'mock-private-key'
+})
+
 afterEach(() => {
   vi.clearAllMocks()
+  mockSendNotification.mockReset()
 })
 
 describe('dispatchNotification', () => {
@@ -177,5 +191,54 @@ describe('dispatchNotification', () => {
     expect(result.channels[0].attempted).toBe(0)
     expect(result.totalDelivered).toBe(0)
     expect(mockExpoClient.sendPushNotificationsAsync).not.toHaveBeenCalled()
+  })
+
+  // Caso 6: web_push — entrega com sucesso
+  it('caso 6: web_push — entrega com sucesso', async () => {
+    mockSendNotification.mockResolvedValue({ statusCode: 201 })
+    mockRepositories.devices.listActiveByUser.mockResolvedValue([{ push_token: '{"endpoint":"https://fcm.googleapis.com","keys":{"p256dh":"abc","auth":"123"}}' }])
+
+    const result = await dispatchNotification({
+      userId: 'user-6',
+      kind: 'dose_reminder',
+      payload: mockPayload,
+      channels: ['web_push'],
+      context: makeContext(),
+      repositories: mockRepositories,
+      bot: mockBot,
+      expoClient: mockExpoClient,
+    })
+
+    expect(result.totalDelivered).toBe(1)
+    expect(result.totalFailed).toBe(0)
+    expect(result.channels[0].channel).toBe('web_push')
+    expect(mockSendNotification).toHaveBeenCalled()
+  })
+
+  // Caso 7: web_push com erro 410 (Gone) desativa o token
+  it('caso 7: web_push com erro 410 (Gone) desativa o token', async () => {
+    const error = new Error('Subscription no longer active')
+    error.statusCode = 410
+    mockSendNotification.mockRejectedValue(error)
+    
+    const mockToken = '{"endpoint":"https://fcm.googleapis.com","keys":{"p256dh":"bad","auth":"456"}}'
+    mockRepositories.devices.listActiveByUser.mockResolvedValue([{ push_token: mockToken }])
+    mockRepositories.devices.deactivateByToken.mockResolvedValue()
+
+    const result = await dispatchNotification({
+      userId: 'user-7',
+      kind: 'dose_reminder',
+      payload: mockPayload,
+      channels: ['web_push'],
+      context: makeContext(),
+      repositories: mockRepositories,
+      bot: mockBot,
+      expoClient: mockExpoClient,
+    })
+
+    expect(mockRepositories.devices.deactivateByToken).toHaveBeenCalledWith(mockToken)
+    expect(result.channels[0].success).toBe(false)
+    expect(result.channels[0].deactivatedTokens).toContain(mockToken)
+    expect(result.totalFailed).toBe(1)
   })
 })


### PR DESCRIPTION
# 📦 feat(api): Web Push Dispatcher + PWA Deep Linking

## 🎯 Resumo

Esta PR implementa o canal de entrega `web_push` no Dispatcher Central de notificações (Camada L3) e adiciona suporte a deep linking e pré-preenchimento de tomadas no PWA Web para habilitar o fluxo completo de notificações PWA.

---

## 📋 Tarefas Implementadas

### 🔔 Central Notification Dispatcher (L3)
- [x] Criação de `server/notifications/channels/webPushChannel.js` integrando chaves VAPID (`web-push` NPM) e tratamento de erros 410 (Gone) / 404 (Not Found) para desativação instantânea de tokens inválidos na tabela `notification_devices`.
- [x] Integração do canal `web_push` no despachador central `server/notifications/dispatcher/_dispatchHelpers.js`.
- [x] Cobertura de testes unitários robustos em `server/notifications/dispatcher/dispatchNotification.test.js` (envio bem-sucedido e desativação de token por 410 Gone).

### 🌐 PWA Web Client
- [x] Adicionado interceptador de deep links em `apps/web/src/App.jsx` usando um hook `useEffect` com dependência em `session`.
- [x] Suporte à abertura direta das views: `/stock` (estoque), `/history` (histórico), `/settings` (configurações), `/notifications` (inbox), `/admin-dlq` (administração de DLQ) e `/today` ou `/` (dashboard).
- [x] Suporte à abertura automatizada do `DoseRegisterModal` pré-preenchido para tomadas individuais (via `protocolId` e `planId`) e suporte preliminar a tomadas em lote (via `protocolIds` no modo `misc`).
- [x] Correção do bypass de ESLint com justificativa clara e robusta antes da declaração de `eslint-disable react-hooks/set-state-in-effect`.

### 📦 Configurações e Versionamento
- [x] Adicionada dependência `"web-push": "^3.6.7"` ao `package.json` raiz.
- [x] Versionamento do `@dosiq/web` incrementado para `3.4.2` em `apps/web/package.json`.
- [x] Atualização de `CHANGELOG.md` na seção `[Unreleased]` (adicionando entradas para Web/PWA e Backend/Infra sob a regra R-221).

---

## 🔧 Arquivos Principais

```
server/
├── notifications/
│   ├── channels/
│   │   └── webPushChannel.js               # Canal de entrega Web Push via NPM web-push
│   └── dispatcher/
│       ├── _dispatchHelpers.js             # Registro do canal web_push no despachador central
│       └── dispatchNotification.test.js    # Testes unitários para envio e desativação de tokens
apps/
└── web/
    └── src/
        └── App.jsx                         # Roteamento de deep linking e pré-preenchimento no PWA
```

---

## ✅ Checklist de Verificação

### Código
- [x] Todos os testes passam (`npm run test:critical` - 932 passed)
- [x] Lint sem erros (`npm run lint` - 0 errors)
- [x] Build bem-sucedido (`npm run build` - PWA builds cleanly)

### Funcionalidade
- [x] Rotas do PWA interceptam caminhos e atualizam `currentView` dinamicamente no carregamento.
- [x] Parâmetros de consulta (query params) abrem modal de dose com valores corretos (camelCase to snake_case mapping).
- [x] Dispatcher central orquestra disparos em lote usando `web_push` para os dispositivos registrados.

---

## 🚀 Como Testar

```bash
# 1. Executar testes de dispatcher e integração
rtk npm run test:critical

# 2. Iniciar PWA localmente
rtk npm run dev
```

**Resultado esperado:**
- Os testes em `dispatchNotification.test.js` cobrem o envio e expiração/desativação de tokens e passam.
- Acessar `http://localhost:5173/stock` navega diretamente para o Estoque.
- Acessar `http://localhost:5173/today?protocolId=xxx` inicializa no Dashboard e abre o modal de dose pré-selecionando o protocolo.

---

## 🔗 Issues Relacionadas

- Related to Spec #2 (Web Push Dispatcher Integration)

---

## 🏷️ Informações de Versionamento

**Tipo:** Patch (Spec #2)
**Plataformas afetadas:** Web/PWA, Backend/Infra
**Versão anterior:** web 3.4.1
**Versão sugerida:** web 3.4.2
**Changelog:** CHANGELOG.md [Unreleased] atualizado

---

## 🤖 AI Review Response

| Sugestão | Prioridade | Decisão | Detalhe |
|----------|------------|---------|---------|
| Limpar URL com `replaceState` após deep link | High | **Aplicado** | Commit bb9c752f |
| Optional chaining `e?.message` no setup VAPID | Medium | **Aplicado** | Commit bb9c752f |
| Validação de existência de `device?.push_token` no loop | Medium | **Aplicado** | Commit bb9c752f |
| Tratar `SyntaxError` de JSON para desativar token inválido | Medium | **Aplicado** | Commit bb9c752f |

---

/cc @reviewers
/cc @gemini-code-assist
