### PR TITLE
fix(bot): corrigir timezone no cron e emojis/saudações de lembretes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 ### Web/PWA (4.1.5 → 4.1.6)
 - **Fixed** (`patch`, PR #TBD): Atualizado para compatibilidade com a versão mais recente do Shared/Core.
 
+### Server
+- **Fixed** (`patch`, PR #TBD): Corrigido bug em `_reminderHelpers.js` onde lembretes individuais (`dose_reminder`) mostravam o emoji `🌙` e saudações noturnas a qualquer hora do dia por ausência de envio do parâmetro `hour` no payload de notificação.
+- **Fixed** (`patch`, PR #TBD): Corrigido duplo deslocamento de fuso horário de Brasília no endpoint `/api/notify.js` que causava atraso em execuções de cron e predições de estoque no Vercel (12:00 PM/1:00 PM em vez de 10:00 AM).
+- **Refactored** (`patch`, PR #TBD): Adicionada função utilitária `getRawNow()` em `server/utils/dateUtils.js` e substituído `new Date()` em `api/notify.js` para conformidade com regras do linter ESLint sem uso de diretivas bypass `eslint-disable`.
+
+
 ### Mobile (0.12.0 → 0.13.0)
 - **Alarmes Críticos Locais, Supressão de Pushes e Melhoria de Usabilidade** (Minor, Spec 025):
   - Habilitada a flag `native_alarm_enabled` por padrão para iOS e Android para supressão automática de pushes remotos de doses críticas e prevenção de duplicidades.

--- a/api/notify.js
+++ b/api/notify.js
@@ -15,7 +15,7 @@ import { dispatchNotification } from '../server/notifications/dispatcher/dispatc
 import { createClient } from '@supabase/supabase-js';
 import ws from 'ws';
 import { Expo } from 'expo-server-sdk';
-import { getServerTimestamp, getNow, getSaoPauloTime } from '../server/utils/dateUtils.js';
+import { getServerTimestamp, getSaoPauloTime, getRawNow } from '../server/utils/dateUtils.js';
 
 const logger = createLogger('CronNotify');
 
@@ -351,7 +351,7 @@ export default async function handler(req, res) {
   const bot = createNotifyBotAdapter(token);
   const notificationDispatcher = _createNotificationDispatcher(bot);
 
-  const now = getNow();
+  const now = getRawNow();
   const spDate = getSaoPauloTime(now);
 
   const currentHHMM = spDate.toLocaleTimeString('pt-BR', {

--- a/server/bot/_reminderHelpers.js
+++ b/server/bot/_reminderHelpers.js
@@ -73,7 +73,8 @@ async function _processUserReminderBlock(userId, currentHHMM, currentHour, block
       medicineId: dose.medicineId, 
       time: currentHHMM, 
       dosagePerIntake: dose.dosagePerIntake,
-      dosageUnit: dose.dosageUnit
+      dosageUnit: dose.dosageUnit,
+      hour: currentHour
     };
   }
 
@@ -261,6 +262,7 @@ async function _checkRemindersFromInstances(dispatcher, correlationId) {
               dosagePerIntake: dose.dosagePerIntake,
               dosageUnit: dose.dosageUnit,
               dosagePerPill: dose.dosagePerPill,
+              hour: currentHour,
               critical_alarm: dose.critical_alarm ?? false,
             };
           }

--- a/server/utils/dateUtils.js
+++ b/server/utils/dateUtils.js
@@ -46,6 +46,16 @@ export function getNow() {
 }
 
 /**
+ * Retorna a data/hora atual "bruta" (sem ajuste de fuso horário).
+ * Útil para timers e momentos que serão processados por outras funções de fuso.
+ * @returns {Date}
+ */
+export function getRawNow() {
+  return new Date();
+}
+
+
+/**
  * Converte string de data (YYYY-MM-DD) para Date em timezone local (SP)
  * @param {string} dateStr - Data no formato YYYY-MM-DD
  * @returns {Date} Date object em timezone local (meia-noite local de SP)


### PR DESCRIPTION
Corrigidos bugs de emojis incorretos nas mensagens do Telegram (ausência de hora no payload) e deslocamento duplo de fuso horário no cron. Centralizada a lógica de data bruta na nova função getRawNow() no utilitário de datas, eliminando o bypass do linter.