### PR TITLE
feat(db): medicamentos líquidos 022 Fase A — migração DB + RPC FIFO líquida

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 ### Web/PWA (4.1.5 → 4.1.6)
 - **Fixed** (`patch`, PR #TBD): Atualizado para compatibilidade com a versão mais recente do Shared/Core.
 
+### Backend/Infra (DB) — Medicamentos Líquidos 022 Fase A
+- **Added** (`minor`, PR #TBD): Migração `docs/migrations/20260607_liquid_meds_db.sql` — fundação de medicamentos líquidos (épico 022 Fase A): CHECK de `dosage_unit` com `mg/ml`/`ui/ml`; colunas `medicines.units_per_ml` (razão→ml genérica, ADR-058) e `medicines.presentation`; `protocols.intake_unit`; `CHECK (stock.quantity >= 0)`; migração idempotente de líquidos legados (`ml`/`gotas` → `mg/ml` + `intake_unit`). RPC `consume_stock_fifo` (4-arg) ganha ramo líquido (converte tomada→ml via `units_per_ml`, baixa decimal por FIFO); overload legacy 3-arg removido. Líquido derivado de `dosage_unit LIKE '%/ml'` (decisão-mãe).
+
 ### Server
+- **Changed** (`patch`, PR #TBD): `server/bot/callbacks/conversational.js` migrado para a assinatura 4-arg de `consume_stock_fifo` (passa `p_user_id`) após remoção do overload 3-arg (022 Fase A).
 - **Fixed** (`patch`, PR #TBD): Corrigido bug em `_reminderHelpers.js` onde lembretes individuais (`dose_reminder`) mostravam o emoji `🌙` e saudações noturnas a qualquer hora do dia por ausência de envio do parâmetro `hour` no payload de notificação.
 - **Fixed** (`patch`, PR #TBD): Corrigido duplo deslocamento de fuso horário de Brasília no endpoint `/api/notify.js` que causava atraso em execuções de cron e predições de estoque no Vercel (12:00 PM/1:00 PM em vez de 10:00 AM).
 - **Refactored** (`patch`, PR #TBD): Adicionada função utilitária `getRawNow()` em `server/utils/dateUtils.js` e substituído `new Date()` em `api/notify.js` para conformidade com regras do linter ESLint sem uso de diretivas bypass `eslint-disable`.

--- a/docs/migrations/20260607_liquid_meds_db.sql
+++ b/docs/migrations/20260607_liquid_meds_db.sql
@@ -1,0 +1,235 @@
+-- ============================================================================
+-- Migration: Medicamentos Líquidos (Épico 022) — Fase A (DB/Backend)
+-- Data: 2026-06-07
+-- Spec: plans/specs/022-liquid-medications/{spec,plan,analysis}.md
+-- Decisão-mãe: líquido := dosage_unit LIKE '%/ml' (não booleano is_liquid).
+-- Coordenação 012 (ADR-058): units_per_ml genérica (razão→ml) + presentation.
+--
+-- Idempotente: rodar 2× = no-op.
+-- Ordem: (A.1) CHECK dosage_unit → (A.2) colunas+checks → (A.3) migração dados
+--        → (A.4) RPC consume_stock_fifo 4-arg líquida + DROP overload 3-arg.
+--
+-- Evidência DB ao vivo (C1/T001, projeto kwqjtdsqkkbebfiaxubb):
+--   - dosage_unit: text livre, SEM CHECK (default 'mg'). Valores: mg(88) ui(3)
+--     ml(3) un(2) g(2) mcg(1); ZERO 'gotas'. A.1 = ADD (não drop/recreate).
+--   - units_per_ml / presentation / protocols.intake_unit: ausentes (NEW).
+--   - stock.quantity numeric NOT NULL, sem negativos (CHECK seguro).
+--   - consume_stock_fifo: 2 overloads (3-arg auth.uid() + 4-arg p_user_id).
+--     Callers: doseActions.js (4-arg), medicineLogService.js (4-arg),
+--     conversational.js (3-arg → migrado p/ 4-arg neste épico). DROP 3-arg.
+-- ============================================================================
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- A.1 — CHECK de unidades de concentração (ADD; não existia)
+-- Set legacy-safe: mantém ml/gotas até a migração A.3 zerar o uso de ml.
+-- O form (Fase C) deixa de oferecer ml/gotas como concentração.
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.medicines DROP CONSTRAINT IF EXISTS medicines_dosage_unit_check;
+ALTER TABLE public.medicines ADD CONSTRAINT medicines_dosage_unit_check
+  CHECK (dosage_unit IN ('mg','mcg','g','ml','ui','un','gotas','mg/ml','ui/ml'));
+
+-- ----------------------------------------------------------------------------
+-- A.2 — Colunas estruturais + check de saldo
+-- ----------------------------------------------------------------------------
+-- Coluna genérica de densidade/razão→ml (ADR-058; ex-drops_per_ml).
+-- Significado adapta-se à dosage_unit: gotas=20 (gotas/ml), ui/ml=100 (U-100), ml=1.
+-- Conversão no decremento: ml = p_quantity / units_per_ml (quando intake_unit='gotas').
+-- NUMERIC (não INTEGER) p/ futuras concentrações fracionárias; default 20 serve gotas.
+ALTER TABLE public.medicines ADD COLUMN IF NOT EXISTS units_per_ml NUMERIC DEFAULT 20;
+
+-- Forma farmacêutica explícita (additiva — ADR-058; alinha MEDICINE_TYPES).
+-- NÃO substitui is_liquid derivado (decisão-mãe). Eixo de forma que a 012 estende.
+ALTER TABLE public.medicines ADD COLUMN IF NOT EXISTS presentation TEXT DEFAULT 'comprimido';
+ALTER TABLE public.medicines DROP CONSTRAINT IF EXISTS medicines_presentation_check;
+ALTER TABLE public.medicines ADD CONSTRAINT medicines_presentation_check
+  CHECK (presentation IN ('comprimido','capsula','liquido','injecao','pomada','spray','outro'));
+
+-- Unidade física da tomada (gotas/ml/UI; NULL p/ sólidos).
+ALTER TABLE public.protocols ADD COLUMN IF NOT EXISTS intake_unit TEXT DEFAULT NULL;
+
+-- Saldo não-negativo (sem negativos hoje — verificado).
+ALTER TABLE public.stock DROP CONSTRAINT IF EXISTS chk_stock_quantity_non_negative;
+ALTER TABLE public.stock ADD CONSTRAINT chk_stock_quantity_non_negative CHECK (quantity >= 0);
+
+-- Colunas em tabelas existentes não exigem novos GRANTs (regra vale p/ CREATE TABLE). RLS preservada.
+
+-- ----------------------------------------------------------------------------
+-- A.3 — Migração de dados (ml/gotas → mg/ml + intake_unit + presentation)
+-- Idempotente. Hoje só há 3 linhas 'ml' (zero 'gotas').
+-- ----------------------------------------------------------------------------
+-- 3a. Move a unidade de tomada antiga p/ os protocolos do medicamento líquido legado.
+UPDATE public.protocols p
+SET intake_unit = m.dosage_unit          -- 'ml' ou 'gotas'
+FROM public.medicines m
+WHERE p.medicine_id = m.id
+  AND m.dosage_unit IN ('ml','gotas')
+  AND p.intake_unit IS NULL;
+
+-- 3b. Converte a unidade do medicamento p/ o modelo de concentração.
+UPDATE public.medicines
+SET dosage_unit  = 'mg/ml',
+    units_per_ml = COALESCE(units_per_ml, 20),
+    presentation = 'liquido'
+WHERE dosage_unit IN ('ml','gotas');
+
+-- 3c. Backfill de presentation p/ remanescentes sem valor (default cobre novas; legados NULL → comprimido).
+UPDATE public.medicines
+SET presentation = 'comprimido'
+WHERE presentation IS NULL;
+
+-- dosage_per_pill deixado como está (NULL p/ legados; massa ativa só exibida quando preenchida).
+-- 'ui' líquido legado (raríssimo, ambíguo vs sólido 'ui') NÃO convertido automaticamente — revisão manual.
+
+-- ----------------------------------------------------------------------------
+-- A.4 — RPC consume_stock_fifo (4-arg, sobrecarga líquida) + DROP overload 3-arg
+-- D1 (operador): migrar caller p/ 4-arg + DROP 3-arg (conversational.js editado).
+-- D2 (operador): manter FIFO purchase_date (sem FEFO).
+-- Preserva G2 (filtro entry_type != 'legacy_unrecoverable') + G3 (guard medicine_logs).
+-- Hardening: SET search_path = '' + refs public. qualificadas.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.consume_stock_fifo(
+  p_user_id UUID,
+  p_medicine_id UUID,
+  p_quantity NUMERIC,          -- dose na unidade de tomada (líquidos); unidades (sólidos)
+  p_medicine_log_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id UUID := p_user_id;
+  v_is_liquid BOOLEAN;
+  v_units_per_ml NUMERIC;       -- razão→ml genérica (gotas/ml=20, UI/ml=100); ex-drops_per_ml
+  v_intake_unit TEXT;
+  v_remaining NUMERIC;
+  v_total_available NUMERIC := 0;
+  v_total_consumed NUMERIC := 0;
+  v_rows_consumed INTEGER := 0;
+  v_to_consume NUMERIC;
+  v_stock_row public.stock%ROWTYPE;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'user_id é obrigatório para chamadas server-side';
+  END IF;
+
+  IF p_quantity IS NULL OR p_quantity <= 0 THEN
+    RAISE EXCEPTION 'Quantidade para consumo deve ser maior que zero';
+  END IF;
+
+  IF p_medicine_log_id IS NULL THEN
+    RAISE EXCEPTION 'medicine_log_id é obrigatório';
+  END IF;
+
+  -- Guard de posse (G3): log pertence ao user e ao medicamento.
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.medicine_logs
+    WHERE id = p_medicine_log_id
+      AND medicine_id = p_medicine_id
+      AND user_id = v_user_id
+  ) THEN
+    RAISE EXCEPTION 'Log de medicamento não encontrado para o usuário';
+  END IF;
+
+  -- Detecção de líquido pela unidade de concentração (decisão-mãe).
+  SELECT (dosage_unit LIKE '%/ml'), COALESCE(units_per_ml, 20)
+  INTO v_is_liquid, v_units_per_ml
+  FROM public.medicines
+  WHERE id = p_medicine_id;
+
+  IF COALESCE(v_is_liquid, FALSE) THEN
+    -- intake_unit do protocolo vinculado ao log.
+    SELECT p.intake_unit INTO v_intake_unit
+    FROM public.protocols p
+    JOIN public.medicine_logs l ON l.protocol_id = p.id
+    WHERE l.id = p_medicine_log_id;
+
+    IF v_intake_unit = 'gotas' THEN
+      v_remaining := ROUND(p_quantity / v_units_per_ml, 2);   -- gotas → ml
+    ELSE
+      v_remaining := ROUND(p_quantity, 2);                    -- 'ml', 'UI' (v1 escala direta), fallback
+    END IF;
+    -- NOTA (012): insulina basal estende o branch 'UI' p/ converter via v_units_per_ml. Fora do escopo 022.
+  ELSE
+    v_remaining := p_quantity;                                -- sólidos: linear inteiro
+  END IF;
+
+  -- Disponibilidade (G2: exclui legacy_unrecoverable).
+  SELECT COALESCE(SUM(quantity), 0)
+  INTO v_total_available
+  FROM public.stock
+  WHERE medicine_id = p_medicine_id
+    AND user_id = v_user_id
+    AND quantity > 0
+    AND entry_type != 'legacy_unrecoverable';
+
+  IF v_total_available < v_remaining THEN
+    RAISE EXCEPTION 'Estoque insuficiente';
+  END IF;
+
+  -- FIFO por purchase_date (D2: mantém ordem atual; sem FEFO).
+  FOR v_stock_row IN
+    SELECT *
+    FROM public.stock
+    WHERE medicine_id = p_medicine_id
+      AND user_id = v_user_id
+      AND quantity > 0
+      AND entry_type != 'legacy_unrecoverable'
+    ORDER BY purchase_date ASC, created_at ASC, id ASC
+    FOR UPDATE
+  LOOP
+    EXIT WHEN v_remaining <= 0;
+
+    v_to_consume := LEAST(v_stock_row.quantity, v_remaining);
+
+    UPDATE public.stock
+    SET quantity = quantity - v_to_consume
+    WHERE id = v_stock_row.id;
+
+    INSERT INTO public.stock_consumptions (
+      user_id, medicine_log_id, medicine_id, stock_id, quantity_consumed
+    )
+    VALUES (
+      v_user_id, p_medicine_log_id, p_medicine_id, v_stock_row.id, v_to_consume
+    );
+
+    v_remaining := v_remaining - v_to_consume;
+    v_total_consumed := v_total_consumed + v_to_consume;
+    v_rows_consumed := v_rows_consumed + 1;
+  END LOOP;
+
+  IF v_remaining > 0 THEN
+    RAISE EXCEPTION 'Falha de consistência: consumo FIFO incompleto';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'medicine_log_id', p_medicine_log_id,
+    'medicine_id', p_medicine_id,
+    'is_liquid', v_is_liquid,
+    'quantity_requested', p_quantity,
+    'quantity_consumed', v_total_consumed,
+    'consumption_rows_created', v_rows_consumed
+  );
+END;
+$$;
+
+-- SECURITY DEFINER hardening (CLAUDE.md).
+REVOKE EXECUTE ON FUNCTION public.consume_stock_fifo(UUID, UUID, NUMERIC, UUID) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.consume_stock_fifo(UUID, UUID, NUMERIC, UUID) FROM anon;
+GRANT EXECUTE ON FUNCTION public.consume_stock_fifo(UUID, UUID, NUMERIC, UUID) TO authenticated, service_role;
+
+-- DROP do overload legacy 3-arg (D1). Caller único (conversational.js) migrado p/ 4-arg.
+DROP FUNCTION IF EXISTS public.consume_stock_fifo(UUID, NUMERIC, UUID);
+
+COMMIT;
+
+-- ----------------------------------------------------------------------------
+-- Validação pós-migração (rodar manualmente após COMMIT):
+--   SELECT count(*) FROM public.medicines WHERE dosage_unit IN ('ml','gotas');  -- → 0
+--   SELECT proname, pg_get_function_identity_arguments(oid)
+--     FROM pg_proc WHERE proname='consume_stock_fifo';                          -- → só a 4-arg
+-- ----------------------------------------------------------------------------

--- a/docs/migrations/20260607_liquid_meds_db.sql
+++ b/docs/migrations/20260607_liquid_meds_db.sql
@@ -47,7 +47,11 @@ ALTER TABLE public.medicines ADD CONSTRAINT medicines_presentation_check
   CHECK (presentation IN ('comprimido','capsula','liquido','injecao','pomada','spray','outro'));
 
 -- Unidade física da tomada (gotas/ml/UI; NULL p/ sólidos).
+-- CHECK sincronizado com INTAKE_UNITS do core (R-082); 'UI' maiúsculo casa o enum Zod.
 ALTER TABLE public.protocols ADD COLUMN IF NOT EXISTS intake_unit TEXT DEFAULT NULL;
+ALTER TABLE public.protocols DROP CONSTRAINT IF EXISTS protocols_intake_unit_check;
+ALTER TABLE public.protocols ADD CONSTRAINT protocols_intake_unit_check
+  CHECK (intake_unit IN ('gotas','ml','UI'));  -- NULL passa (sólidos)
 
 -- Saldo não-negativo (sem negativos hoje — verificado).
 ALTER TABLE public.stock DROP CONSTRAINT IF EXISTS chk_stock_quantity_non_negative;
@@ -136,7 +140,8 @@ BEGIN
   END IF;
 
   -- Detecção de líquido pela unidade de concentração (decisão-mãe).
-  SELECT (dosage_unit LIKE '%/ml'), COALESCE(units_per_ml, 20)
+  -- NULLIF guarda contra units_per_ml = 0 no DB (evita divisão por zero); cai no default 20.
+  SELECT (dosage_unit LIKE '%/ml'), COALESCE(NULLIF(units_per_ml, 0), 20)
   INTO v_is_liquid, v_units_per_ml
   FROM public.medicines
   WHERE id = p_medicine_id;
@@ -148,12 +153,22 @@ BEGIN
     JOIN public.medicine_logs l ON l.protocol_id = p.id
     WHERE l.id = p_medicine_log_id;
 
+    -- Avulso (protocol_id NULL → sem intake_unit): default 'ml' (escala direta), nunca 'gotas'
+    -- (evita débito 20× ao tratar gotas como ml). Persistir intake_unit em medicine_logs p/
+    -- logs avulsos de gotas é follow-up da Fase B (logSchema).
+    v_intake_unit := COALESCE(v_intake_unit, 'ml');
+
     IF v_intake_unit = 'gotas' THEN
       v_remaining := ROUND(p_quantity / v_units_per_ml, 2);   -- gotas → ml
     ELSE
       v_remaining := ROUND(p_quantity, 2);                    -- 'ml', 'UI' (v1 escala direta), fallback
     END IF;
     -- NOTA (012): insulina basal estende o branch 'UI' p/ converter via v_units_per_ml. Fora do escopo 022.
+
+    -- Guard de no-op: dose > 0 que arredonda p/ 0.00 (ex: 0.004) não pode "consumir" silenciosamente.
+    IF v_remaining <= 0 THEN
+      RAISE EXCEPTION 'Dose muito pequena para débito de estoque (arredondou para 0 ml)';
+    END IF;
   ELSE
     v_remaining := p_quantity;                                -- sólidos: linear inteiro
   END IF;
@@ -165,7 +180,7 @@ BEGIN
   WHERE medicine_id = p_medicine_id
     AND user_id = v_user_id
     AND quantity > 0
-    AND entry_type != 'legacy_unrecoverable';
+    AND (entry_type IS NULL OR entry_type != 'legacy_unrecoverable');
 
   IF v_total_available < v_remaining THEN
     RAISE EXCEPTION 'Estoque insuficiente';
@@ -178,7 +193,7 @@ BEGIN
     WHERE medicine_id = p_medicine_id
       AND user_id = v_user_id
       AND quantity > 0
-      AND entry_type != 'legacy_unrecoverable'
+      AND (entry_type IS NULL OR entry_type != 'legacy_unrecoverable')
     ORDER BY purchase_date ASC, created_at ASC, id ASC
     FOR UPDATE
   LOOP

--- a/plans/specs/022-liquid-medications/analysis.md
+++ b/plans/specs/022-liquid-medications/analysis.md
@@ -115,3 +115,23 @@ G2/G3 = correções obrigatórias (preservar comportamento), sem decisão. ADD C
 - **G2/G3 preservados** no novo corpo 4-arg (filtro `legacy_unrecoverable` + guard `medicine_logs`). **G5:** adotar `SET search_path = ''` + refs `public.` qualificadas (hardening).
 
 Gaps resolvidos → reality check **PASS**. Escopo Fase A revisado: A.1 ADD CHECK · A.2 colunas · A.3 migração (só 3 `ml`) · A.4 RPC 4-arg líquida + DROP 3-arg + edit `conversational.js`.
+
+---
+
+## Failure Modes & Degenerate Inputs — `consume_stock_fifo` (R-270)
+
+> Tabela obrigatória pós-PR #650 (revisor pegou 7 defeitos comportamentais que o reality-check estrutural não viu). Toda função/RPC nova das Fases B/C herda este formato ANTES de codar.
+
+| Input / condição | Degenerado | Esperado | Coberto (commit) |
+|------------------|-----------|----------|------------------|
+| `p_user_id` | NULL | raise 'user_id obrigatório' | ✅ |
+| `p_quantity` | NULL / ≤0 | raise 'quantidade > 0' | ✅ |
+| `p_medicine_log_id` | NULL / log inexistente | raise (guard de posse) | ✅ G3 |
+| `units_per_ml` | `0` / NULL | `COALESCE(NULLIF(.,0),20)` — sem div/0 | ✅ 53d3c09f |
+| dose líquida | arredonda p/ `0.00` ml | raise 'dose muito pequena' (não no-op) | ✅ 53d3c09f |
+| `protocol_id` no log | NULL (avulso) | `COALESCE(intake_unit,'ml')` — nunca tratar gotas como ml | ✅ 53d3c09f (persistir unit em logs = follow-up B) |
+| `entry_type` | NULL | NULL-safe `(IS NULL OR != 'legacy_unrecoverable')` — não excluir | ✅ 53d3c09f |
+| múltiplos lotes | dose cruza frascos | zera 1º, debita saldo do próximo, atômico | ✅ teste |
+| sólido | — | caminho linear inteiro | ✅ teste |
+
+Teste: harness `BEGIN … ROLLBACK` no DB ao vivo (prod intocado), incluindo os casos que **devem** levantar exceção (dose minúscula confirmado RAISE).

--- a/plans/specs/022-liquid-medications/analysis.md
+++ b/plans/specs/022-liquid-medications/analysis.md
@@ -79,3 +79,39 @@ Mudança de formato (`ml`/`gotas` → `mg/ml` + `intake_unit`) **tem** entregáv
 | LOW | Cross-validação `_medicineIsLiquid` (form) vs. service | decidir no PR da Fase B, documentar |
 
 Sem CRITICAL/HIGH. Os 2 MEDIUM são confirmações de C1 já agendadas como tasks-gate (T001/T015) — não bloqueiam o planejamento, bloqueiam o código da fase respectiva até resolver.
+
+---
+
+## C1 Reality Check — Fase A (executado 2026-06-07, projeto kwqjtdsqkkbebfiaxubb)
+
+**T001 resolvido (evidência DB ao vivo):**
+| Claim do plan | Repo/DB real | Verified? | Nota |
+|---------------|--------------|-----------|------|
+| `medicines_dosage_unit_check` p/ DROP/recreate (A.1) | **Nenhum CHECK existe** — `dosage_unit text` livre, default `'mg'` | ✅ | A.1 vira **ADD** CHECK (não drop/recreate) |
+| Valores legados `ml`/`gotas` | `ml`=3, `gotas`=**0**; resto mg/ui/un/g/mcg ∈ enum-alvo | ✅ | migração toca só 3 linhas `ml`; ADD CHECK seguro |
+| `units_per_ml`/`presentation`/`protocols.intake_unit` ausentes | confirmado ausentes | ✅ | NEW |
+| `stock.quantity` sem negativos | `negative_stock=0` | ✅ | CHECK(quantity>=0) seguro |
+| `consume_stock_fifo` = 1 função (4-arg) | **2 overloads**: 3-arg (`auth.uid()`) + 4-arg (`p_user_id`) | ❌→ | plan assumiu 1 |
+
+**Gaps HIGH no plan A.4 (corpo da RPC) — corpo proposto diverge do real, causaria regressão:**
+
+| # | Sev | Gap | Real (DB) | Plan propôs | Ação |
+|---|-----|-----|-----------|-------------|------|
+| G1 | HIGH | Caller faltando | `conversational.js:319` chama a **3-arg** (chatbot dose) | plan só lista doseActions+medicineLogService (4-arg) | líquido não debitaria por volume no chatbot |
+| G2 | HIGH | Filtro `entry_type != 'legacy_unrecoverable'` | presente nos 2 (SUM + loop) | **omitido** | consumiria estoque legacy_unrecoverable = regressão |
+| G3 | HIGH | Guard `medicine_logs` existência (log↔user↔medicine) | presente nos 2 | **omitido** | perderia validação de posse |
+| G4 | MEDIUM | FIFO ordering | `purchase_date ASC, created_at, id` (FIFO puro) | `expiration_date ASC NULLS LAST, ...` (FEFO) | muda ordem p/ sólidos também — **decisão** |
+| G5 | LOW | `SET search_path` | `TO 'public'` | `= ''` + `public.` qualificado (hardening CLAUDE.md) | OK adotar `''`, mas exige todas refs qualificadas |
+
+**Decisões abertas (operador) antes de A.4:**
+- **D1 (G1):** cobrir a 3-arg? Opção (a) extrair helper privado `_consume_stock_fifo_impl(user,med,qty,log)` c/ lógica líquida e ambos overloads delegam (DRY, cobre chatbot); (b) migrar `conversational.js` p/ 4-arg + DROP 3-arg.
+- **D2 (G4):** FIFO atual (`purchase_date`) ou mudar p/ FEFO (`expiration_date` primeiro)? FEFO melhor p/ líquidos com validade, mas altera comportamento dos sólidos.
+
+G2/G3 = correções obrigatórias (preservar comportamento), sem decisão. ADD CHECK em `dosage_unit` com set legacy-safe `{mg,mcg,g,ml,ui,un,gotas,mg/ml,ui/ml}`.
+
+**Decisões resolvidas (operador, 2026-06-07):**
+- **D1 → migrar caller + DROP 3-arg.** `conversational.js:319` passa a 4-arg (`p_user_id: userId` — `userId` já em escopo em `_createLogAndDecrementStock`). `DROP FUNCTION public.consume_stock_fifo(uuid,numeric,uuid)`. Único caller 3-arg (grep server/apps/api/packages confirmou). A.4 mexe em código bot (cross-fase, aceito).
+- **D2 → manter FIFO `purchase_date`** (sem FEFO; menor blast radius, sólidos inalterados).
+- **G2/G3 preservados** no novo corpo 4-arg (filtro `legacy_unrecoverable` + guard `medicine_logs`). **G5:** adotar `SET search_path = ''` + refs `public.` qualificadas (hardening).
+
+Gaps resolvidos → reality check **PASS**. Escopo Fase A revisado: A.1 ADD CHECK · A.2 colunas · A.3 migração (só 3 `ml`) · A.4 RPC 4-arg líquida + DROP 3-arg + edit `conversational.js`.

--- a/plans/specs/022-liquid-medications/contracts/consume_stock_fifo.md
+++ b/plans/specs/022-liquid-medications/contracts/consume_stock_fifo.md
@@ -1,8 +1,8 @@
 # Contract: `consume_stock_fifo` (RPC PostgreSQL)
 
-**Tipo**: SQL function (SECURITY DEFINER) · **Status**: existente, sobrecarregada (não-breaking)
+**Tipo**: SQL function (SECURITY DEFINER) · **Status**: 4-arg sobrecarregada p/ líquido; overload 3-arg **REMOVIDO** (D1)
 
-## Assinatura (preservada)
+## Assinatura (única após Fase A)
 ```sql
 consume_stock_fifo(
   p_user_id UUID,
@@ -11,22 +11,27 @@ consume_stock_fifo(
   p_medicine_log_id UUID
 ) RETURNS JSONB
 ```
+> **Breaking interno (D1):** o overload legacy 3-arg `(p_medicine_id, p_quantity, p_medicine_log_id)` (que derivava user via `auth.uid()`) foi **DROPADO**. Único caller (`conversational.js`) migrado p/ 4-arg. Sem assinatura nova exposta a clientes além da 4-arg já existente.
 
 ## Comportamento
 - **Líquido** (`dosage_unit LIKE '%/ml'`): converte `p_quantity` p/ ml via `intake_unit` + `units_per_ml` (`gotas` → `ROUND(p_quantity/units_per_ml, 2)`; `ml`/`UI` → escala direta) e deduz por FIFO de `stock.quantity`.
 - **Sólido**: caminho linear inteiro (subtrai `p_quantity`).
-- FIFO por `expiration_date ASC NULLS LAST, purchase_date, created_at, id`, `FOR UPDATE`.
+- FIFO por `purchase_date ASC, created_at ASC, id ASC`, `FOR UPDATE` (D2: mantém ordem atual, sem FEFO).
+- Filtra `entry_type != 'legacy_unrecoverable'` (G2) na disponibilidade e no loop.
+- Guard de posse `medicine_logs` (log↔user↔medicine) antes de consumir (G3).
+- `SET search_path = ''` + refs `public.` qualificadas (hardening).
 - Grava `stock_consumptions.quantity_consumed` por lote.
-- `RAISE EXCEPTION` em saldo insuficiente / inputs nulos.
+- `RAISE EXCEPTION` em saldo insuficiente / inputs nulos / log não encontrado.
 
 ## Retorno
 ```json
 { "medicine_log_id", "medicine_id", "is_liquid", "quantity_requested", "quantity_consumed", "consumption_rows_created" }
 ```
 
-## Callers (não quebrar)
-- `server/services/medicineLogService.js`
-- `server/bot/callbacks/doseActions.js:96`
+## Callers (todos 4-arg após Fase A)
+- `server/services/medicineLogService.js:40`
+- `server/bot/callbacks/doseActions.js:98`
+- `server/bot/callbacks/conversational.js:319` (migrado 3-arg → 4-arg nesta fase)
 
 ## Compatibilidade
-Assinatura inalterada ⇒ **não-breaking**. Sólidos seguem caminho idêntico ao atual. `restore_stock_for_log` não requer mudança (lê `quantity_consumed` decimal).
+Sólidos seguem caminho idêntico ao atual (FIFO `purchase_date`). Líquido = ramo novo derivado da unidade. `restore_stock_for_log` não requer mudança (lê `quantity_consumed` decimal). Overload 3-arg removido — sem caller remanescente (grep server/apps/api/packages).

--- a/server/bot/callbacks/conversational.js
+++ b/server/bot/callbacks/conversational.js
@@ -317,6 +317,7 @@ async function _createLogAndDecrementStock(userId, protocolId, medicineId, pills
 
   if (!fetchError && stockEntries.length > 0) {
     const { error: consumeError } = await supabase.rpc('consume_stock_fifo', {
+      p_user_id: userId,
       p_medicine_id: medicineId,
       p_quantity: pillsToDecrease,
       p_medicine_log_id: createdLog.id


### PR DESCRIPTION
## Épico 022 — Medicamentos Líquidos · Fase A (DB/Backend)

Fundação ponta-a-ponta de líquidos, camada **DB/backend**. Líquido é **derivado** de `dosage_unit LIKE '%/ml'` (decisão-mãe PO), não booleano.

### Mudanças
**Migração `docs/migrations/20260607_liquid_meds_db.sql`** (idempotente):
- CHECK `dosage_unit` + `mg/ml`/`ui/ml` (ADD — não existia; valida `text` livre)
- `medicines.units_per_ml` (razão→ml genérica — ADR-058, reusada pela 012) + `medicines.presentation`
- `protocols.intake_unit` + `CHECK (stock.quantity >= 0)`
- Migração de líquidos legados `ml`/`gotas` → `mg/ml` + `intake_unit` (só 3 linhas `ml`, zero `gotas`)
- RPC `consume_stock_fifo` (4-arg): ramo líquido (tomada→ml via `units_per_ml`, baixa decimal FIFO `purchase_date`), preservando filtro `legacy_unrecoverable` + guard de posse; **DROP do overload legacy 3-arg**

**`server/bot/callbacks/conversational.js`**: migrado p/ assinatura 4-arg (`p_user_id`).

### Reality check (C1 vs DB ao vivo) — corrigiu 3 gaps do plano
- **G1**: caller `conversational.js` usava overload 3-arg (omitido no plano) → migrado + 3-arg dropado
- **G2**: filtro `entry_type != 'legacy_unrecoverable'` preservado (plano omitira)
- **G3**: guard `medicine_logs` (posse) preservado (plano omitira)

Registrado como **AP-217** (reescrever função SQL sem diff contra `pg_get_functiondef`).

### Testes
- **DB `BEGIN…ROLLBACK`** (prod intocado): líquido 15 gotas÷20 = 0,75 ml multilote FIFO (lote antigo zera, próximo debita 0,25) · sólido linear = 3 · migração `ml`→0 · overloads pós-DROP = 1 — **10/10 PASS**
- `validate:agent` **1116/1116** · lint-clean no arquivo alterado

### Decisões do operador
- **D1**: DROP overload 3-arg + migrar caller (vs manter ambos)
- **D2**: manter FIFO `purchase_date` (sem FEFO)

### ⚠️ Deploy
Migração **NÃO aplicada em prod** — será aplicada via MCP **pré-merge, após aprovação**.

### SQP (R-221)
Backend/Infra + Server(bot) · `minor` (fundação, não user-facing até Fase B/C) · sem bump de app · CHANGELOG `[Unreleased]` atualizado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AI Review Response (gemini-code-assist)

| Sugestão | Pri | Decisão | Commit/Razão |
|---|---|---|---|
| entry_type NULL-safe (disponibilidade) | High | Aplicada | 53d3c09f |
| entry_type NULL-safe (loop FIFO) | High | Aplicada | 53d3c09f |
| Log avulso líquido → débito 20× | High | Aplicada | 53d3c09f (COALESCE intake_unit ml); persistir em logs = follow-up Fase B |
| getTotalQuantity p/ validação | High | Declinada | Fora de escopo — código pré-existente, não tocado por esta PR |
| Divisão por zero (units_per_ml=0) | Medium | Aplicada | 53d3c09f (NULLIF) |
| CHECK intake_unit | Medium | Aplicada | 53d3c09f (gotas/ml/UI) |
| Consumo silencioso de zero | Medium | Aplicada | 53d3c09f (guard pós-ROUND) |
