### PR TITLE
chore(infra): fixar versao do node em 22.x

### DIFF
--- a/.agent/memory/rules/infra_and_deploy/R-263.md
+++ b/.agent/memory/rules/infra_and_deploy/R-263.md
@@ -11,7 +11,7 @@ sprint: "2026-W23"
 
 ## Regra
 
-Declarar `"engines": { "node": ">=22.0.0" }` no `package.json` raiz **e** `NODE_VERSION=22` nas env vars da Vercel. Sem essa âncora, bumps silenciosos de runtime da Vercel mudam o ambiente de execução sem sinal visível no código ou no CI.
+Declarar `"engines": { "node": "22.x" }` no `package.json` raiz **e** `NODE_VERSION=22` nas env vars da Vercel. Sem essa âncora, bumps silenciosos de runtime da Vercel mudam o ambiente de execução sem sinal visível no código ou no CI.
 
 ## Por que
 
@@ -21,7 +21,7 @@ Vercel atualiza o runtime padrão periodicamente. Uma função que funcionava em
 
 ```json
 // package.json raiz
-"engines": { "node": ">=22.0.0" }
+"engines": { "node": "22.x" }
 ```
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 ## [Unreleased]
 
 ### Infra
-- **Upgrade para Node.js 22 LTS e CI Hardening** (Patch, apps/web 4.1.3→**4.1.4**):
-  - Atualizado o runtime do projeto do Node 20 para o Node 22 LTS nos ambientes local, CI e Vercel.
+- **Ancoragem rígida no Node 22 e CI Hardening** (Patch, apps/web 4.1.3→**4.1.5**):
+  - Atualizado o runtime do projeto do Node 20 para o Node 22 LTS nos ambientes local, CI e Vercel, fixando a restrição em `"22.x"` no `package.json` raiz para evitar upgrades silenciosos indesejados da Vercel para a versão 24.
   - Atualizado `actions/github-script` de `v7` para `v8` em todos os workflows do GitHub Actions para eliminar deprecation warnings de Node 20.
   - Substituída a action de terceiros `tj-actions/changed-files` por um script Git nativo com `git diff` no workflow de testes para mitigação de riscos de supply chain (adicionando `fetch-depth: 0` ao checkout do lint job).
   - Implementado smoke test de cold start (`scripts/smoke-server.mjs`) que valida as importações de módulos críticos de backend/serverless (Supabase, Bot Factory, DLQ e canais de notificação) integrado ao pipeline de CI.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dosiq/web",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "4.1.0",
   "type": "module",
   "engines": {
-    "node": ">=22.0.0"
+    "node": "22.x"
   },
   "workspaces": [
     "apps/*",

--- a/plans/PLAN_SERVER_REGRESSION_COVERAGE.md
+++ b/plans/PLAN_SERVER_REGRESSION_COVERAGE.md
@@ -59,7 +59,7 @@ Adicionado ao processo de bump de `@supabase/supabase-js` ou outras libs com sub
 
 ```json
 "engines": {
-  "node": ">=22.0.0"
+  "node": "22.x"
 }
 ```
 

--- a/plans/specs/024-node22-upgrade/spec.md
+++ b/plans/specs/024-node22-upgrade/spec.md
@@ -95,7 +95,7 @@ Então o smoke test deve rodar automaticamente
 
 | ID | Requisito | US |
 |----|-----------|:--:|
-| FR-01 | Declarar `engines.node >= 22.0.0` em `package.json` raiz | US1 |
+| FR-01 | Declarar `engines.node: 22.x` em `package.json` raiz | US1 |
 | FR-02 | Criar `.nvmrc` com valor `22` | US1 |
 | FR-03 | Setar `NODE_VERSION=22` na Vercel via CLI para prod/preview/dev | US1 |
 | FR-04 | Mudar `NODE_VERSION: '20'` → `'22'` em `test.yml` e `gemini-review.yml` | US2 |
@@ -112,7 +112,7 @@ Então o smoke test deve rodar automaticamente
 | ID | Critério | Verificação | Gate |
 |----|----------|-------------|:----:|
 | SC-01 | `.nvmrc` contém `22` | `cat .nvmrc` | G1 |
-| SC-02 | `package.json` engines ≥ 22 | `grep engines package.json` | G1 |
+| SC-02 | `package.json` engines == 22.x | `grep engines package.json` | G1 |
 | SC-03 | Vercel NODE_VERSION = 22 | `vercel env ls` | G1 |
 | SC-04 | CI: NODE_VERSION '22' em workflows | `grep NODE_VERSION .github/workflows/*.yml` | G1 |
 | SC-05 | CI: zero ocorrências de `github-script@v7` | `grep 'github-script@v7' .github/workflows/*.yml` → vazio | G1 |


### PR DESCRIPTION
# 📦 chore(infra): fixar versao do node em 22.x

## 🎯 Resumo

Esta PR fixa rigidamente a versão do runtime Node.js em `22.x` (LTS ativo) no `package.json` raiz do monorepo. Isso impede que a Vercel atualize silenciosamente o ambiente de execução serverless para o Node 24, mantendo a consistência com os ambientes de desenvolvimento local e de CI.

---

## 📋 Tarefas Implementadas

### ✅ Infraestrutura e Configuração
- [x] Restrição rígida de `engines.node` alterada de `">=22.0.0"` para `"22.x"` no `package.json` raiz.
- [x] Atualização da versão do `@dosiq/web` de `4.1.4` para `4.1.5` (`apps/web/package.json`).
- [x] Atualização da regra de infraestrutura e deployment `R-263` (`.agent/memory/rules/infra_and_deploy/R-263.md`) refletindo o lock `"22.x"`.
- [x] Ajustes nos documentos de especificação (`plans/specs/024-node22-upgrade/spec.md`) e plano de regressão (`plans/PLAN_SERVER_REGRESSION_COVERAGE.md`).
- [x] Adicionado registro no `CHANGELOG.md`.

---

## 🔧 Arquivos Principais

```
dosiq/
├── package.json                                    # Restrição engines.node definida para "22.x"
├── apps/web/package.json                           # Bump de versão para 4.1.5
├── CHANGELOG.md                                    # Log de alterações em português
├── .agent/memory/rules/infra_and_deploy/R-263.md   # Atualização da regra R-263
└── plans/
    ├── PLAN_SERVER_REGRESSION_COVERAGE.md          # Atualização de referência de engine no doc de regressão
    └── specs/024-node22-upgrade/spec.md            # Atualização de critérios de aceitação e especificação
```

---

## ✅ Checklist de Verificação

### Código
- [x] Todos os testes passam (`rtk npm run validate:agent`)
- [x] Lint sem erros (`rtk npm run lint`)
- [x] Build bem-sucedido (`rtk npm run build`)

---

## 🚀 Como Testar

```bash
# 1. Obter a branch local
git checkout chore/lock-node-22

# 2. Executar os testes críticos e validação de CI
rtk npm run validate:agent

# 3. Rodar o linter
rtk npm run lint
```

**Resultado esperado:**
- Todos os testes passam localmente.
- O build de produção funciona normalmente.

---

## 🏷️ Informações de Versionamento

**Tipo:** Patch
**Plataformas afetadas:** Backend/Infra / Web/PWA
**Versão anterior:** web 4.1.4
**Versão sugerida:** web 4.1.5
**Changelog:** CHANGELOG.md atualizado

/cc @reviewers
/cc @gemini-code-assist
