### PR TITLE
fix(infra): passa ws como transport ao Supabase client (Node.js < 22)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-dom": "19.0.0",
         "react-virtuoso": "^4.18.3",
         "web-push": "^3.6.7",
+        "ws": "^8.21.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -21526,9 +21527,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-dom": "19.0.0",
     "react-virtuoso": "^4.18.3",
     "web-push": "^3.6.7",
+    "ws": "^8.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/server/services/supabase.js
+++ b/server/services/supabase.js
@@ -2,6 +2,7 @@ import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { createClient } from '@supabase/supabase-js';
+import ws from 'ws';
 
 // Carrega dotenv apenas em ambiente de desenvolvimento (não em Vercel)
 if (process.env.NODE_ENV !== 'production' && !process.env.VERCEL) {
@@ -20,5 +21,8 @@ if (!supabaseUrl || (!supabaseAnonKey && !supabaseServiceKey)) {
   throw new Error('Variáveis de ambiente do Supabase não configuradas');
 }
 
-// Em ambiente de servidor, preferimos a service_role key para ignorar RLS
-export const supabase = createClient(supabaseUrl, supabaseServiceKey || supabaseAnonKey);
+// Em ambiente de servidor, preferimos a service_role key para ignorar RLS.
+// Node.js < 22 não tem WebSocket nativo — ws passado como transport (supabase-js 2.90+).
+export const supabase = createClient(supabaseUrl, supabaseServiceKey || supabaseAnonKey, {
+  realtime: { transport: ws },
+});


### PR DESCRIPTION
## Problema

`supabase-js` 2.90+ requer WebSocket nativo (Node 22+) ou pacote `ws` passado via `realtime.transport`. Vercel roda Node 20 → o módulo `server/services/supabase.js` falha no import, derrubando qualquer função serverless que o importa (incluindo `generate-doses` e `notify`).

**Erro em prod:**
```
Error: Node.js 20 detected without native WebSocket support.
Suggested solution: install "ws" and provide it via transport option.
  at server/services/supabase.js:24
```

## Fix

- `server/services/supabase.js`: `import ws from 'ws'` + `realtime: { transport: ws }` no `createClient`
- `package.json`: `ws ^8.21.0` como dependência direta (era transitiva — risco de ser removida em hoist futuro)

## Arquivos

- `server/services/supabase.js` (+3 linhas)
- `package.json` / `package-lock.json`

## Test plan

- [ ] Deploy Vercel → verificar `generate-doses` sem erro de WebSocket
- [ ] Verificar cron `notify` também funciona (mesmo client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)