### PR TITLE
fix(server): ws transport em todos os createClient serverless (Node 20)

### DIFF
--- a/api/dlq.js
+++ b/api/dlq.js
@@ -2,6 +2,7 @@
 // Dead Letter Queue Admin API - Router consolidado
 // Rotas: GET /api/dlq (list) | POST /api/dlq?action=retry&id=:id | POST /api/dlq?action=discard&id=:id
 import { createClient } from '@supabase/supabase-js';
+import ws from 'ws';
 import { DLQStatus } from '../server/services/deadLetterQueue.js';
 import { verifyAdminAccess } from '../server/utils/auth.js';
 import { handleRetry } from './dlq/_handlers/retry.js';
@@ -18,7 +19,7 @@ const adminChatId = process.env.ADMIN_CHAT_ID;
  */
 async function handleList(req, res) {
   // Create Supabase client with service role key (bypasses RLS for admin access)
-  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+  const supabase = createClient(supabaseUrl, supabaseServiceKey, { realtime: { transport: ws } });
 
   try {
     // Parse query parameters

--- a/api/dlq.js
+++ b/api/dlq.js
@@ -13,13 +13,14 @@ const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
 const adminChatId = process.env.ADMIN_CHAT_ID;
 
+// Singleton clients — instanciados no module scope para reuso em warm invocations (R-089)
+const supabase = createClient(supabaseUrl, supabaseServiceKey, { realtime: { transport: ws } });
+
 /**
  * Handler: list (GET /api/dlq)
  * Lista notificações falhas com paginação
  */
 async function handleList(req, res) {
-  // Create Supabase client with service role key (bypasses RLS for admin access)
-  const supabase = createClient(supabaseUrl, supabaseServiceKey, { realtime: { transport: ws } });
 
   try {
     // Parse query parameters

--- a/api/dlq/_handlers/discard.js
+++ b/api/dlq/_handlers/discard.js
@@ -2,6 +2,7 @@
 // Dead Letter Queue Handler - Discard a failed notification
 // NOTA: Este handler é chamado pelo router api/dlq.js, que já faz a autenticação
 import { createClient } from '@supabase/supabase-js';
+import ws from 'ws';
 import { createLogger } from '../../../server/bot/logger.js';
 import { getServerTimestamp } from '../../../server/utils/dateUtils.js';
 
@@ -30,7 +31,7 @@ export async function handleDiscard(req, res) {
   }
 
   // Create Supabase client with service role key
-  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+  const supabase = createClient(supabaseUrl, supabaseServiceKey, { realtime: { transport: ws } });
 
   try {
     // Fetch the failed notification

--- a/api/dlq/_handlers/retry.js
+++ b/api/dlq/_handlers/retry.js
@@ -1,6 +1,7 @@
 // api/dlq/_handlers/retry.js
 // Dead Letter Queue Handler - Retry a failed notification via Dispatcher (ADR-030)
 import { createClient } from '@supabase/supabase-js';
+import ws from 'ws';
 import { createLogger } from '../../../server/bot/logger.js';
 import { dispatchNotification } from '../../../server/notifications/dispatcher/dispatchNotification.js';
 import { Expo } from 'expo-server-sdk';
@@ -114,7 +115,7 @@ export async function handleRetry(req, res) {
 
   if (!id) return res.status(400).json({ error: 'Missing notification ID' });
 
-  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+  const supabase = createClient(supabaseUrl, supabaseServiceKey, { realtime: { transport: ws } });
   const expoClient = new Expo({ accessToken: process.env.EXPO_ACCESS_TOKEN });
 
   try {

--- a/api/notify.js
+++ b/api/notify.js
@@ -13,6 +13,7 @@ import {
 } from '../server/bot/tasks.js';
 import { dispatchNotification } from '../server/notifications/dispatcher/dispatchNotification.js';
 import { createClient } from '@supabase/supabase-js';
+import ws from 'ws';
 import { Expo } from 'expo-server-sdk';
 import { getServerTimestamp, getNow, getSaoPauloTime } from '../server/utils/dateUtils.js';
 
@@ -21,7 +22,8 @@ const logger = createLogger('CronNotify');
 // Singleton clients — instanciados no module scope para reuso em warm invocations (R-089)
 const supabase = createClient(
   process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { realtime: { transport: ws } }
 );
 const expoClient = new Expo({ accessToken: process.env.EXPO_ACCESS_TOKEN });
 

--- a/api/share.js
+++ b/api/share.js
@@ -10,6 +10,7 @@
 
 import { z } from 'zod'
 import { createClient } from '@supabase/supabase-js'
+import ws from 'ws'
 import { createHash } from 'crypto'
 import { getServerTimestamp, addHours } from '../server/utils/dateUtils.js'
 
@@ -209,7 +210,7 @@ async function verifyAuth(token) {
   }
 
   try {
-    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { realtime: { transport: ws } })
     const { data, error } = await supabase.auth.getUser(token)
 
     if (error || !data.user) {

--- a/api/users/_handlers/beta-signup.js
+++ b/api/users/_handlers/beta-signup.js
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
+import ws from 'ws'
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const ALLOWED_FEATURES = new Set(['android', 'ios', 'other', 'caregiver_mode'])
@@ -35,7 +36,8 @@ export async function handleBetaSignup(req, res) {
 
     const supabase = createClient(
       process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL,
-      process.env.SUPABASE_SERVICE_ROLE_KEY
+      process.env.SUPABASE_SERVICE_ROLE_KEY,
+      { realtime: { transport: ws } }
     )
 
     const { error } = await supabase

--- a/api/users/_handlers/register-webpush.js
+++ b/api/users/_handlers/register-webpush.js
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
+import ws from 'ws'
 import { notificationDeviceRepository } from '../../../server/notifications/repositories/notificationDeviceRepository.js'
 
 export async function handleRegisterWebpush(req, res) {
@@ -8,7 +9,8 @@ export async function handleRegisterWebpush(req, res) {
 
     const supabase = createClient(
       process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL,
-      process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY
+      process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY,
+      { realtime: { transport: ws } }
     )
 
     const { data: { user }, error: authError } = await supabase.auth.getUser(token)

--- a/server/notifications/repositories/notificationDeviceRepository.js
+++ b/server/notifications/repositories/notificationDeviceRepository.js
@@ -3,12 +3,14 @@
 // Rastreia Expo tokens, info do dispositivo e status de ativação
 
 import { createClient } from '@supabase/supabase-js'
+import ws from 'ws'
 import { z } from 'zod'
 import { getNow, getServerTimestamp } from '../../utils/dateUtils.js'
 
 const supabase = createClient(
   process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { realtime: { transport: ws } }
 )
 
 const upsertSchema = z.object({

--- a/server/notifications/repositories/notificationPreferenceRepository.js
+++ b/server/notifications/repositories/notificationPreferenceRepository.js
@@ -2,13 +2,15 @@
 // Lê de user_settings.notification_preference e verifica telegram_chat_id
 
 import { createClient } from '@supabase/supabase-js'
+import ws from 'ws'
 import { z } from 'zod'
 
 const notificationPreferenceSchema = z.enum(['telegram', 'mobile_push', 'both', 'none'])
 
 const supabase = createClient(
   process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { realtime: { transport: ws } }
 )
 
 export const notificationPreferenceRepository = {

--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -1,6 +1,7 @@
 // server/utils/auth.js
 // Utilitário compartilhado de verificação de acesso administrativo
 import { createClient } from '@supabase/supabase-js';
+import ws from 'ws';
 import { createLogger } from '../bot/logger.js';
 
 const logger = createLogger('AdminAuth');
@@ -24,7 +25,8 @@ export async function verifyAdminAccess(authHeader) {
   const supabase = createClient(supabaseUrl, supabaseAnonKey, {
     global: {
       headers: { Authorization: `Bearer ${token}` }
-    }
+    },
+    realtime: { transport: ws },
   });
 
   try {


### PR DESCRIPTION
## Problema

PR #636 corrigiu apenas \`server/services/supabase.js\`. Os demais módulos que chamam \`createClient\` diretamente continuavam crashando em Node 20 (sem WebSocket nativo) — evidenciado pelo erro em \`api/notify.js\` após o merge.

## Causa

\`@supabase/supabase-js\` ≥ 2.91 bundla \`realtime-js\` que verifica \`WebSocket\` global **no construtor**, mesmo sem uso de Realtime. Node 20 (Vercel) não tem \`WebSocket\` nativo.

## Arquivos corrigidos (9)

| Arquivo | Tipo |
|---------|------|
| \`api/notify.js\` | Cron orchestrator |
| \`api/dlq.js\` | DLQ router |
| \`api/share.js\` | PDF share |
| \`api/dlq/_handlers/retry.js\` | DLQ handler |
| \`api/dlq/_handlers/discard.js\` | DLQ handler |
| \`api/users/_handlers/beta-signup.js\` | Beta signup |
| \`api/users/_handlers/register-webpush.js\` | WebPush register |
| \`server/notifications/repositories/notificationDeviceRepository.js\` | Repo |
| \`server/notifications/repositories/notificationPreferenceRepository.js\` | Repo |
| \`server/utils/auth.js\` | Admin auth |

Fix: `realtime: { transport: ws }` em cada `createClient` + `import ws from 'ws'`.

**AP-210 / AP-212 / R-262 / R-264**

🤖 Generated with [Claude Code](https://claude.com/claude-code)