### PR TITLE
fix(notifications): adiciona time/scheduledTime ao dispatch de instances

### DIFF
--- a/server/bot/_reminderHelpers.js
+++ b/server/bot/_reminderHelpers.js
@@ -200,8 +200,13 @@ async function _checkRemindersFromInstances(dispatcher, correlationId) {
           parseISO(windowStart).toLocaleString('en-US', { timeZone: userTz, hour: 'numeric', hour12: false }),
           10
         );
-        // HH:MM extraído da janela UTC — mesmo padrão do caminho via protocolos
-        const currentHHMM = windowStart.slice(11, 16);
+        // HH:MM no fuso do usuário (scheduled_for é UTC; display deve ser local)
+        const currentHHMM = new Intl.DateTimeFormat('en-GB', {
+          timeZone: userTz,
+          hour: '2-digit',
+          minute: '2-digit',
+          hour12: false,
+        }).format(parseISO(windowStart));
 
         for (const block of blocks) {
           const instanceIdsInBlock = block.doses.map(d => d.instanceId).filter(Boolean);

--- a/server/bot/_reminderHelpers.js
+++ b/server/bot/_reminderHelpers.js
@@ -200,6 +200,8 @@ async function _checkRemindersFromInstances(dispatcher, correlationId) {
           parseISO(windowStart).toLocaleString('en-US', { timeZone: userTz, hour: 'numeric', hour12: false }),
           10
         );
+        // HH:MM extraído da janela UTC — mesmo padrão do caminho via protocolos
+        const currentHHMM = windowStart.slice(11, 16);
 
         for (const block of blocks) {
           const instanceIdsInBlock = block.doses.map(d => d.instanceId).filter(Boolean);
@@ -210,13 +212,13 @@ async function _checkRemindersFromInstances(dispatcher, correlationId) {
             kind = 'dose_reminder_by_plan';
             data = {
               planId: block.planId, planName: block.planName,
-              hour: currentHour, doses: block.doses,
+              scheduledTime: currentHHMM, hour: currentHour, doses: block.doses,
               protocolIds: block.doses.map(d => d.protocolId),
             };
           } else if (block.kind === 'misc') {
             kind = 'dose_reminder_misc';
             data = {
-              hour: currentHour, doses: block.doses,
+              scheduledTime: currentHHMM, hour: currentHour, doses: block.doses,
               protocolIds: block.doses.map(d => d.protocolId),
             };
           } else {
@@ -226,6 +228,7 @@ async function _checkRemindersFromInstances(dispatcher, correlationId) {
               medicineName: dose.medicineName,
               protocolId: dose.protocolId,
               medicineId: dose.medicineId,
+              time: currentHHMM,
               dosagePerIntake: dose.dosagePerIntake,
               dosageUnit: dose.dosageUnit,
             };


### PR DESCRIPTION
## Problema

Caminho `_checkRemindersFromInstances` (Spec 011) omitia `time` e `scheduledTime` no objeto `data` passado ao dispatcher. `doseReminderDataSchema` exige `time: string` → Zod rejeitava com `"Este campo é obrigatório"` → notificação falhava em produção.

**Erro em prod:**
```
Error: Invalid data for dose_reminder: [{"expected":"string","code":"invalid_type","path":["time"],"message":"Este campo é obrigatório"}]
  at formatDoseReminder (buildNotificationPayload.js:161)
```

## Root Cause

`_processUserReminderBlock` (caminho via protocolos) passava `time: currentHHMM`. O novo caminho via instances foi adicionado no Sprint 011 sem incluir este campo.

## Fix

Deriva `currentHHMM = windowStart.slice(11, 16)` (mesmo padrão UTC do caminho via protocolos) e injeta em todos os três cases:
- `dose_reminder` → `time: currentHHMM`
- `dose_reminder_by_plan` → `scheduledTime: currentHHMM`
- `dose_reminder_misc` → `scheduledTime: currentHHMM`

## Arquivos

- `server/bot/_reminderHelpers.js` — 1 arquivo, +5 -2

## Test plan

- [ ] Deploy para prod e verificar próximo cron `/api/notify` sem erro `Invalid data for dose_reminder`
- [ ] Log deve mostrar `instância(s) devida(s)` → dispatch sem erro

🤖 Generated with [Claude Code](https://claude.com/claude-code)