### PR TITLE
fix(server): adicionar snooze no actionSchema do Zod (Spec 025)

### DIFF
--- a/server/notifications/payloads/_payloadSchemas.js
+++ b/server/notifications/payloads/_payloadSchemas.js
@@ -82,7 +82,7 @@ export const kindSchema = z.enum([
 
 // Schemas para ações interativas (Gate 4 preliminar)
 export const actionSchema = z.object({
-  id: z.enum(['take', 'skip', 'take_plan', 'take_misc']),
+  id: z.enum(['take', 'skip', 'take_plan', 'take_misc', 'snooze']),
   label: z.string(),
   params: z.record(z.string(), z.unknown()).optional()
 });


### PR DESCRIPTION
# 📦 fix(server): adicionar snooze no actionSchema do Zod (Spec 025)

## 🎯 Resumo

Esta PR corrige a falha de validação do Zod no servidor Vercel. A ação `snooze` foi adicionada à lista de ações válidas no payload de lembrete de dose, mas o `actionSchema` em `_payloadSchemas.js` não continha o valor `'snooze'` no enum de IDs de ação, fazendo com que o cron falhasse ao despachar notificações unitárias.

---

## 📋 Tarefas Implementadas

### ✅ Correção do Zod Schema
- [x] Adicionado `'snooze'` ao enum de IDs de ação no `actionSchema` em [_payloadSchemas.js](file:///Users/coelhotv/git/dosiq/server/notifications/payloads/_payloadSchemas.js).

### ✅ Validação
- [x] Rodados os testes de payload do servidor especificamente com o comando `npx vitest run server/notifications/payloads/__tests__/buildNotificationPayload.test.js`. Todos os testes agora passam com sucesso.

---

## 🔧 Arquivos Principais

```
server/
└── notifications/
    └── payloads/
        └── _payloadSchemas.js      # Adicionado 'snooze' ao actionSchema
```

---

/cc @reviewers
/cc @gemini-code-assist
