### PR TITLE
feat(notifications): grouping local alarms by plan and evolve adherence reports (Spec 025)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ## [Unreleased]
 
+### Mobile (0.12.0 → 0.13.0)
+- **Alarmes Críticos Locais, Supressão de Pushes e Melhoria de Usabilidade** (Minor, Spec 025):
+  - Habilitada a flag `native_alarm_enabled` por padrão para iOS e Android para supressão automática de pushes remotos de doses críticas e prevenção de duplicidades.
+  - Implementado o agrupamento local de alarmes no Notifee (`useAlarmScheduler.js`), consolidando múltiplas doses críticas do mesmo minuto em um único trigger.
+  - Atualizada a tela cheia de alarme (`AlarmFullScreen.jsx`) e as ações rápidas (`quickDoseRegistration.js`) para suportar visualização e confirmação/descarte em lote.
+  - Ajustadas as cópias de exibição do alarme local em `alarmService.js` para usar o padrão clínico customizado para doses críticas (essenciais) de forma coerente.
+  - Integrada a solicitação contextual de permissões de push (`enablePushAtIntent`) ao toggle de alarme essencial do formulário de protocolos (`ProtocolFormBody.jsx`), incluindo modais de aviso customizadas para Xiaomi (HyperOS/MIUI) e Android 14+.
+  - Mapeado o deep link `'history'` para a tela correta de Histórico de Doses (`ROUTES.DOSE_HISTORY`) nas telas de inbox e no hook de recebimento de notificações.
+  - Corrigido o canal de áudio crítico do Android bumpado para `dose-alarm-critical-v2` e direcionado ao som `alarm_dose` para evitar o som padrão do sistema (como gotas no Xiaomi).
+  - Substituído o erro console.error obstrutivo no setup do token de push por console.warn no hook `usePushNotifications.js` para evitar a tela de erro no ambiente de desenvolvimento que cobria a tela de alarme.
+  - **Nota de loja relevante:** "Novo: Lembretes mais inteligentes para medicamentos essenciais. Se você tem mais de um remédio no mesmo horário, o alarme agora toca apenas uma vez e permite confirmar todos de uma vez só."
+
+### Server
+- **Divisão de blocos de notificação no Cron, Preferências do Bot e Novo Copy Clínico** (Minor, Spec 025):
+  - Modificado o cron do backend (`_reminderHelpers.js`) para pré-separar instâncias críticas e normais antes de agrupar, evitando o silenciamento de medicamentos normais em blocos mistos.
+  - Atualizado o comando `/start` do bot do Telegram para configurar `channel_telegram_enabled = true` e atualizar `notification_preference` de forma consistente no banco de dados.
+  - Refatorado o copy das notificações (`buildNotificationPayload.js`) para formato clínico acolhedor e estruturado com concentração e unidade em lembretes unitários no Telegram e Push.
+  - Integrado o suporte completo de Soneca (+5 min) e Skip (Pular) para o bot do Telegram via callback query, manipulando as instâncias de dose no banco.
+
 ### Infra
 - **Ancoragem rígida no Node 22 e CI Hardening** (Patch, apps/web 4.1.3→**4.1.5**):
   - Atualizado o runtime do projeto do Node 20 para o Node 22 LTS nos ambientes local, CI e Vercel, fixando a restrição em `"22.x"` no `package.json` raiz para evitar upgrades silenciosos indesejados da Vercel para a versão 24.

--- a/api/notify.js
+++ b/api/notify.js
@@ -264,7 +264,7 @@ async function _executeCronJobs(notificationDispatcher, bot, correlationId, spDa
   results.push('daily_adherence_report');
 
   // 3. Tasks at 09:00
-  if (currentHour === 9 && currentMinute === 0) {
+  if (currentHour === 10 && currentMinute === 0) {
     await withCorrelation(
       (context) => checkStockAlerts(bot, { ...context, notificationDispatcher }),
       { correlationId, jobType: 'stock_alerts' }
@@ -287,8 +287,8 @@ async function _executeCronJobs(notificationDispatcher, bot, correlationId, spDa
     results.push('titration_alerts');
   }
 
-  // 5. Adherence Reports: Sunday 21:00-23:59 SP (window covers UTC-3 to UTC-5 at 23:00 local)
-  if (currentWeekDay === 0 && currentHour >= 21) {
+  // 5. Adherence Reports: Sunday 09:00-12:00 SP (window covers UTC-3 to UTC-5 at 09:00 local)
+  if (currentWeekDay === 0 && currentHour >= 9 && currentHour <= 12) {
     await withCorrelation(
       (context) => checkAdherenceReports(bot, { ...context, notificationDispatcher }),
       { correlationId, jobType: 'adherence_reports' }

--- a/api/notify.js
+++ b/api/notify.js
@@ -263,7 +263,7 @@ async function _executeCronJobs(notificationDispatcher, bot, correlationId, spDa
   );
   results.push('daily_adherence_report');
 
-  // 3. Tasks at 09:00
+  // 3. Tasks at 10:00
   if (currentHour === 10 && currentMinute === 0) {
     await withCorrelation(
       (context) => checkStockAlerts(bot, { ...context, notificationDispatcher }),

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -5,7 +5,7 @@
 
 const BUILD_PROFILE = process.env.EAS_BUILD_PROFILE || 'production'
 
-const APP_VERSION = '0.12.0' // R-182: versão semântica (sem prefixo 'v')
+const APP_VERSION = '0.13.0' // R-182: versão semântica (sem prefixo 'v')
 const [major, minor, patch] = APP_VERSION.split('.').map(Number)
 // buildNumber/versionCode derivado da versão semântica: major*10000 + minor*100 + patch
 // 0.2.4 → 204 | 0.3.0 → 300 | 1.0.0 → 10000

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dosiq/mobile",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "index.js",
   "scripts": {
     "start": "expo start",

--- a/apps/mobile/src/__tests__/doseService.undoDose.test.js
+++ b/apps/mobile/src/__tests__/doseService.undoDose.test.js
@@ -3,8 +3,6 @@
  * Jest + jest-expo
  */
 
-import { undoDose } from '../features/dose/services/doseService'
-
 // Mock do supabase
 jest.mock('../platform/supabase/nativeSupabaseClient', () => ({
   supabase: {
@@ -27,6 +25,7 @@ jest.mock('@dosiq/core', () => ({
   logSchema: {
     safeParse: jest.fn(),
   },
+  parseISO: (str) => new Date(str),
 }))
 
 // Mock dos analytics
@@ -40,8 +39,11 @@ jest.mock('../shared/utils/debugLog', () => ({
   debugLog: jest.fn(),
 }))
 
+import { undoDose } from '../features/dose/services/doseService'
 import { supabase } from '../platform/supabase/nativeSupabaseClient'
 import { createDoseInstanceRepository } from '@dosiq/core'
+
+const mockRepository = createDoseInstanceRepository.mock.results[0].value
 
 describe('undoDose', () => {
   afterEach(() => {
@@ -54,20 +56,14 @@ describe('undoDose', () => {
       data: { user: { id: 'user-123' } },
     })
 
-    const mockRepository = {
-      getById: jest.fn().mockResolvedValue({
-        id: 'inst-1',
-        medicine_log_id: 'log-1',
-        scheduled_for: '2020-01-01T08:00:00Z',
-        tolerance_minutes: 30,
-        medicine_id: 'med-1',
-      }),
-      revertToUnregistered: jest.fn().mockResolvedValue(true),
-      markTaken: jest.fn(),
-      findAnchorInstance: jest.fn(),
-    }
-
-    createDoseInstanceRepository.mockReturnValue(mockRepository)
+    mockRepository.getById.mockResolvedValue({
+      id: 'inst-1',
+      medicine_log_id: 'log-1',
+      scheduled_for: '2020-01-01T08:00:00Z',
+      tolerance_minutes: 30,
+      medicine_id: 'med-1',
+    })
+    mockRepository.revertToUnregistered.mockResolvedValue(true)
 
     // Mock do encadeamento de supabase: .from().delete().eq().eq()
     const mockEq2 = jest.fn(() => ({ error: null }))
@@ -84,7 +80,7 @@ describe('undoDose', () => {
 
     // Assertions
     expect(result.success).toBe(true)
-    expect(mockRepository.revertToUnregistered).toHaveBeenCalledWith('inst-1')
+    expect(mockRepository.revertToUnregistered).toHaveBeenCalledWith('inst-1', 'missed')
     expect(supabase.rpc).toHaveBeenCalledWith('restore_stock_for_log', {
       p_medicine_log_id: 'log-1',
       p_reason: 'dose_deleted_restore',
@@ -99,27 +95,21 @@ describe('undoDose', () => {
       data: { user: { id: 'user-123' } },
     })
 
-    const mockRepository = {
-      getById: jest.fn().mockResolvedValue({
-        id: 'inst-2',
-        medicine_log_id: null,
-        scheduled_for: '2020-01-01T08:00:00Z',
-        tolerance_minutes: 30,
-        medicine_id: 'med-1',
-      }),
-      revertToUnregistered: jest.fn().mockResolvedValue(true),
-      markTaken: jest.fn(),
-      findAnchorInstance: jest.fn(),
-    }
-
-    createDoseInstanceRepository.mockReturnValue(mockRepository)
+    mockRepository.getById.mockResolvedValue({
+      id: 'inst-2',
+      medicine_log_id: null,
+      scheduled_for: '2020-01-01T08:00:00Z',
+      tolerance_minutes: 30,
+      medicine_id: 'med-1',
+    })
+    mockRepository.revertToUnregistered.mockResolvedValue(true)
 
     // Execute
     const result = await undoDose('inst-2')
 
     // Assertions
     expect(result.success).toBe(true)
-    expect(mockRepository.revertToUnregistered).toHaveBeenCalledWith('inst-2')
+    expect(mockRepository.revertToUnregistered).toHaveBeenCalledWith('inst-2', 'missed')
     expect(supabase.rpc).not.toHaveBeenCalled()
   })
 
@@ -129,14 +119,7 @@ describe('undoDose', () => {
       data: { user: { id: 'user-123' } },
     })
 
-    const mockRepository = {
-      getById: jest.fn().mockResolvedValue(null),
-      revertToUnregistered: jest.fn(),
-      markTaken: jest.fn(),
-      findAnchorInstance: jest.fn(),
-    }
-
-    createDoseInstanceRepository.mockReturnValue(mockRepository)
+    mockRepository.getById.mockResolvedValue(null)
 
     // Execute
     const result = await undoDose('inst-not-found')
@@ -152,20 +135,14 @@ describe('undoDose', () => {
       data: { user: { id: 'user-123' } },
     })
 
-    const mockRepository = {
-      getById: jest.fn().mockResolvedValue({
-        id: 'inst-1',
-        medicine_log_id: 'log-1',
-        scheduled_for: '2020-01-01T08:00:00Z',
-        tolerance_minutes: 30,
-        medicine_id: 'med-1',
-      }),
-      revertToUnregistered: jest.fn().mockResolvedValue(true),
-      markTaken: jest.fn(),
-      findAnchorInstance: jest.fn(),
-    }
-
-    createDoseInstanceRepository.mockReturnValue(mockRepository)
+    mockRepository.getById.mockResolvedValue({
+      id: 'inst-1',
+      medicine_log_id: 'log-1',
+      scheduled_for: '2020-01-01T08:00:00Z',
+      tolerance_minutes: 30,
+      medicine_id: 'med-1',
+    })
+    mockRepository.revertToUnregistered.mockResolvedValue(true)
 
     // Mock do rpc com erro
     supabase.rpc.mockResolvedValue({ error: new Error('rpc error') })

--- a/apps/mobile/src/__tests__/useHistoryMutation.test.js
+++ b/apps/mobile/src/__tests__/useHistoryMutation.test.js
@@ -53,7 +53,7 @@ describe('useHistoryMutation', () => {
         taken_at: '2026-01-01T08:00:00',
         quantity_taken: 1,
       }),
-      'inst-1'
+      { instanceId: 'inst-1' }
     )
     expect(AsyncStorage.removeItem).toHaveBeenCalledWith(
       '@dosiq/today-snapshot'

--- a/apps/mobile/src/features/dashboard/services/dashboardService.js
+++ b/apps/mobile/src/features/dashboard/services/dashboardService.js
@@ -21,7 +21,7 @@ export async function getActiveProtocols(userId, dateStr) {
   z.string().uuid().parse(userId)
   const { data, error } = await supabase
     .from('protocols')
-    .select('id, name, medicine_id, active, frequency, time_schedule, dosage_per_intake, start_date, end_date, titration_status, weekdays, critical_alarm')
+    .select('id, name, medicine_id, active, frequency, time_schedule, dosage_per_intake, start_date, end_date, titration_status, weekdays, critical_alarm, treatment_plan_id, treatment_plan:treatment_plans(id, name, emoji, color)')
     .eq('user_id', userId)
     .eq('active', true)
     .lte('start_date', dateStr)

--- a/apps/mobile/src/features/dose/screens/AlarmFullScreen.jsx
+++ b/apps/mobile/src/features/dose/screens/AlarmFullScreen.jsx
@@ -23,6 +23,16 @@ export default function AlarmFullScreen({ navigation, route }) {
   const data = useMemo(() => route?.params || {}, [route?.params])
   const { medicineName, scheduledTime } = data
   const snoozeMaxed = parseInt(data.snoozeAttempt || '0', 10) >= 3
+  const isGrouped = data.isGrouped === 'true'
+
+  const groupedDosesList = useMemo(() => {
+    if (!isGrouped || !data.groupedDoses) return []
+    try {
+      return JSON.parse(data.groupedDoses)
+    } catch {
+      return []
+    }
+  }, [isGrouped, data.groupedDoses])
 
   const close = useCallback(() => {
     if (navigation.canGoBack()) navigation.goBack()
@@ -49,10 +59,9 @@ export default function AlarmFullScreen({ navigation, route }) {
         scheduledFor: data.scheduledFor,
         toleranceMinutes: data.toleranceMinutes != null ? Number(data.toleranceMinutes) : null,
         currentSnoozeAttempt: parseInt(data.snoozeAttempt || '0', 10),
+        isCritical: data.isCritical === 'true' || data.isCritical === true,
         data: {
-          protocolId: data.protocolId,
-          medicineId: data.medicineId,
-          quantityTaken: data.quantityTaken,
+          ...data,
         },
       })
     } finally {
@@ -83,10 +92,28 @@ export default function AlarmFullScreen({ navigation, route }) {
           <View style={styles.iconWrap}>
             <Pill size={56} color={colors.bg.card} strokeWidth={1.75} />
           </View>
-          <Text style={styles.kicker}>HORA DA DOSE</Text>
-          <Text style={styles.medicine} accessibilityRole="header">
-            {medicineName || 'Sua dose'}
+          <Text style={styles.kicker}>
+            {isGrouped ? 'DOSES ESSENCIAIS' : 'HORA DA DOSE'}
           </Text>
+
+          {isGrouped ? (
+            <View style={styles.groupedList}>
+              {groupedDosesList.map((d, index) => {
+                const dosageInfo = d.dosagePerPill && d.dosageUnit ? ` (${d.dosagePerPill}${d.dosageUnit})` : ''
+                const qtyInfo = ` - ${d.dosagePerIntake ?? 1} un.`
+                return (
+                  <Text key={d.instanceId || index} style={styles.groupedItem} accessibilityRole="text">
+                    💊 {d.medicineName}{dosageInfo}{qtyInfo}
+                  </Text>
+                )
+              })}
+            </View>
+          ) : (
+            <Text style={styles.medicine} accessibilityRole="header">
+              {medicineName || 'Sua dose'}
+            </Text>
+          )}
+
           {!!scheduledTime && <Text style={styles.time}>{scheduledTime}</Text>}
         </View>
 
@@ -96,10 +123,10 @@ export default function AlarmFullScreen({ navigation, route }) {
             onPress={onTaken}
             disabled={busy}
             accessibilityRole="button"
-            accessibilityLabel="Tomei a dose"
+            accessibilityLabel={isGrouped ? 'Tomar todas as doses' : 'Tomei a dose'}
           >
             <Check size={28} color={colors.bg.card} strokeWidth={3} />
-            <Text style={styles.btnTakenText}>Tomei</Text>
+            <Text style={styles.btnTakenText}>{isGrouped ? 'Tomar todas' : 'Tomei'}</Text>
           </TouchableOpacity>
 
           {!snoozeMaxed && (
@@ -120,10 +147,10 @@ export default function AlarmFullScreen({ navigation, route }) {
             onPress={onSkip}
             disabled={busy}
             accessibilityRole="button"
-            accessibilityLabel="Pular esta dose"
+            accessibilityLabel={isGrouped ? 'Pular todas as doses' : 'Pular esta dose'}
           >
             <X size={26} color={colors.text.primary} strokeWidth={2.5} />
-            <Text style={styles.btnSkipText}>Pular</Text>
+            <Text style={styles.btnSkipText}>{isGrouped ? 'Pular todas' : 'Pular'}</Text>
           </TouchableOpacity>
         </View>
       </SafeAreaView>
@@ -174,6 +201,18 @@ const styles = StyleSheet.create({
   medicine: {
     fontSize: 34,
     fontWeight: '800',
+    color: colors.bg.card,
+    textAlign: 'center',
+  },
+  groupedList: {
+    width: '100%',
+    marginVertical: spacing[4],
+    gap: spacing[2],
+    alignItems: 'center',
+  },
+  groupedItem: {
+    fontSize: 24,
+    fontWeight: '700',
     color: colors.bg.card,
     textAlign: 'center',
   },

--- a/apps/mobile/src/features/notifications/screens/NotificationInboxScreen.jsx
+++ b/apps/mobile/src/features/notifications/screens/NotificationInboxScreen.jsx
@@ -35,7 +35,7 @@ const DEEP_LINK_TARGETS = {
   dashboard:        ROUTES.TODAY,
   stock:            ROUTES.STOCK,
   treatment:        ROUTES.TREATMENTS,
-  history:          ROUTES.TODAY,
+  history:          ROUTES.DOSE_HISTORY,
   'bulk-plan':      ROUTES.TODAY,
   'bulk-misc':      ROUTES.TODAY,
   'dose-individual': ROUTES.TODAY,

--- a/apps/mobile/src/features/treatments/components/ProtocolFormBody.jsx
+++ b/apps/mobile/src/features/treatments/components/ProtocolFormBody.jsx
@@ -1,9 +1,5 @@
-// ProtocolFormBody.jsx — sub-componente de render do ProtocolFormScreen.
-// Isola as 6 seções (Medicamento, Info, Frequência, Período, Organização,
-// Observações) pra manter o screen principal enxuto.
-
-import { useMemo, useCallback } from 'react'
-import { View, Text, Switch, Alert, Linking, StyleSheet } from 'react-native'
+import { useMemo, useCallback, useState } from 'react'
+import { View, Text, Switch, Alert, Linking, StyleSheet, Modal, TouchableOpacity } from 'react-native'
 import { parseLocalDate, formatActiveIngredientFormula } from '@dosiq/core'
 import FormInput from '@shared/components/form/FormInput'
 import FormSelect from '@shared/components/form/FormSelect'
@@ -15,6 +11,22 @@ import PlanSelectField from '@treatments/components/PlanSelectField'
 import { colors, spacing } from '@shared/styles/tokens'
 import { enablePushAtIntent } from '@platform/notifications/pushPermission'
 import { supabase } from '@platform/supabase/nativeSupabaseClient'
+import {
+  needsFullScreenIntentAccess,
+  openFullScreenIntentSettings,
+  isXiaomiDevice,
+} from '@platform/alarms/alarmService'
+
+const XIAOMI_MSG =
+  'Você precisa de uma etapa extra para o alarme funcionar na tela bloqueada. Abra as configurações abaixo e:\n\n' +
+  '1. Escolha "Outras permissões" e ative *Sempre permitir* em:\n' +
+  '  a. "Mostrar na Tela de bloqueio"\n' +
+  '  b. "Abrir novas janelas enquanto executa em segundo plano"\n' +
+  '  c. "Exibir janelas pop-up"\n\n'+
+  'Quando terminar, pode fechar essa janela.'
+
+const GENERIC_MSG =
+  'Para o alarme funcionar na tela bloqueada, toque em <Abrir configurações> abaixo e ligue "Notificações em tela cheia".'
 
 const FREQUENCY_OPTIONS = [
   { value: 'diário', label: 'Diário' },
@@ -37,6 +49,9 @@ export default function ProtocolFormBody({
   onStartDateChange,
   onEndDateChange,
 }) {
+  const [guideVisible, setGuideVisible] = useState(false)
+  const [guideMsg, setGuideMsg] = useState('')
+
   const startDateAsDate = useMemo(
     () => (form.values.start_date ? parseLocalDate(form.values.start_date) : null),
     [form.values.start_date]
@@ -74,6 +89,12 @@ export default function ProtocolFormBody({
           )
         }
         return
+      }
+
+      // Checar se precisa de acesso especial de alarme em tela cheia (Android 14+ / Xiaomi)
+      if (needsFullScreenIntentAccess()) {
+        setGuideMsg(isXiaomiDevice() ? XIAOMI_MSG : GENERIC_MSG)
+        setGuideVisible(true)
       }
     }
     form.handleChange('critical_alarm', next)
@@ -220,6 +241,37 @@ export default function ProtocolFormBody({
           helperText="Opcional"
         />
       </Section>
+
+      <Modal
+        visible={guideVisible}
+        transparent
+        animationType="fade"
+        statusBarTranslucent
+        onRequestClose={() => setGuideVisible(false)}
+      >
+        <View style={styles.backdrop}>
+          <View style={styles.dialog}>
+            <Text style={styles.dialogTitle}>Falta um passo no seu celular</Text>
+            <Text style={styles.dialogBody}>{guideMsg}</Text>
+            <TouchableOpacity
+              style={[styles.dialogBtn, styles.dialogBtnPrimary]}
+              onPress={() => openFullScreenIntentSettings()}
+              accessibilityRole="button"
+              accessibilityLabel="Abrir configurações"
+            >
+              <Text style={styles.dialogBtnPrimaryText}>Abrir configurações</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.dialogBtn}
+              onPress={() => setGuideVisible(false)}
+              accessibilityRole="button"
+              accessibilityLabel="Fechar aviso"
+            >
+              <Text style={styles.dialogBtnText}>Fechar</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
     </>
   )
 }
@@ -279,5 +331,46 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: colors.text?.secondary,
     lineHeight: 18,
+  },
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    paddingHorizontal: spacing[5],
+  },
+  dialog: {
+    backgroundColor: colors.bg.card,
+    borderRadius: 12,
+    padding: spacing[5],
+    gap: spacing[3],
+  },
+  dialogTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.text.primary,
+  },
+  dialogBody: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: colors.text.secondary,
+  },
+  dialogBtn: {
+    minHeight: 48,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  dialogBtnPrimary: {
+    backgroundColor: colors.brand.primary,
+  },
+  dialogBtnPrimaryText: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.bg.card,
+  },
+  dialogBtnText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.text.secondary,
   },
 })

--- a/apps/mobile/src/features/treatments/components/ProtocolFormBody.jsx
+++ b/apps/mobile/src/features/treatments/components/ProtocolFormBody.jsx
@@ -13,7 +13,8 @@ import WeekdaySelector from '@treatments/components/WeekdaySelector'
 import TimeSchedulePicker from '@treatments/components/TimeSchedulePicker'
 import PlanSelectField from '@treatments/components/PlanSelectField'
 import { colors, spacing } from '@shared/styles/tokens'
-import { ensurePushPermission } from '@platform/notifications/pushPermission'
+import { enablePushAtIntent } from '@platform/notifications/pushPermission'
+import { supabase } from '@platform/supabase/nativeSupabaseClient'
 
 const FREQUENCY_OPTIONS = [
   { value: 'diário', label: 'Diário' },
@@ -60,7 +61,7 @@ export default function ProtocolFormBody({
   const handleCriticalAlarmToggle = useCallback(async (next) => {
     if (next) {
       // R-239: checar permissão no ponto de intenção
-      const { granted, blocked } = await ensurePushPermission()
+      const { granted, blocked } = await enablePushAtIntent({ supabase })
       if (!granted) {
         if (blocked) {
           Alert.alert(

--- a/apps/mobile/src/platform/alarms/AlarmSchedulerBridge.jsx
+++ b/apps/mobile/src/platform/alarms/AlarmSchedulerBridge.jsx
@@ -50,6 +50,10 @@ function openAlarmScreen(notification) {
     scheduledFor: data.scheduledFor,
     toleranceMinutes: data.toleranceMinutes,
     snoozeAttempt: data.snoozeAttempt,
+    isCritical: data.isCritical,
+    isGrouped: data.isGrouped,
+    groupedDoses: data.groupedDoses,
+    doseInstanceIds: data.doseInstanceIds,
   })
 }
 

--- a/apps/mobile/src/platform/alarms/alarmService.js
+++ b/apps/mobile/src/platform/alarms/alarmService.js
@@ -34,7 +34,7 @@ import { debugLog } from '@shared/utils/debugLog'
 export const ALARM_CHANNEL_ID = 'dose-alarm-v3'
 // Canal crítico Android (Spec 010, R-261): id separado para alarmes críticos (critical_alarm=true).
 // NUNCA mudar o id dose-alarm-v3 acima; bumpar este ao trocar som do canal crítico.
-export const ALARM_CRITICAL_CHANNEL_ID = 'dose-alarm-critical-v1'
+export const ALARM_CRITICAL_CHANNEL_ID = 'dose-alarm-critical-v2'
 const SOUND_ANDROID = 'alarm_dose' // res/raw/alarm_dose (sem extensão)
 const SOUND_IOS = 'alarm_dose.wav'
 // iOS interruption level (T013). 'timeSensitive' fura Focus/DND e é auto-concedido.
@@ -170,7 +170,7 @@ export async function ensureAlarmCriticalChannel() {
     id: ALARM_CRITICAL_CHANNEL_ID,
     name: 'Alarmes críticos de dose',
     importance: AndroidImportance.HIGH,
-    sound: 'default',
+    sound: SOUND_ANDROID,
     vibration: true,
     bypassDnd: true,
     visibility: AndroidVisibility.PUBLIC,
@@ -194,18 +194,18 @@ function getAlarmCopy({ medicineName, data }) {
     if (doses.length === 0) {
       return {
         title: '💊 Hora da dose',
-        body: 'Está na hora da sua dose.',
+        body: 'Está na hora do seu remédio.',
       }
     }
 
     if (doses.length === 1) {
       const d = doses[0]
       const dosageInfo = d.dosagePerPill && d.dosageUnit ? ` (${d.dosagePerPill}${d.dosageUnit})` : ''
-      const intakeInfo = ` - ${d.dosagePerIntake ?? 1} un.`
+      const intakeInfo = ` • ${d.dosagePerIntake ?? 1} un.`
       const desc = `${d.medicineName}${dosageInfo}${intakeInfo}`
       return {
-        title: '💊 Medicamento essencial',
-        body: `💊 Medicamento essencial: hora do seu ${desc}${time ? ` (${time})` : ''}.`,
+        title: '💊 Remédio essencial',
+        body: `Hora de tomar ${desc}${time ? ` — ${time}` : ''}.`,
       }
     }
 
@@ -215,13 +215,13 @@ function getAlarmCopy({ medicineName, data }) {
 
     if (samePlan) {
       return {
-        title: '📋 Uso essencial',
-        body: `📋 Uso essencial: hora dos medicamentos do plano ${firstPlan}${time ? ` (${time})` : ''}.`,
+        title: '📂 Plano essencial',
+        body: `Hora dos remédios do plano ${firstPlan}${time ? ` — ${time}` : ''}.`,
       }
     } else {
       return {
-        title: '💊 Doses essenciais',
-        body: `💊 Doses essenciais pendentes para as ${time || ''}.`,
+        title: '📋 Doses essenciais',
+        body: `Doses pendentes para as ${time || ''}.`,
       }
     }
   } else {
@@ -232,11 +232,11 @@ function getAlarmCopy({ medicineName, data }) {
     const quantity = data?.quantityTaken || '1'
 
     const dosageInfo = dosagePerPill && dosageUnit ? ` (${dosagePerPill}${dosageUnit})` : ''
-    const intakeInfo = ` - ${quantity} un.`
+    const intakeInfo = ` • ${quantity} un.`
     const desc = `${name}${dosageInfo}${intakeInfo}`
     return {
-      title: '💊 Medicamento essencial',
-      body: `💊 Medicamento essencial: hora do seu ${desc}${time ? ` (${time})` : ''}.`,
+      title: '💊 Remédio essencial',
+      body: `Hora de tomar ${desc}${time ? ` — ${time}` : ''}.`,
     }
   }
 }
@@ -245,16 +245,26 @@ function getAlarmCopy({ medicineName, data }) {
 // isCritical=true: iOS fura modo silencioso (entitlement critical-alerts); Android: canal crítico dedicado.
 function buildNotification({ doseInstanceId, medicineName, data, notificationId, isCritical = false }) {
   const { title, body } = getAlarmCopy({ doseInstanceId, medicineName, data })
+  const sanitizedData = {}
+  if (data) {
+    for (const [key, value] of Object.entries(data)) {
+      if (value !== null && value !== undefined) {
+        sanitizedData[key] = typeof value === 'object' ? JSON.stringify(value) : String(value)
+      }
+    }
+  }
+  sanitizedData.doseInstanceId = String(doseInstanceId)
+
   return {
     id: notificationId,
     title,
     body,
-    data: { ...data, doseInstanceId },
+    data: sanitizedData,
     android: {
       channelId: isCritical ? ALARM_CRITICAL_CHANNEL_ID : ALARM_CHANNEL_ID,
       category: AndroidCategory.ALARM,
       importance: AndroidImportance.HIGH,
-      sound: isCritical ? 'default' : SOUND_ANDROID,
+      sound: SOUND_ANDROID,
       // Loop do som + notif persistente: toca até o usuário escolher Tomei/Pular.
       // ongoing+autoCancel:false impedem swipe/auto-dismiss; cancelAlarm para o som.
       loopSound: true,
@@ -271,8 +281,12 @@ function buildNotification({ doseInstanceId, medicineName, data, notificationId,
     },
     ios: {
       sound: SOUND_IOS,
-      interruptionLevel: isCritical ? 'critical' : IOS_INTERRUPTION_LEVEL,
-      ...(isCritical ? { critical: true } : {}), // fura mute físico (entitlement critical-alerts)
+      // Temporariamente forçando timeSensitive para critical_alarm enquanto o entitlement
+      // com.apple.developer.usernotifications.critical-alerts está em aprovação pela Apple.
+      // Com 'critical', se o entitlement não estiver presente no profile de provisionamento,
+      // o iOS rejeita a notificação inteira silenciosamente.
+      interruptionLevel: IOS_INTERRUPTION_LEVEL,
+      // critical: true, // Desativado até obter o entitlement
       categoryId: ALARM_CHANNEL_ID, // ações registradas em ensureAlarmCategories (T015)
       // iOS suprime som/banner de notif quando o app está em foreground por padrão.
       // Declarar pra o alarme tocar/aparecer mesmo com o app aberto (paridade Android).

--- a/apps/mobile/src/platform/alarms/alarmService.js
+++ b/apps/mobile/src/platform/alarms/alarmService.js
@@ -178,14 +178,73 @@ export async function ensureAlarmCriticalChannel() {
   criticalChannelEnsured = true
 }
 
+// Monta o copy clínico customizado e acolhedor dos alarmes
+function getAlarmCopy({ medicineName, data }) {
+  const time = data?.scheduledTime
+  const isGrouped = data?.isGrouped === 'true'
+
+  if (isGrouped) {
+    let doses = []
+    try {
+      doses = JSON.parse(data.groupedDoses || '[]')
+    } catch {
+      // fallback
+    }
+
+    if (doses.length === 0) {
+      return {
+        title: '💊 Hora da dose',
+        body: 'Está na hora da sua dose.',
+      }
+    }
+
+    if (doses.length === 1) {
+      const d = doses[0]
+      const dosageInfo = d.dosagePerPill && d.dosageUnit ? ` (${d.dosagePerPill}${d.dosageUnit})` : ''
+      const intakeInfo = ` - ${d.dosagePerIntake ?? 1} un.`
+      const desc = `${d.medicineName}${dosageInfo}${intakeInfo}`
+      return {
+        title: '💊 Medicamento essencial',
+        body: `💊 Medicamento essencial: hora do seu ${desc}${time ? ` (${time})` : ''}.`,
+      }
+    }
+
+    // Verifica se todos pertencem ao mesmo plano de tratamento
+    const firstPlan = doses[0].treatmentPlanName
+    const samePlan = firstPlan && doses.every((d) => d.treatmentPlanName === firstPlan)
+
+    if (samePlan) {
+      return {
+        title: '📋 Uso essencial',
+        body: `📋 Uso essencial: hora dos medicamentos do plano ${firstPlan}${time ? ` (${time})` : ''}.`,
+      }
+    } else {
+      return {
+        title: '💊 Doses essenciais',
+        body: `💊 Doses essenciais pendentes para as ${time || ''}.`,
+      }
+    }
+  } else {
+    // Dose única essencial
+    const name = medicineName || data?.medicineName || 'sua dose'
+    const dosagePerPill = data?.dosagePerPill
+    const dosageUnit = data?.dosageUnit
+    const quantity = data?.quantityTaken || '1'
+
+    const dosageInfo = dosagePerPill && dosageUnit ? ` (${dosagePerPill}${dosageUnit})` : ''
+    const intakeInfo = ` - ${quantity} un.`
+    const desc = `${name}${dosageInfo}${intakeInfo}`
+    return {
+      title: '💊 Medicamento essencial',
+      body: `💊 Medicamento essencial: hora do seu ${desc}${time ? ` (${time})` : ''}.`,
+    }
+  }
+}
+
 // Monta o objeto de notificação compartilhado por agendamento e nag.
 // isCritical=true: iOS fura modo silencioso (entitlement critical-alerts); Android: canal crítico dedicado.
 function buildNotification({ doseInstanceId, medicineName, data, notificationId, isCritical = false }) {
-  const title = '💊 Hora da dose'
-  const time = data?.scheduledTime
-  const body = medicineName
-    ? `Está na hora de tomar ${medicineName}${time ? ` (${time})` : ''}.`
-    : 'Está na hora da sua dose.'
+  const { title, body } = getAlarmCopy({ doseInstanceId, medicineName, data })
   return {
     id: notificationId,
     title,
@@ -250,7 +309,7 @@ export async function scheduleAlarm({
     medicineName,
     notificationId: doseInstanceId,
     isCritical,
-    data: { ...data, medicineName, scheduledFor, toleranceMinutes, nagAttempt: '0', snoozeAttempt: '0' },
+    data: { ...data, medicineName, scheduledFor, toleranceMinutes, isCritical, nagAttempt: '0', snoozeAttempt: '0' },
   })
 
   await notifee.createTriggerNotification(notification, {
@@ -280,7 +339,7 @@ export async function cancelAlarm(doseInstanceId) {
  * Re-agenda um nag +5min se ignorado, máx 3 tentativas, reativamente (FR-003).
  * Respeita a tolerância da instância (D): além da janela, para de insistir.
  * @param {{ doseInstanceId: string, medicineName?: string, scheduledFor?: string|number|Date,
- *           toleranceMinutes?: number|null, currentNagAttempt?: number, data?: object }} params
+ *           toleranceMinutes?: number|null, currentNagAttempt?: number, isCritical?: boolean, data?: object }} params
  */
 export async function scheduleNag({
   doseInstanceId,
@@ -288,6 +347,7 @@ export async function scheduleNag({
   scheduledFor,
   toleranceMinutes = null,
   currentNagAttempt = 0,
+  isCritical = false,
   data = {},
 }) {
   const next = currentNagAttempt + 1
@@ -306,7 +366,8 @@ export async function scheduleNag({
     doseInstanceId,
     medicineName,
     notificationId: `${doseInstanceId}:nag:${next}`,
-    data: { ...data, medicineName, scheduledFor, toleranceMinutes, nagAttempt: String(next) },
+    isCritical,
+    data: { ...data, medicineName, scheduledFor, toleranceMinutes, isCritical, nagAttempt: String(next) },
   })
 
   await notifee.createTriggerNotification(notification, {
@@ -329,6 +390,7 @@ export async function scheduleSnooze({
   scheduledFor,
   toleranceMinutes = null,
   currentSnoozeAttempt = 0,
+  isCritical = false,
   data = {},
 }) {
   // Cancela primeiro: mata o loop do som da notif atual.
@@ -342,11 +404,13 @@ export async function scheduleSnooze({
     doseInstanceId,
     medicineName,
     notificationId: doseInstanceId,
+    isCritical,
     data: {
       ...data,
       medicineName,
       scheduledFor,
       toleranceMinutes,
+      isCritical,
       nagAttempt: '0',
       snoozeAttempt: String(next),
     },
@@ -361,7 +425,12 @@ export async function scheduleSnooze({
   // Persiste snoozed_until no DB para que syncAlarms não re-agende no próximo sync.
   try {
     const repo = createDoseInstanceRepository({ client: supabase })
-    await repo.setSnoozedUntil(doseInstanceId, nextTs)
+    if (data?.isGrouped === 'true' && data?.doseInstanceIds) {
+      const ids = data.doseInstanceIds.split(',')
+      await Promise.all(ids.map((id) => repo.setSnoozedUntil(id, nextTs)))
+    } else {
+      await repo.setSnoozedUntil(doseInstanceId, nextTs)
+    }
   } catch (err) {
     if (__DEV__) console.warn('[alarmService] setSnoozedUntil falhou', doseInstanceId, err?.message)
   }

--- a/apps/mobile/src/platform/alarms/quickDoseRegistration.js
+++ b/apps/mobile/src/platform/alarms/quickDoseRegistration.js
@@ -35,13 +35,42 @@ async function invalidate(keys) {
  * @param {object} data - { doseInstanceId, protocolId, medicineId, quantityTaken }
  */
 export async function registerTaken(data) {
-  const { doseInstanceId, protocolId, medicineId, quantityTaken } = data || {}
+  const { doseInstanceId, isGrouped, groupedDoses } = data || {}
   if (!doseInstanceId) return { success: false }
-  // Silenciar PRIMEIRO: o usuário agiu — para o som/notif na hora, mesmo que o
-  // registro no DB falhe depois. Sem isso, um erro de rede deixaria o alarme tocando.
+  // Silenciar PRIMEIRO: o usuário agiu — para o som/notif na hora.
   await alarmService.cancelAlarm(doseInstanceId)
   if (data.__dev) return { success: true, dev: true } // smoke do DevHub: sem DB
-  // Coalescência nula (não `|| 1`): quantityTaken=0 deve ser respeitado, não virar 1.
+
+  if (isGrouped === 'true' && groupedDoses) {
+    let doses = []
+    try {
+      doses = JSON.parse(groupedDoses)
+    } catch {
+      // fallback
+    }
+
+    if (doses.length > 0) {
+      await Promise.all(
+        doses.map(async (d) => {
+          const quantity = d.dosagePerIntake != null ? Number(d.dosagePerIntake) : 1
+          await registerDose(
+            {
+              protocol_id: d.protocolId || null,
+              medicine_id: d.medicineId,
+              taken_at: getRawNow().toISOString(),
+              quantity_taken: quantity,
+            },
+            { instanceId: d.instanceId }
+          )
+        })
+      )
+      await invalidate(SNAPSHOTS_TAKEN)
+      return { success: true }
+    }
+  }
+
+  // Fallback para dose única
+  const { protocolId, medicineId, quantityTaken } = data || {}
   const quantity = quantityTaken != null ? Number(quantityTaken) : 1
   await registerDose(
     {
@@ -61,10 +90,28 @@ export async function registerTaken(data) {
  * @param {object} data - { doseInstanceId }
  */
 export async function registerSkip(data) {
-  const { doseInstanceId } = data || {}
+  const { doseInstanceId, isGrouped, groupedDoses } = data || {}
   if (!doseInstanceId) return { success: false }
   await alarmService.cancelAlarm(doseInstanceId) // silencia primeiro
   if (data.__dev) return { success: true, dev: true } // smoke do DevHub: sem DB
+
+  if (isGrouped === 'true' && groupedDoses) {
+    let doses = []
+    try {
+      doses = JSON.parse(groupedDoses)
+    } catch {
+      // fallback
+    }
+
+    if (doses.length > 0) {
+      const ids = doses.map((d) => d.instanceId)
+      await supabase.from('dose_instances').update({ status: 'skipped_user' }).in('id', ids)
+      await invalidate(SNAPSHOTS_SKIP)
+      return { success: true }
+    }
+  }
+
+  // Fallback para dose única
   await supabase.from('dose_instances').update({ status: 'skipped_user' }).eq('id', doseInstanceId)
   await invalidate(SNAPSHOTS_SKIP)
   return { success: true }
@@ -79,13 +126,15 @@ export async function registerSkip(data) {
 // tolerância dinâmica, mesmo payload de re-registro. Extraído pra manter
 // handleAlarmAction abaixo do teto de complexidade (R-? lint).
 function rescheduleBase(data) {
-  const { doseInstanceId, protocolId, medicineId, quantityTaken, medicineName, toleranceMinutes } = data
+  const { doseInstanceId, toleranceMinutes, isCritical } = data
+  const isCrit = isCritical === 'true' || isCritical === true
   return {
     doseInstanceId,
-    medicineName,
+    medicineName: data.medicineName || '',
     scheduledFor: data.scheduledFor,
     toleranceMinutes: toleranceMinutes != null ? Number(toleranceMinutes) : null,
-    data: { protocolId, medicineId, quantityTaken },
+    isCritical: isCrit,
+    data: { ...data },
   }
 }
 

--- a/apps/mobile/src/platform/alarms/quickDoseRegistration.js
+++ b/apps/mobile/src/platform/alarms/quickDoseRegistration.js
@@ -50,20 +50,18 @@ export async function registerTaken(data) {
     }
 
     if (doses.length > 0) {
-      await Promise.all(
-        doses.map(async (d) => {
-          const quantity = d.dosagePerIntake != null ? Number(d.dosagePerIntake) : 1
-          await registerDose(
-            {
-              protocol_id: d.protocolId || null,
-              medicine_id: d.medicineId,
-              taken_at: getRawNow().toISOString(),
-              quantity_taken: quantity,
-            },
-            { instanceId: d.instanceId }
-          )
-        })
-      )
+      for (const d of doses) {
+        const quantity = d.dosagePerIntake != null ? Number(d.dosagePerIntake) : 1
+        await registerDose(
+          {
+            protocol_id: d.protocolId || null,
+            medicine_id: d.medicineId,
+            taken_at: getRawNow().toISOString(),
+            quantity_taken: quantity,
+          },
+          { instanceId: d.instanceId }
+        )
+      }
       await invalidate(SNAPSHOTS_TAKEN)
       return { success: true }
     }

--- a/apps/mobile/src/platform/alarms/useAlarmScheduler.js
+++ b/apps/mobile/src/platform/alarms/useAlarmScheduler.js
@@ -21,6 +21,7 @@ import {
   ensureInstancesUpTo,
   getRawNow,
   addDays,
+  parseISO,
 } from '@dosiq/core'
 import { supabase } from '@platform/supabase/nativeSupabaseClient'
 import { alarmService } from './alarmService'
@@ -63,21 +64,67 @@ export async function syncAlarms({ userId, protocols, tz }) {
       return true
     })
 
-  await alarmService.cancelAll()
+  // Agrupa alarmes do mesmo minuto pelo epoch timestamp absoluto
+  const groups = new Map()
   for (const it of items) {
-    await alarmService.scheduleAlarm({
-      doseInstanceId: it.instanceId,
-      medicineName: it.medicineName,
-      scheduledFor: it.scheduledFor, // F: instante absoluto
-      toleranceMinutes: it.toleranceMinutes, // D: cutoff dinâmico
-      isCritical: it.critical,
-      data: {
+    const ts = parseISO(it.scheduledFor).getTime()
+    if (!groups.has(ts)) {
+      groups.set(ts, [])
+    }
+    groups.get(ts).push(it)
+  }
+
+  await alarmService.cancelAll()
+  for (const [ts, groupItems] of groups.entries()) {
+    if (groupItems.length === 1) {
+      const it = groupItems[0]
+      await alarmService.scheduleAlarm({
+        doseInstanceId: it.instanceId,
+        medicineName: it.medicineName,
+        scheduledFor: it.scheduledFor, // F: instante absoluto
+        toleranceMinutes: it.toleranceMinutes, // D: cutoff dinâmico
+        isCritical: it.critical,
+        data: {
+          protocolId: it.protocolId,
+          medicineId: it.medicineId,
+          quantityTaken: String(it.dosagePerIntake ?? 1),
+          scheduledTime: it.scheduledTime || '',
+          dosagePerPill: it.dosagePerPill != null ? String(it.dosagePerPill) : '',
+          dosageUnit: it.dosageUnit || '',
+        },
+      })
+    } else {
+      // Múltiplos alarmes no mesmo minuto
+      const first = groupItems[0]
+      const doseInstanceIds = groupItems.map((it) => it.instanceId).join(',')
+      const groupedDoses = groupItems.map((it) => ({
+        instanceId: it.instanceId,
+        medicineName: it.medicineName,
         protocolId: it.protocolId,
         medicineId: it.medicineId,
-        quantityTaken: String(it.dosagePerIntake ?? 1),
-        scheduledTime: it.scheduledTime || '',
-      },
-    })
+        dosagePerIntake: it.dosagePerIntake,
+        dosagePerPill: it.dosagePerPill,
+        dosageUnit: it.dosageUnit,
+        treatmentPlanName: it.treatmentPlanName,
+        scheduledTime: it.scheduledTime,
+        toleranceMinutes: it.toleranceMinutes,
+      }))
+      const maxTolerance = Math.max(...groupItems.map((it) => it.toleranceMinutes ?? 120))
+
+      await alarmService.scheduleAlarm({
+        doseInstanceId: String(ts),
+        medicineName: '', // Nome vazio sinaliza agrupamento no alarme local
+        scheduledFor: first.scheduledFor,
+        toleranceMinutes: maxTolerance,
+        isCritical: groupItems.some((it) => it.critical),
+        data: {
+          isGrouped: 'true',
+          doseInstanceIds,
+          groupedDoses: JSON.stringify(groupedDoses),
+          scheduledTime: first.scheduledTime || '',
+        },
+      })
+    }
   }
 }
 

--- a/apps/mobile/src/platform/notifications/registerPushToken.js
+++ b/apps/mobile/src/platform/notifications/registerPushToken.js
@@ -5,7 +5,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { getExpoPushToken } from './getExpoPushToken'
 import { syncNotificationDevice } from './syncNotificationDevice'
-import { isAlarmEnabled } from '@platform/alarms/alarmEnabledStore'
 import { debugLog } from '@shared/utils/debugLog'
 
 export const PUSH_TOKEN_KEY = '@dosiq/expo-push-token'
@@ -27,7 +26,7 @@ export async function registerPushToken({ supabase, userId, nativeAlarmEnabled }
     return null
   }
 
-  const alarmFlag = nativeAlarmEnabled ?? (await isAlarmEnabled())
+  const alarmFlag = nativeAlarmEnabled ?? true
   await syncNotificationDevice({ supabase, userId: uid, token, nativeAlarmEnabled: alarmFlag })
   await AsyncStorage.setItem(PUSH_TOKEN_KEY, token)
   debugLog('registerPushToken', 'token registrado', token.substring(0, 20) + '...')

--- a/apps/mobile/src/platform/notifications/usePushNotifications.js
+++ b/apps/mobile/src/platform/notifications/usePushNotifications.js
@@ -20,6 +20,7 @@ const SCREEN_TO_ROUTE = {
   'bulk-plan': ROUTES.TODAY,
   'bulk-misc': ROUTES.TODAY,
   'dose-individual': ROUTES.TODAY,
+  'history': ROUTES.DOSE_HISTORY,
 }
 
 // Navega para a tela correta a partir de um tap em push notification.
@@ -114,7 +115,7 @@ export function usePushNotifications({ supabase, session }) {
         await registerPushToken({ supabase, userId: session.user.id })
       } catch (error) {
         if (isMounted && __DEV__) {
-          console.error('[usePushNotifications] Erro durante setup:', error.message)
+          console.warn('[usePushNotifications] Erro durante setup (não-fatal):', error.message)
         }
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,11 +58,14 @@
         "vite": "^7.2.4",
         "vitest": "^4.0.16",
         "yaml-lint": "^1.7.0"
+      },
+      "engines": {
+        "node": "22.x"
       }
     },
     "apps/mobile": {
       "name": "@dosiq/mobile",
-      "version": "0.2.3",
+      "version": "0.4.0",
       "dependencies": {
         "@expo-google-fonts/comfortaa": "^0.4.2",
         "@notifee/react-native": "^9.1.8",
@@ -186,7 +189,7 @@
     },
     "apps/web": {
       "name": "@dosiq/web",
-      "version": "4.1.0",
+      "version": "4.1.5",
       "dependencies": {
         "@vercel/speed-insights": "^2.0.0",
         "vite-plugin-pwa": "1.2.0",
@@ -5558,9 +5561,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5576,9 +5576,6 @@
       "integrity": "sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5596,9 +5593,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5615,9 +5609,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5633,9 +5624,6 @@
       "integrity": "sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5879,9 +5867,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5897,9 +5882,6 @@
       "integrity": "sha512-ARyfcMCIxVLDgLf6FQ8Oo1/TFySpnquV+vuSb4SFQZfYDqgMklzwv0NYXxWD0aB6enElyMDs6pQJBzusEKCkOg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5917,9 +5899,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5935,9 +5914,6 @@
       "integrity": "sha512-9bUml6rMgk+8GF5rvNMweFspkzSiCjqpV6HduwiUyexqfGKrmjq9IZOxxvnzkE2RGdQzP507NNDoVNYIoGQYuA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5955,9 +5931,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5973,9 +5946,6 @@
       "integrity": "sha512-sRG1KIfZ0ML9ToEygm5aM/5GJeBA05uHlgW3M0Rx/DNWMJhuahLmqWuB02aWSmijndLfEKXLLXIWhvWupRG8lg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5993,9 +5963,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6011,9 +5978,6 @@
       "integrity": "sha512-EgoutsP3YfqzN8a9vpc9+XLr0bmBl0dA3uOMiP77+exATCPxJBkJErGmQkqk6RtTp5XqX6q6mB45qWQyKk6+pA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6793,9 +6757,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6811,9 +6772,6 @@
       "integrity": "sha512-UvApLEGholmxw/HIwmUnLq3CwdydbhaHHllvWiCTNbyGom7wTwOtz5OAQbAKZYyiEOeIXZNPkM7nA4Dtng7CLw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6831,9 +6789,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6849,9 +6804,6 @@
       "integrity": "sha512-T6Eg0xWwcxd/MzBcuv4Z37YVbUbJxy5cMNnbIt/Yr99wFwli30O4BPlY8hKeGyn6lWNtU0QioBS46lVzDN38bg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/plans/adherence_stats_approaches.md
+++ b/plans/adherence_stats_approaches.md
@@ -1,0 +1,87 @@
+# Draft: Abordagens para Viabilização de Estatísticas Avançadas em Notificações Push
+
+Este rascunho analisa possíveis abordagens de arquitetura para viabilizar estatísticas de engajamento clinicamente ricas (pontualidade, streaks consecutivos, turnos de esquecimento) nas notificações de adesão do Dosiq, contornando a limitação de timeout de 60 segundos do cron/serverless no Vercel.
+
+---
+
+## O Desafio Tecnológico
+Calcular métricas complexas para múltiplos usuários em lote durante a execução do cron pode causar:
+1. **CPU/Memory Exceeded:** Operações de ordenação e comparação temporal de múltiplos arrays de instâncias em JS.
+2. **I/O Overhead:** Múltiplas queries SQL por usuário (ex: carregar todos os logs de medicamentos recentes e todas as doses agendadas).
+3. **Cron Timeout (60s):** Estouro do tempo limite de execução concorrente da Serverless Function.
+
+Abaixo, detalhamos três abordagens possíveis para contornar esses limites.
+
+---
+
+## 1. Abordagem: Rollups Incrementais (Tabelas de Agregação Diária)
+
+### Conceito
+Em vez de calcular o histórico em tempo de envio do relatório, mantemos uma tabela de estatísticas consolidadas por usuário para o dia (`user_daily_adherence_stats`). 
+Cada vez que uma dose é marcada como `taken`, `missed` ou `skipped`, incrementamos as colunas correspondentes de forma atômica no banco de dados.
+
+### Exemplo de Schema
+```sql
+CREATE TABLE user_daily_adherence_stats (
+  user_id           uuid REFERENCES auth.users(id),
+  date              date NOT NULL,  -- YYYY-MM-DD local
+  expected_count    int DEFAULT 0,
+  taken_count       int DEFAULT 0,
+  taken_late_count  int DEFAULT 0,  -- tomadas após a tolerância
+  missed_count      int DEFAULT 0,
+  skipped_count     int DEFAULT 0,
+  current_streak    int DEFAULT 0,
+  PRIMARY KEY (user_id, date)
+);
+```
+
+### Como o Relatório consome
+Às 9:00 AM, o cron executa uma query simples e indexada:
+```sql
+SELECT * FROM user_daily_adherence_stats 
+WHERE user_id = $1 AND date = yesterday();
+```
+O tempo de processamento cai para **$O(1)$ por usuário**, pois todos os dados já estão calculados.
+
+### Prós
+*   **Performance excepcional:** Query de apenas uma linha no momento do cron.
+*   **Histórico persistido:** Fácil de plotar gráficos de histórico e heatmaps sem processamento pesado.
+
+### Contras
+*   **Complexidade de escrita:** O código que realiza o registro de medicamentos (`markTaken`, `markMissed`) precisa incrementar esses contadores de forma atômica ou via triggers de banco de dados (PG Triggers).
+
+---
+
+## 2. Abordagem: Fila de Tarefas / Background Workers (Desacoplamento Assíncrono)
+
+### Conceito
+Desacoplar o agendamento do processamento do relatório. Às 9:00 AM, a cron do Vercel apenas dispara uma tarefa leve de orquestração que enfileira "mensagens de cálculo" para cada usuário ativo em um serviço de filas assíncronas (como Inngest, BullMQ ou QStash). 
+
+### Como funciona
+1. A cron do Vercel busca usuários ativos e publica mensagens na fila: `{ userId: "abc", reportType: "daily_adherence" }`.
+2. Um worker externo ou uma rota serverless dedicada é acionada de forma assíncrona por mensagem.
+3. Como cada execução assíncrona calcula e envia a notificação para **apenas um usuário individual**, a função tem seu próprio limite de tempo (ex: 10s individual), eliminando o risco de timeout coletivo.
+
+### Prós
+*   **Isolamento total:** Um erro ou lentidão no cálculo de um usuário não afeta os demais.
+*   **Alta escalabilidade:** Consegue processar milhares de usuários concorrentemente distribuídos na fila.
+
+### Contras
+*   **Dependência de infraestrutura externa:** Requer a configuração de um sistema de filas e workers robusto.
+
+---
+
+## 3. Abordagem: Rollup Mensal Pré-existente (`dose_adherence_monthly`)
+
+### Conceito
+Aproveitar o rollup de banco de dados planejado na tabela `dose_adherence_monthly` para armazenar metadados adicionais durante o cron de consolidação mensal (ou semanal). 
+
+### Como funciona
+A cada fechamento de período (ex: domingo de madrugada ou dia 1 do mês), um script em lote calcula de forma otimizada os dados agregados para o período e salva na tabela de rollup. O envio do relatório lê diretamente dessa tabela no dia seguinte.
+
+### Prós
+*   **Baixo impacto de infraestrutura:** Reusa tabelas e modelos planejados.
+*   **Processamento em horário de baixo tráfego:** O cálculo pesado roda de madrugada, enquanto o envio da notificação ocorre às 9h sem custo.
+
+### Contras
+*   Não resolve para o relatório diário (que requer dados imediatos do dia anterior), servindo prioritariamente para relatórios semanais e mensais.

--- a/plans/specs/025-fix-notifications-alarms/plan.md
+++ b/plans/specs/025-fix-notifications-alarms/plan.md
@@ -53,6 +53,22 @@ O alarme local do aplicativo (usando Notifee) deve refletir a mesma clareza e ac
 - Quando disparado de forma agrupada por plano essencial, deve exibir o copy `"📋 Uso essencial: hora dos medicamentos do plano {Plano} ({Hora})."`.
 - Quando agrupado e de origens diversas, deve exibir o copy `"💊 Doses essenciais pendentes para as {Hora}."`.
 
+### 7. Planejamento do Changelog & Releases (R-221/R-243)
+Conforme o protocolo SQP (R-221), as seguintes entradas serão adicionadas ao `CHANGELOG.md` sob a seção `[Unreleased]` ao fim do ciclo:
+
+#### Mobile (0.12.0 → 0.13.0)
+- **Alarmes Críticos Locais e Supressão de Pushes** (Minor, Spec 025):
+  - Habilitada a flag `native_alarm_enabled` por padrão para iOS e Android para supressão automática de pushes remotos de doses críticas e prevenção de duplicidades.
+  - Implementado o agrupamento local de alarmes no Notifee (`useAlarmScheduler.js`), consolidando múltiplas doses críticas do mesmo minuto em um único trigger.
+  - Atualizada a tela cheia de alarme (`AlarmFullScreen.jsx`) e as ações rápidas (`quickDoseRegistration.js`) para suportar visualização e confirmação/descarte em lote.
+  - Ajustadas as cópias de exibição do alarme local em `alarmService.js` para usar o padrão clínico customizado para doses críticas (essenciais) de forma coerente.
+  - Integrada a solicitação contextual de permissões de push (`enablePushAtIntent`) ao toggle de alarme essencial do formulário de protocolos (`ProtocolFormBody.jsx`).
+  - **Nota de loja relevante:** "Novo: Lembretes mais inteligentes para medicamentos essenciais. Se você tem mais de um remédio no mesmo horário, o alarme agora toca apenas uma vez e permite confirmar todos de uma vez só."
+
+#### Server
+- **Reversão de cópias de notificações normais** (Patch, Spec 025):
+  - Revertido o texto de lembrete de doses normais para o formato legado original com "cp" (comprimidos) no builder de payloads (`buildNotificationPayload.js`).
+
 ---
 
 ## Plano de Verificação

--- a/plans/specs/025-fix-notifications-alarms/tasks.md
+++ b/plans/specs/025-fix-notifications-alarms/tasks.md
@@ -8,14 +8,14 @@
 - [x] **T006** [US3] Ajustar formatação e copy de lembrete em `server/notifications/payloads/buildNotificationPayload.js`
 - [x] **T007** [US3] Configurar som e interrupção corretos no `server/notifications/channels/expoPushChannel.js`
 - [x] **T008** [C4] Rodar testes críticos do servidor (`npm run test:critical` ou vitest específico)
-- [ ] **T009** [US4] Forçar `native_alarm_enabled: true` por padrão para iOS e Android em `registerPushToken.js`
-- [ ] **T010** [US4] Adicionar fluxo de permissão contextual `enablePushAtIntent` ao `ProtocolFormBody.jsx` ao ativar alarme crítico
-- [ ] **T011** [US4] Agrupar alarmes do mesmo minuto em um único trigger Notifee em `useAlarmScheduler.js`
-- [ ] **T012** [US4] Atualizar ações rápidas para tratar registro em lote no `quickDoseRegistration.js`
-- [ ] **T013** [US4] Atualizar tela cheia do alarme `AlarmFullScreen.jsx` para exibir lista de doses agrupadas e confirmar em lote
-- [ ] **T013a** [US3/US4] Ajustar o copy de exibição do alarme local no `alarmService.js` (incluindo suporte a plano essencial e doses avulsas essenciais)
-- [ ] **T014** [C4] Executar testes do app mobile e validar funcionamento dos handlers de doses e lote
-- [ ] **T015** [C4] Rodar suite completa de validação `rtk npm run validate:agent` e `rtk lint`
+- [x] **T009** [US4] Forçar `native_alarm_enabled: true` por padrão para iOS e Android em `registerPushToken.js`
+- [x] **T010** [US4] Adicionar fluxo de permissão contextual `enablePushAtIntent` ao `ProtocolFormBody.jsx` ao ativar alarme crítico
+- [x] **T011** [US4] Agrupar alarmes do mesmo minuto em um único trigger Notifee em `useAlarmScheduler.js`
+- [x] **T012** [US4] Atualizar ações rápidas para tratar registro em lote no `quickDoseRegistration.js`
+- [x] **T013** [US4] Atualizar tela cheia do alarme `AlarmFullScreen.jsx` para exibir lista de doses agrupadas e confirmar em lote
+- [x] **T013a** [US3/US4] Ajustar o copy de exibição do alarme local no `alarmService.js` (incluindo suporte a plano essencial e doses avulsas essenciais)
+- [x] **T014** [C4] Executar testes do app mobile e validar funcionamento dos handlers de doses e lote
+- [x] **T015** [C4] Rodar suite completa de validação `rtk npm run validate:agent` e `rtk lint`
 - [ ] **T016** [C5] Executar bump de versão em `apps/mobile/app.config.js`
 - [ ] **T017** [C5] Atualizar `CHANGELOG.md` na seção `[Unreleased]` em português
 - [ ] **T018** [C5] Registrar logs do SQP e DEVFLOW C5 no journal de eventos e weekly journal

--- a/plans/specs/025-fix-notifications-alarms/tasks.md
+++ b/plans/specs/025-fix-notifications-alarms/tasks.md
@@ -16,7 +16,7 @@
 - [ ] **T013a** [US3/US4] Ajustar o copy de exibição do alarme local no `alarmService.js` (incluindo suporte a plano essencial e doses avulsas essenciais)
 - [ ] **T014** [C4] Executar testes do app mobile e validar funcionamento dos handlers de doses e lote
 - [ ] **T015** [C4] Rodar suite completa de validação `rtk npm run validate:agent` e `rtk lint`
-- [ ] **T016** [C5] Executar bump de versão em `apps/mobile/package.json`
+- [ ] **T016** [C5] Executar bump de versão em `apps/mobile/app.config.js`
 - [ ] **T017** [C5] Atualizar `CHANGELOG.md` na seção `[Unreleased]` em português
 - [ ] **T018** [C5] Registrar logs do SQP e DEVFLOW C5 no journal de eventos e weekly journal
 - [ ] **T019** [C5] Atualizar status da sessão no `.agent/state.json` para `"completed"`

--- a/plans/specs/025-fix-notifications-alarms/tasks.md
+++ b/plans/specs/025-fix-notifications-alarms/tasks.md
@@ -16,7 +16,7 @@
 - [x] **T013a** [US3/US4] Ajustar o copy de exibição do alarme local no `alarmService.js` (incluindo suporte a plano essencial e doses avulsas essenciais)
 - [x] **T014** [C4] Executar testes do app mobile e validar funcionamento dos handlers de doses e lote
 - [x] **T015** [C4] Rodar suite completa de validação `rtk npm run validate:agent` e `rtk lint`
-- [ ] **T016** [C5] Executar bump de versão em `apps/mobile/app.config.js`
+- [x] **T016** [C5] Executar bump de versão em `apps/mobile/app.config.js`
 - [ ] **T017** [C5] Atualizar `CHANGELOG.md` na seção `[Unreleased]` em português
 - [ ] **T018** [C5] Registrar logs do SQP e DEVFLOW C5 no journal de eventos e weekly journal
 - [ ] **T019** [C5] Atualizar status da sessão no `.agent/state.json` para `"completed"`

--- a/server/bot/__tests__/tasks.test.js
+++ b/server/bot/__tests__/tasks.test.js
@@ -1,10 +1,31 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { 
   runDailyDigest, 
   runDailyAdherenceReport, 
   checkStockAlerts 
 } from '../tasks.js';
-// import { supabase } from '../../services/supabase.js';
+
+// Setup de variáveis de controle de tempo mockado global para simplificar dateUtils
+globalThis.__mockTime = '09:00';
+globalThis.__mockWeekday = 0;
+globalThis.__mockDayOfMonth = 1;
+
+vi.mock('../../utils/dateUtils.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getCurrentTimeInTimezone: vi.fn(() => {
+      return globalThis.__mockTime;
+    }),
+    getCurrentDatePartsInTimezone: vi.fn(() => {
+      return {
+        hhmm: globalThis.__mockTime,
+        weekday: globalThis.__mockWeekday,
+        dayOfMonth: globalThis.__mockDayOfMonth
+      };
+    })
+  };
+});
 
 const mockDataQueue = [];
 
@@ -16,11 +37,13 @@ const { mockSupabase } = vi.hoisted(() => {
     neq: vi.fn().mockReturnThis(),
     in: vi.fn().mockReturnThis(),
     gte: vi.fn().mockReturnThis(),
+    lte: vi.fn().mockReturnThis(),
     lt: vi.fn().mockReturnThis(),
     single: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
     limit: vi.fn().mockReturnThis(),
     contains: vi.fn().mockReturnThis(),
+    or: vi.fn().mockReturnThis(),
     // Supabase queries are thenables
     then: vi.fn((onFulfilled) => {
       const result = mockDataQueue.shift() || { data: [], error: null };
@@ -34,19 +57,28 @@ vi.mock('../../services/supabase.js', () => ({
   supabase: mockSupabase
 }));
 
+vi.mock('../doseInstanceScheduler.js', () => ({
+  sweepMissedInstances: vi.fn(() => Promise.resolve(0)),
+  generateDoseInstances: vi.fn(() => Promise.resolve({ processed: 0, generated: 0 })),
+  cleanupPausedProtocols: vi.fn(() => Promise.resolve({ cleaned: 0 }))
+}));
+
 // Helper to set mock results in order
 const setMockData = (data, error = null) => {
   mockDataQueue.push({ data, error });
 };
 
-
+// Helper to set count results in order (for doseInstanceRepo.countByStatus)
+const setMockCount = (count) => {
+  mockDataQueue.push({ count, error: null });
+};
 
 vi.mock('../../bot/logger.js', () => ({
   createLogger: () => ({
-    info: vi.fn(),
-    error: vi.fn(),
-    warn: vi.fn(),
-    debug: vi.fn(),
+    info: vi.fn(console.log),
+    error: vi.fn((msg, err, ctx) => console.error(msg, err, ctx)),
+    warn: vi.fn(console.warn),
+    debug: vi.fn(console.log),
   }),
 }));
 
@@ -55,7 +87,7 @@ vi.mock('../../services/notificationDeduplicator.js', () => ({
   shouldSendGroupedNotification: vi.fn(() => Promise.resolve(true)),
 }));
 
-describe('Tasks Service - Wave 11 Refactor', () => {
+describe('Tasks Service - Wave 11 Refactor & Phase 3', () => {
   let mockDispatcher;
 
   beforeEach(() => {
@@ -66,88 +98,113 @@ describe('Tasks Service - Wave 11 Refactor', () => {
     };
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   describe('runDailyDigest', () => {
     it('should correctly build the Morning Planner message', async () => {
-      // Mock user settings
-      setMockData([{ user_id: 'user1', display_name: 'Test User', digest_time: '08:00', timezone: 'America/Sao_Paulo' }]);
+      globalThis.__mockTime = '08:00';
+      globalThis.__mockWeekday = 1; // Segunda-feira
 
-      // Mock protocols
+      // 1. Mock user settings (notification_mode = digest_morning)
+      setMockData([{ user_id: 'user1', display_name: 'Test User', digest_time: '08:00', timezone: 'America/Sao_Paulo', notification_mode: 'digest_morning' }]);
+
+      // 2. Mock active protocols for the user
       setMockData([
         { 
           user_id: 'user1', 
           name: 'Med 1', 
           time_schedule: ['08:00', '20:00'], 
           medicine: { name: 'Aspirina', dosage_unit: 'pill' },
-          dosage_per_intake: 1
+          dosage_per_intake: 1,
+          frequency: 'diário',
+          active: true
         }
       ]);
 
-      // Mock logs (yesterday)
-      setMockData([{ id: 'log1' }]); // 1 dose taken yesterday
-
       await runDailyDigest({}, { correlationId: 'test-corr', notificationDispatcher: mockDispatcher });
 
-      expect(mockDispatcher.dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockDispatcher.dispatch).toHaveBeenCalledWith({
+        userId: 'user1',
         kind: 'daily_digest',
-        payload: expect.objectContaining({
-          metadata: expect.objectContaining({
-            greeting: 'Bom dia',
-            yesterdayPercentage: 50, // 1 taken / 2 scheduled
-            scheduleCount: 2,
-          }),
+        data: expect.objectContaining({
+          firstName: 'Test User',
+          hour: 8,
+          pendingCount: 2,
+          medicines: expect.arrayContaining([
+            expect.objectContaining({ name: 'Aspirina', time: '08:00' }),
+            expect.objectContaining({ name: 'Aspirina', time: '20:00' })
+          ])
         }),
-      }));
+        context: expect.objectContaining({
+          correlationId: 'test-corr'
+        })
+      });
     });
   });
 
   describe('runDailyAdherenceReport', () => {
-    it('should generate storytelling based on performance improvement', async () => {
-      // Mock user settings (23:00)
-      setMockData([{ user_id: 'user1', display_name: 'Test User', digest_time: '23:00', timezone: 'America/Sao_Paulo' }]);
+    it('should generate storytelling based on yesterday vs anteontem performance', async () => {
+      globalThis.__mockTime = '09:00';
+      globalThis.__mockWeekday = 0; // Domingo
 
-      // Mock protocols
-      setMockData([
-        { 
-          user_id: 'user1', 
-          name: 'Med 1', 
-          time_schedule: ['08:00', '20:00'], 
-          medicine: { name: 'Aspirina' }
-        }
-      ]);
+      // 1. Mock user settings (retrieved in runDailyAdherenceReportViaDispatcher)
+      setMockData([{ user_id: 'user1', display_name: 'Test User', timezone: 'America/Sao_Paulo', notification_mode: 'active' }]);
 
-      // Mock logs (today and yesterday)
-      setMockData([
-        { taken_at: '2026-04-29T08:05:00Z', protocol_id: 'p1' }, // today
-        { taken_at: '2026-04-29T20:10:00Z', protocol_id: 'p1' }, // today (100%)
-        { taken_at: '2026-04-28T08:10:00Z', protocol_id: 'p1' }, // yesterday (50%)
-      ]);
+      // 2. Mock protocols active query (Filtro 1)
+      setMockData([{ id: 'p1' }]);
+
+      // 3. Mock yesterdayCounts (taken=2, missed=0, pending=0, skipped_paused=0, skipped_user=0)
+      setMockCount(2); // taken
+      setMockCount(0); // missed
+      setMockCount(0); // pending
+      setMockCount(0); // skipped_paused
+      setMockCount(0); // skipped_user
+
+      // 4. Mock beforeYesterdayCounts (taken=1, missed=1, pending=0, skipped_paused=0, skipped_user=0)
+      setMockCount(1); // taken
+      setMockCount(1); // missed
+      setMockCount(0); // pending
+      setMockCount(0); // skipped_paused
+      setMockCount(0); // skipped_user
 
       await runDailyAdherenceReport({}, { correlationId: 'test-corr', notificationDispatcher: mockDispatcher });
 
-      expect(mockDispatcher.dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockDispatcher.dispatch).toHaveBeenCalledWith({
+        userId: 'user1',
         kind: 'adherence_report',
-        payload: expect.objectContaining({
-          metadata: expect.objectContaining({
-            percentage: 100,
-            storytelling: expect.stringContaining('📈 Melhora'),
-          }),
+        data: expect.objectContaining({
+          firstName: 'Test User',
+          period: 'ontem',
+          percentage: 100,
+          taken: 2,
+          total: 2,
+          comparison: expect.objectContaining({
+            previousPercentage: 50,
+            deltaPercent: 50,
+            trend: 'up'
+          })
         }),
-      }));
+        context: expect.objectContaining({
+          correlationId: 'test-corr',
+          jobType: 'adherence_report'
+        })
+      });
     });
   });
 
   describe('checkStockAlerts', () => {
     it('should provide predictive stock alerts (days remaining)', async () => {
-      // Mock users
+      // 1. Mock user settings
       setMockData([{ user_id: 'user1', timezone: 'America/Sao_Paulo' }]);
 
-      // Mock protocols (consumption calculation)
+      // 2. Mock active protocols
       setMockData([
-        { user_id: 'user1', medicine_id: 'med1', time_schedule: ['08:00', '20:00'], dosage_per_intake: 1 }
+        { user_id: 'user1', medicine_id: 'med1', time_schedule: ['08:00', '20:00'], dosage_per_intake: 1, frequency: 'diário', active: true }
       ]);
 
-      // Mock stock
+      // 3. Mock stock
       setMockData([
         { user_id: 'user1', medicine_id: 'med1', quantity: 10, medicine: { name: 'Aspirina' } }
       ]);
@@ -155,16 +212,19 @@ describe('Tasks Service - Wave 11 Refactor', () => {
       await checkStockAlerts({}, { correlationId: 'test-corr', notificationDispatcher: mockDispatcher });
 
       // Daily consumption = 2. Stock = 10. Days remaining = 5.
-      expect(mockDispatcher.dispatch).toHaveBeenCalledWith(expect.objectContaining({
+      expect(mockDispatcher.dispatch).toHaveBeenCalledWith({
+        userId: 'user1',
         kind: 'stock_alert',
-        payload: expect.objectContaining({
-          metadata: expect.objectContaining({
-            daysRemaining: 5,
-            stockQuantity: 10,
-          }),
+        data: expect.objectContaining({
+          medicineName: 'Aspirina',
+          remaining: 10,
+          daysRemaining: 5
         }),
-      }));
+        context: expect.objectContaining({
+          correlationId: 'test-corr',
+          jobType: 'stock_alert_dispatcher'
+        })
+      });
     });
   });
-
 });

--- a/server/bot/_adherenceHelpers.js
+++ b/server/bot/_adherenceHelpers.js
@@ -6,7 +6,7 @@ import { createDoseInstanceRepository } from '@dosiq/core';
 import { sweepMissedInstances } from './doseInstanceScheduler.js';
 
 const logger = createLogger('AdherenceHelpers');
-const ADHERENCE_REPORT_TIME = '23:00';
+const ADHERENCE_REPORT_TIME = '09:00';
 
 // Adesão do bot ← dose_instances (S3.7/ADR-054): % = taken/(taken+missed), skipped_* neutro.
 // countByStatus é head-count server-side (R-249 OOM-safe, imune a truncamento PostgREST AP-186).
@@ -52,44 +52,63 @@ async function _getEligibleUsersForAdherence(users, correlationId) {
 async function _processUserAdherence(user, dispatcher, correlationId) {
   const { user_id: userId, display_name: displayName } = user;
   try {
+    // Filtro 1: Apenas usuários com tratamentos ativos no banco
+    const { data: activeProtocols, error: protocolsError } = await supabase
+      .from('protocols')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('active', true)
+      .limit(1);
+
+    if (protocolsError || !activeProtocols || activeProtocols.length === 0) {
+      logger.debug(`Usuário sem tratamentos ativos. Pulando relatório diário.`, { userId });
+      return;
+    }
+
     const dateToday = getTodayLocal();
     const startOfDay = parseLocalDate(dateToday);
+    
+    // Período de Ontem (análise principal): D-1 00:00:00 até D-1 23:59:59.999
     const dateYesterdayDate = addDays(startOfDay, -1);
-
-    // Adesão de hoje e ontem ← dose_instances por status (head-count server-side).
-    // Janela por scheduled_for; o sweep das 23h (runDaily) já fechou as pending vencidas.
-    // countByStatus usa limites inclusivos (gte/lte) → o teto de ontem deve excluir o
-    // exato startOfDay (senão uma instância às 00:00 conta nos dois dias — double-count).
-    // Nota G1 (ADR-053): startOfDay vem de parseLocalDate (meia-noite no tz do servidor),
-    // não da meia-noite real de SP — alinhamento fino de tz fica para a F4.
-    const todayCounts = await doseInstanceRepo.countByStatus({
-      userId, fromTs: startOfDay.toISOString(), toTs: addDays(startOfDay, 1).toISOString(),
-    });
-    // Teto exclusivo de ontem (ms-1): aritmética de epoch, não o parse de string YYYY-MM-DD do R-020.
     // eslint-disable-next-line no-restricted-syntax
     const yesterdayEndExclusive = new Date(startOfDay.getTime() - 1).toISOString();
     const yesterdayCounts = await doseInstanceRepo.countByStatus({
       userId, fromTs: dateYesterdayDate.toISOString(), toTs: yesterdayEndExclusive,
     });
 
-    const takenDoses = todayCounts.taken;
-    const totalToday = todayCounts.taken + todayCounts.missed;
-    const percentage = _adherencePct(todayCounts.taken, todayCounts.missed);
-    const percentageYesterday = _adherencePct(yesterdayCounts.taken, yesterdayCounts.missed);
-    const hasYesterday = (yesterdayCounts.taken + yesterdayCounts.missed) > 0;
+    const totalYesterday = yesterdayCounts.taken + yesterdayCounts.missed;
 
-    const delta = percentage - percentageYesterday;
+    // Filtro 2: Apenas usuários com pelo menos 1 dose esperada no período analisado
+    if (totalYesterday === 0) {
+      logger.debug(`Usuário sem doses esperadas ontem. Pulando relatório diário.`, { userId });
+      return;
+    }
+
+    // Período de Anteontem (para comparação): D-2 00:00:00 até D-2 23:59:59.999
+    const dateBeforeYesterdayDate = addDays(startOfDay, -2);
+    // eslint-disable-next-line no-restricted-syntax
+    const beforeYesterdayEndExclusive = new Date(dateYesterdayDate.getTime() - 1).toISOString();
+    const beforeYesterdayCounts = await doseInstanceRepo.countByStatus({
+      userId, fromTs: dateBeforeYesterdayDate.toISOString(), toTs: beforeYesterdayEndExclusive,
+    });
+
+    const takenDoses = yesterdayCounts.taken;
+    const percentage = _adherencePct(yesterdayCounts.taken, yesterdayCounts.missed);
+    const percentageBeforeYesterday = _adherencePct(beforeYesterdayCounts.taken, beforeYesterdayCounts.missed);
+    const hasBeforeYesterday = (beforeYesterdayCounts.taken + beforeYesterdayCounts.missed) > 0;
+
+    const delta = percentage - percentageBeforeYesterday;
     const trend = delta > 0 ? 'up' : delta < 0 ? 'down' : 'flat';
-    const comparison = hasYesterday
-      ? { previousPercentage: percentageYesterday, deltaPercent: Math.abs(delta), trend }
+    const comparison = hasBeforeYesterday
+      ? { previousPercentage: percentageBeforeYesterday, deltaPercent: Math.abs(delta), trend }
       : undefined;
 
     const data = {
       firstName: displayName || 'Paciente',
-      period: 'hoje',
+      period: 'ontem',
       percentage,
       taken: takenDoses,
-      total: totalToday,
+      total: totalYesterday,
       comparison
     };
 
@@ -124,13 +143,12 @@ export async function runDailyAdherenceReportViaDispatcher(dispatcher, correlati
 
     logger.info(`Running daily adherence report for ${eligibleUsers.length} users`, { correlationId });
 
-    // E2/S3.7: fechar as pending vencidas ANTES de medir — o relatório das 23h lê o dia
-    // corrente antes do sweep das 3AM; sem isto doses esquecidas seguem pending e inflam a
-    // adesão. Idempotente (writer #3, AP-190). Global, mas roda 1× quando alguém bate 23h.
+    // E2/S3.7: fechar as pending vencidas ANTES de medir — o relatório das 9h lê as doses
+    // de ontem, mas o sweep prévio garante consistência. Idempotente (writer #3, AP-190).
     try {
       await sweepMissedInstances();
     } catch (sweepErr) {
-      logger.error('Falha no sweep pré-relatório 23h (segue best-effort)', sweepErr, { correlationId });
+      logger.error('Falha no sweep pré-relatório 9h (segue best-effort)', sweepErr, { correlationId });
     }
 
     for (const user of eligibleUsers) {
@@ -160,15 +178,28 @@ export async function checkAdherenceReportsViaDispatcher(dispatcher, correlation
 
       const timezone = user.timezone || 'America/Sao_Paulo';
       const { hhmm, weekday } = getCurrentDatePartsInTimezone(timezone);
-      if (weekday !== 0 || hhmm !== '23:00') continue;
+      if (weekday !== 0 || hhmm !== '09:00') continue;
+
+      // Filtro 1: Apenas usuários com tratamentos ativos no banco
+      const { data: activeProtocols, error: protocolsError } = await supabase
+        .from('protocols')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('active', true)
+        .limit(1);
+      if (protocolsError || !activeProtocols || activeProtocols.length === 0) continue;
 
       const shouldSend = await shouldSendNotification(userId, null, 'weekly_adherence');
       if (!shouldSend) continue;
 
       // Adesão dos últimos 7 dias ← dose_instances (head-count server-side, janela UTC real).
       const counts = await doseInstanceRepo.countByStatus({ userId, ..._utcWindow(7) });
-      const takenDoses = counts.taken;
       const total = counts.taken + counts.missed;
+
+      // Filtro 2: Apenas usuários com pelo menos 1 dose esperada na janela
+      if (total === 0) continue;
+
+      const takenDoses = counts.taken;
       const percentage = _adherencePct(counts.taken, counts.missed);
 
       await dispatcher.dispatch({
@@ -207,15 +238,28 @@ export async function checkMonthlyReportViaDispatcher(dispatcher, correlationId)
 
       const timezone = user.timezone || 'America/Sao_Paulo';
       const { hhmm, dayOfMonth } = getCurrentDatePartsInTimezone(timezone);
-      if (dayOfMonth !== 1 || hhmm !== '10:00') continue;
+      if (dayOfMonth !== 1 || hhmm !== '09:00') continue;
+
+      // Filtro 1: Apenas usuários com tratamentos ativos no banco
+      const { data: activeProtocols, error: protocolsError } = await supabase
+        .from('protocols')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('active', true)
+        .limit(1);
+      if (protocolsError || !activeProtocols || activeProtocols.length === 0) continue;
 
       const shouldSend = await shouldSendNotification(userId, null, 'monthly_report');
       if (!shouldSend) continue;
 
       // Adesão dos últimos 30 dias ← dose_instances (head-count server-side, R-249, janela UTC real).
       const counts = await doseInstanceRepo.countByStatus({ userId, ..._utcWindow(30) });
-      const takenDoses = counts.taken;
       const total = counts.taken + counts.missed;
+
+      // Filtro 2: Apenas usuários com pelo menos 1 dose esperada na janela
+      if (total === 0) continue;
+
+      const takenDoses = counts.taken;
       const percentage = _adherencePct(counts.taken, counts.missed);
 
       await dispatcher.dispatch({

--- a/server/bot/_adherenceHelpers.js
+++ b/server/bot/_adherenceHelpers.js
@@ -49,18 +49,22 @@ async function _getEligibleUsersForAdherence(users, correlationId) {
 
 // _getAdherenceStorytelling removed — moved to Layer 2 (buildNotificationPayload.js)
 
+async function _hasActiveProtocols(userId) {
+  const { data, error } = await supabase
+    .from('protocols')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('active', true)
+    .limit(1);
+  return !error && data && data.length > 0;
+}
+
 async function _processUserAdherence(user, dispatcher, correlationId) {
   const { user_id: userId, display_name: displayName } = user;
   try {
     // Filtro 1: Apenas usuários com tratamentos ativos no banco
-    const { data: activeProtocols, error: protocolsError } = await supabase
-      .from('protocols')
-      .select('id')
-      .eq('user_id', userId)
-      .eq('active', true)
-      .limit(1);
-
-    if (protocolsError || !activeProtocols || activeProtocols.length === 0) {
+    const hasActive = await _hasActiveProtocols(userId);
+    if (!hasActive) {
       logger.debug(`Usuário sem tratamentos ativos. Pulando relatório diário.`, { userId });
       return;
     }
@@ -181,13 +185,8 @@ export async function checkAdherenceReportsViaDispatcher(dispatcher, correlation
       if (weekday !== 0 || hhmm !== '09:00') continue;
 
       // Filtro 1: Apenas usuários com tratamentos ativos no banco
-      const { data: activeProtocols, error: protocolsError } = await supabase
-        .from('protocols')
-        .select('id')
-        .eq('user_id', userId)
-        .eq('active', true)
-        .limit(1);
-      if (protocolsError || !activeProtocols || activeProtocols.length === 0) continue;
+      const hasActive = await _hasActiveProtocols(userId);
+      if (!hasActive) continue;
 
       const shouldSend = await shouldSendNotification(userId, null, 'weekly_adherence');
       if (!shouldSend) continue;
@@ -241,13 +240,8 @@ export async function checkMonthlyReportViaDispatcher(dispatcher, correlationId)
       if (dayOfMonth !== 1 || hhmm !== '09:00') continue;
 
       // Filtro 1: Apenas usuários com tratamentos ativos no banco
-      const { data: activeProtocols, error: protocolsError } = await supabase
-        .from('protocols')
-        .select('id')
-        .eq('user_id', userId)
-        .eq('active', true)
-        .limit(1);
-      if (protocolsError || !activeProtocols || activeProtocols.length === 0) continue;
+      const hasActive = await _hasActiveProtocols(userId);
+      if (!hasActive) continue;
 
       const shouldSend = await shouldSendNotification(userId, null, 'monthly_report');
       if (!shouldSend) continue;

--- a/server/bot/alerts.js
+++ b/server/bot/alerts.js
@@ -29,7 +29,7 @@ function scheduleTask(name, schedule, task) {
 }
 
 export function startStockAlerts(bot, options = {}) {
-  // Run daily at 9:00 AM
+  // Run daily at 10:00 AM
   scheduleTask('checkStockAlerts', '0 10 * * *', () => checkStockAlerts(bot, options));
   console.log('✅ Alertas de estoque configurados (diariamente às 10h)');
 }

--- a/server/bot/alerts.js
+++ b/server/bot/alerts.js
@@ -30,14 +30,14 @@ function scheduleTask(name, schedule, task) {
 
 export function startStockAlerts(bot, options = {}) {
   // Run daily at 9:00 AM
-  scheduleTask('checkStockAlerts', '0 9 * * *', () => checkStockAlerts(bot, options));
-  console.log('✅ Alertas de estoque configurados (diariamente às 9h)');
+  scheduleTask('checkStockAlerts', '0 10 * * *', () => checkStockAlerts(bot, options));
+  console.log('✅ Alertas de estoque configurados (diariamente às 10h)');
 }
 
 export function startAdherenceReports(bot, options = {}) {
-  // Run every Sunday at 10:00 PM
-  scheduleTask('checkAdherenceReports', '0 22 * * 0', () => checkAdherenceReports(bot, options));
-  console.log('✅ Relatórios de adesão configurados (domingos às 22h)');
+  // Run every Sunday at 9:00 AM
+  scheduleTask('checkAdherenceReports', '0 9 * * 0', () => checkAdherenceReports(bot, options));
+  console.log('✅ Relatórios de adesão configurados (domingos às 9h)');
 }
 
 export function startTitrationAlerts(bot, options = {}) {
@@ -47,8 +47,8 @@ export function startTitrationAlerts(bot, options = {}) {
 }
 
 export function startMonthlyReport(bot, options = {}) {
-  scheduleTask('checkMonthlyReport', '0 10 1 * *', () => checkMonthlyReport(bot, options));
-  console.log('✅ Relatórios mensais configurados (dia 1 às 10h)');
+  scheduleTask('checkMonthlyReport', '0 9 1 * *', () => checkMonthlyReport(bot, options));
+  console.log('✅ Relatórios mensais configurados (dia 1 às 9h)');
 }
 
 // Re-export for compatibility

--- a/server/notifications/payloads/_payloadBuilders.js
+++ b/server/notifications/payloads/_payloadBuilders.js
@@ -14,9 +14,9 @@ import { getSaoPauloTime } from '../../utils/dateUtils.js';
 
 const formatDose = (qty, unit) => {
   if (!qty) return undefined;
-  const u = unit?.toLowerCase() || 'cp';
+  const u = unit?.toLowerCase() || 'un.';
   if (['mg', 'mcg', 'g', 'ml'].includes(u)) {
-    return '1 cp';
+    return '1 un.';
   }
   return `${qty} ${u}`;
 };
@@ -39,7 +39,7 @@ export function buildDailyDigestPayload(data) {
       const displayDosage = formatDose(m.dosagePerIntake, m.dosageUnit);
       richMsg += `💊 *${escapeMarkdownV2(m.name)}*\n`;
       richMsg += `⏰ ${escapeMarkdownV2(m.time)}${displayDosage ? ` \\(${escapeMarkdownV2(displayDosage)}\\)` : ''}\n\n`;
-      plainMsg += `⏰ ${m.name} - ${m.time}${displayDosage ? ` (${displayDosage})` : ''}\n`;
+      plainMsg += `⏰ ${m.name} — ${m.time}${displayDosage ? ` (${displayDosage})` : ''}\n`;
     });
     richMsg += `Não se esqueça de registrar no app\\!`;
     plainMsg += `Não se esqueça de registrar no app!`;


### PR DESCRIPTION
# feat(notifications): agrupamento de alarmes por plano e evolução de relatórios (Spec 025)

## 🎯 Resumo

Esta PR implementa o agrupamento de alarmes locais no dispositivo móvel por plano terapêutico para evitar poluição sonora e visual (Fase 2) e evolui a rotina de relatórios de adesão diária, semanal e mensal no backend (Fase 3), incluindo correção de bugs em queries de alarmes locais do mobile e na validação Zod de snooze.

---

## 📋 Tarefas Implementadas

### 📱 Fase 2: Aplicativo Mobile
- [x] Correção na query `getActiveProtocols` para retornar `treatment_plan_id` e a relação `treatment_plan`, habilitando o agrupamento visual de alarmes sob o plano terapêutico correto (evitando o fallback de doses avulsas genéricas).
- [x] Forçado `native_alarm_enabled: true` por padrão para iOS e Android em `registerPushToken.js`.
- [x] Adicionado fluxo de permissão contextual `enablePushAtIntent` ao `ProtocolFormBody.jsx` ao ativar alarme crítico.
- [x] Agrupamento de alarmes do mesmo minuto em um único trigger Notifee em `useAlarmScheduler.js`.
- [x] Atualização de ações rápidas para tratar registro em lote no `quickDoseRegistration.js`.
- [x] Atualização da tela cheia do alarme `AlarmFullScreen.jsx` para exibir lista de doses agrupadas e confirmar em lote.
- [x] Ajustes nos copies de exibição do alarme local em `alarmService.js`.
- [x] Correção do som de alarme crítico no Android e ajuste dos deeplinks de histórico.

### ⚙️ Fase 3: Evolução dos Relatórios de Adesão no Backend
- [x] Criação de rascunho de performance para estatísticas de adesão em `adherence_stats_approaches.md`.
- [x] Alteração do horário dos relatórios de adesão diária, semanal e mensal para as 09:00 AM (local).
- [x] Filtros no envio de relatórios para apenas processar usuários com protocolos ativos e pelo menos 1 dose devida/esperada no período de análise.
- [x] Ajuste do relatório diário de adesão para computar a janela de ontem (D-1) vs anteontem (D-2) e atualizar o copy do período de `'hoje'` para `'ontem'`.

### ✅ Testes e Qualidade
- [x] Testes unitários do backend (Vitest) atualizados e validados com sucesso.
- [x] Testes unitários do mobile (Jest) executados e passando com 100% de sucesso.
- [x] Lint executado sem erros nas alterações.

---

## 🔧 Arquivos Principais

```
apps/mobile/src/
├── features/dashboard/services/dashboardService.js  # Adicionado treatment_plan à busca de protocolos
├── features/notifications/screens/NotificationInboxScreen.jsx
├── features/treatments/components/ProtocolFormBody.jsx
└── platform/
    ├── alarms/
    │   ├── AlarmSchedulerBridge.jsx
    │   ├── alarmService.js
    │   └── useAlarmScheduler.js
    └── notifications/usePushNotifications.js

server/
├── bot/
    ├── __tests__/tasks.test.js
    ├── _adherenceHelpers.js
    └── alerts.js
api/notify.js
```

---

## 🚀 Como Testar

```bash
# 1. Instalar dependências
npm install

# 2. Executar testes críticos
npm run test:critical

# 3. Executar o linter
npm run lint
```

---

## 🔗 Issues Relacionadas

- Related to #645
- Related to #646

---

## 🏷️ Informações de Versionamento

**Tipo:** Minor
**Plataformas afetadas:** Web/PWA / Mobile / Shared/Core / Backend/Infra
**Versão anterior:** mobile 3.3.0 / web 4.0.0
**Versão sugerida:** mobile 3.4.0 / web 4.1.0
**Changelog:** CHANGELOG.md atualizado

---

## 🤖 AI Review Response

| Suggestion | Priority | Decision | Reason |
|------------|----------|----------|--------|
| Evitar `Promise.all` em `quickDoseRegistration.js` | High | Applied | Commit `7460337a` (usar loop sequencial `for...of`) |
| Corrigir horário comentado em `api/notify.js` | Medium | Applied | Commit `3110c68c` (comentário alinhado a 10h) |
| Corrigir horário comentado em `server/bot/alerts.js` | Medium | Applied | Commit `3110c68c` (comentário alinhado a 10h) |
| Extrair verificação de protocolos em `_adherenceHelpers.js` | Medium | Applied | Commit `7460337a` (Centralizado no helper `_hasActiveProtocols`) |

---

## ✅ Checklist de Verificação

### Código
- [x] Todos os testes passam (`npm run test:critical`)
- [x] Lint sem erros (`npm run lint`)
- [x] Build bem-sucedido (`npm run build`)

### Funcionalidade
- [x] Agrupamento correto de alarmes por plano terapêutico no mobile.
- [x] Relatórios de adesão disparados às 9h focados em dados de D-1 vs D-2 com filtros de inatividade.

/cc @reviewers
/cc @gemini-code-assist
