### PR TITLE
feat(core): medicamentos líquidos 022 Fase B — schemas, formatDose, desmembramento

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 ## [Unreleased]
 
 ### Shared/Core
+- **Added** (`minor`, PR #TBD): Medicamentos líquidos 022 Fase B (core/validações/serviços). `medicineSchema`: `DOSAGE_UNITS` ganha `mg/ml`/`ui/ml` e perde `ml`/`gotas` (viram unidade de tomada); novos campos `units_per_ml` (razão→ml, ADR-058) e `presentation` (+`PRESENTATIONS`); `dosage_per_pill` agora nullable (líquidos legados); superRefine exige `units_per_ml` para unidades `/ml`. `protocolSchema`: campo `intake_unit` (`gotas`/`ml`/`UI`) + refine que o exige para líquidos. Cap `quantity_taken` revisado 100→1000 (`logSchema`, `costAnalysisSchema`, `adherencePatternSchema`, `reminderOptimizerSchema`) — cobre doses em gotas (R-022). Novo `formatDose(value, unit)` em `doseUnit.js` (vírgula PT-BR, singular/plural de gota). Novo `createPurchaseRepository.createLiquidPurchase` — desmembra N frascos × volume × preço total em N lotes via `create_purchase_with_stock`, compensando centavos no último (exposto no `stockService` web; mobile herda via spread).
 - **Fixed** (`patch`, PR #TBD): Corrigido `wipeFuturePending` e `wipeFuturePendingForProtocols` no repositório de instâncias de dose para deletar também instâncias com status `skipped_paused` no futuro. Isso garante que edições de agendamento ou propriedades (como `critical_alarm`) realizadas em tratamentos pausados limpem corretamente as instâncias futuras de 24h que estavam pausadas.
 
 ### Mobile (0.13.0 → 0.13.1)

--- a/apps/web/src/features/stock/services/stockService.js
+++ b/apps/web/src/features/stock/services/stockService.js
@@ -22,6 +22,9 @@ export const stockService = {
   getLowStockMedicines: (threshold) => stockRepo.getLowStockMedicines(threshold),
   // `add` = criar compra (cria entrada real em stock via RPC create_purchase_with_stock)
   add: (stock) => purchaseRepo.createPurchase(stock),
+  // Desmembramento de líquido: N frascos × volume × preço total → N lotes (022 Fase B).
+  // Mobile herda via spread {...purchaseRepo}; web mapeia explícito.
+  createLiquidPurchase: (input) => purchaseRepo.createLiquidPurchase(input),
   decrease: (medicineId, quantity, medicineLogId) =>
     stockRepo.decreaseStock(medicineId, quantity, medicineLogId),
   increase: (medicineId, quantity, options) =>

--- a/apps/web/src/schemas/__tests__/validation.test.js
+++ b/apps/web/src/schemas/__tests__/validation.test.js
@@ -179,14 +179,15 @@ describe('Schemas de Validação Zod', () => {
     })
 
     it('deve rejeitar quantidade muito alta', () => {
+      // Cap revisado 100→1000 (022 Fase B): rejeita só >1000.
       const log = {
         medicine_id: '123e4567-e89b-12d3-a456-426614174000',
-        quantity_taken: 150,
+        quantity_taken: 1500,
         taken_at: '2024-01-15T10:00:00Z',
       }
       const result = validateLogCreate(log)
       expect(result.success).toBe(false)
-      expect(result.errors[0].message).toContain('100')
+      expect(result.errors[0].message).toContain('1000')
     })
   })
 

--- a/packages/core/src/repositories/__tests__/createPurchaseRepository.test.js
+++ b/packages/core/src/repositories/__tests__/createPurchaseRepository.test.js
@@ -191,4 +191,69 @@ describe('createPurchaseRepository — parity', () => {
       await expect(repo.updatePurchase('p-1', { quantity: -5 })).rejects.toThrow(/Erro de validação/)
     })
   })
+
+  // ── createLiquidPurchase (desmembramento — 022 Fase B) ──
+  describe('createLiquidPurchase', () => {
+    const LIQ = {
+      medicineId: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d',
+      volumePerBottle: 100,
+      purchaseDate: '2026-01-10',
+    }
+
+    it('3 frascos / R$30 → 3 RPCs, p_quantity=100, unit_price=0.03 (0.30/frasco ÷ 100ml)', async () => {
+      client = makeClient({ data: [], error: null }, { data: { id: 'x' }, error: null })
+      const repo = createPurchaseRepository({ client, getUserId })
+      const res = await repo.createLiquidPurchase({ ...LIQ, numBottles: 3, totalPrice: 30 })
+      expect(res).toHaveLength(3)
+      const rpcs = client._rpcCalls.filter(([n]) => n === 'create_purchase_with_stock')
+      expect(rpcs).toHaveLength(3)
+      rpcs.forEach(([, args]) => {
+        expect(args.p_quantity).toBe(100)
+        expect(args.p_unit_price).toBeCloseTo(0.1, 4) // R$10/frasco ÷ 100ml = 0.10/ml
+      })
+    })
+
+    it('compensa centavos no último frasco (R$10 / 3 frascos)', async () => {
+      client = makeClient({ data: [], error: null }, { data: { id: 'x' }, error: null })
+      const repo = createPurchaseRepository({ client, getUserId })
+      await repo.createLiquidPurchase({ ...LIQ, numBottles: 3, totalPrice: 10 })
+      const rpcs = client._rpcCalls.filter(([n]) => n === 'create_purchase_with_stock')
+      // pricePerBottle=3.33 → unit_price 0.0333; último: 10-3.33*2=3.34 → 0.0334.
+      const prices = rpcs.map(([, a]) => a.p_unit_price)
+      expect(prices[0]).toBeCloseTo(0.0333, 4)
+      expect(prices[2]).toBeCloseTo(0.0334, 4)
+      // total reconstruído ≈ R$10 (sem perda de centavos)
+      const total = prices.reduce((s, p) => s + p * 100, 0)
+      expect(total).toBeCloseTo(10, 2)
+    })
+
+    it('1 frasco → 1 RPC sem compensação', async () => {
+      client = makeClient({ data: [], error: null }, { data: { id: 'x' }, error: null })
+      const repo = createPurchaseRepository({ client, getUserId })
+      await repo.createLiquidPurchase({ ...LIQ, numBottles: 1, totalPrice: 50 })
+      const rpcs = client._rpcCalls.filter(([n]) => n === 'create_purchase_with_stock')
+      expect(rpcs).toHaveLength(1)
+      expect(rpcs[0][1].p_unit_price).toBeCloseTo(0.5, 4)
+    })
+
+    it('numBottles ≤ 0 ou não-inteiro → rejeita (sem loop/div0)', async () => {
+      const repo = createPurchaseRepository({ client, getUserId })
+      await expect(repo.createLiquidPurchase({ ...LIQ, numBottles: 0, totalPrice: 10 })).rejects.toThrow(/frascos/)
+      await expect(repo.createLiquidPurchase({ ...LIQ, numBottles: 2.5, totalPrice: 10 })).rejects.toThrow(/frascos/)
+    })
+
+    it('volumePerBottle ≤ 0 → rejeita (evita div por zero no custo/ml)', async () => {
+      const repo = createPurchaseRepository({ client, getUserId })
+      await expect(
+        repo.createLiquidPurchase({ ...LIQ, volumePerBottle: 0, numBottles: 2, totalPrice: 10 })
+      ).rejects.toThrow(/Volume/)
+    })
+
+    it('totalPrice negativo → rejeita', async () => {
+      const repo = createPurchaseRepository({ client, getUserId })
+      await expect(
+        repo.createLiquidPurchase({ ...LIQ, numBottles: 2, totalPrice: -5 })
+      ).rejects.toThrow(/negativo/)
+    })
+  })
 })

--- a/packages/core/src/repositories/__tests__/createPurchaseRepository.test.js
+++ b/packages/core/src/repositories/__tests__/createPurchaseRepository.test.js
@@ -255,5 +255,14 @@ describe('createPurchaseRepository — parity', () => {
         repo.createLiquidPurchase({ ...LIQ, numBottles: 2, totalPrice: -5 })
       ).rejects.toThrow(/negativo/)
     })
+
+    it('centavos baixos (R$0,04 / 6 frascos) → nenhum unit_price negativo (review #651)', async () => {
+      client = makeClient({ data: [], error: null }, { data: { id: 'x' }, error: null })
+      const repo = createPurchaseRepository({ client, getUserId })
+      await repo.createLiquidPurchase({ ...LIQ, numBottles: 6, totalPrice: 0.04 })
+      const rpcs = client._rpcCalls.filter(([n]) => n === 'create_purchase_with_stock')
+      expect(rpcs).toHaveLength(6)
+      rpcs.forEach(([, a]) => expect(a.p_unit_price).toBeGreaterThanOrEqual(0))
+    })
   })
 })

--- a/packages/core/src/repositories/createPurchaseRepository.js
+++ b/packages/core/src/repositories/createPurchaseRepository.js
@@ -185,8 +185,11 @@ export function createPurchaseRepository({ client, getUserId }) {
       const round2 = (x) => Number(x.toFixed(2))
       const round4 = (x) => Number(x.toFixed(4))
 
-      const pricePerBottle = round2(totalPrice / numBottles)
-      // Último frasco absorve o resto p/ fechar o total exato (evita perda de centavos).
+      // Math.floor (não round2) p/ truncar: garante que pricePerBottle nunca exceda a fração
+      // do total. Senão, em centavos baixos (ex: R$0,04 / 6 frascos) o arredondamento p/ cima
+      // tornaria compensatedLast negativo → unit_price negativo (review #651).
+      const pricePerBottle = Math.floor((totalPrice / numBottles) * 100) / 100
+      // Último frasco absorve o resíduo (sempre >= 0) p/ fechar o total exato.
       const compensatedLast = round2(totalPrice - pricePerBottle * (numBottles - 1))
       const unitPriceMl = round4(pricePerBottle / volumePerBottle)
       const compensatedUnitPriceMl = round4(compensatedLast / volumePerBottle)

--- a/packages/core/src/repositories/createPurchaseRepository.js
+++ b/packages/core/src/repositories/createPurchaseRepository.js
@@ -140,6 +140,77 @@ export function createPurchaseRepository({ client, getUserId }) {
     },
 
     /**
+     * Desmembra a compra de um líquido em N frascos: N chamadas a `createPurchase`
+     * (1 purchase + 1 lote `stock` cada, `original_quantity = quantity = volumePerBottle`),
+     * com `unit_price` = custo POR ML. FIFO opera frasco a frasco. Compensa centavos no
+     * último frasco p/ o total reconstruído (Σ unit_price·volume) fechar exato (022 Fase B).
+     *
+     * @param {Object} input
+     * @param {string} input.medicineId
+     * @param {number} input.numBottles       Nº de frascos (inteiro > 0).
+     * @param {number} input.volumePerBottle  Volume nominal de cada frasco em ml (> 0).
+     * @param {number} input.totalPrice       Preço total da compra (R$, >= 0).
+     * @param {string} input.purchaseDate     YYYY-MM-DD.
+     * @param {string} [input.expirationDate]
+     * @param {string} [input.pharmacy]
+     * @param {string} [input.laboratory]
+     * @param {string} [input.notes]
+     * @returns {Promise<Array>} resultados das N RPCs (1 por lote).
+     * @throws {Error} se numBottles/volumePerBottle inválidos ou validação Zod falhar.
+     */
+    async createLiquidPurchase(input) {
+      const {
+        medicineId,
+        numBottles,
+        volumePerBottle,
+        totalPrice = 0,
+        purchaseDate,
+        expirationDate = null,
+        pharmacy = null,
+        laboratory = null,
+        notes = null,
+      } = input || {}
+
+      // Guards de input degenerado (R-270): evitam loop vazio e divisão por zero.
+      if (!Number.isInteger(numBottles) || numBottles <= 0) {
+        throw new Error('Número de frascos deve ser um inteiro maior que zero')
+      }
+      if (typeof volumePerBottle !== 'number' || volumePerBottle <= 0) {
+        throw new Error('Volume por frasco deve ser maior que zero')
+      }
+      if (typeof totalPrice !== 'number' || totalPrice < 0) {
+        throw new Error('Preço total não pode ser negativo')
+      }
+
+      const round2 = (x) => Number(x.toFixed(2))
+      const round4 = (x) => Number(x.toFixed(4))
+
+      const pricePerBottle = round2(totalPrice / numBottles)
+      // Último frasco absorve o resto p/ fechar o total exato (evita perda de centavos).
+      const compensatedLast = round2(totalPrice - pricePerBottle * (numBottles - 1))
+      const unitPriceMl = round4(pricePerBottle / volumePerBottle)
+      const compensatedUnitPriceMl = round4(compensatedLast / volumePerBottle)
+
+      const results = []
+      for (let i = 0; i < numBottles; i++) {
+        const isLast = i === numBottles - 1
+        // Reusa createPurchase (validação Zod + RPC create_purchase_with_stock por lote).
+        const data = await repo.createPurchase({
+          medicine_id: medicineId,
+          quantity: volumePerBottle,
+          unit_price: isLast ? compensatedUnitPriceMl : unitPriceMl,
+          purchase_date: purchaseDate,
+          expiration_date: expirationDate,
+          pharmacy,
+          laboratory,
+          notes,
+        })
+        results.push(data)
+      }
+      return results
+    },
+
+    /**
      * Edita uma purchase existente — APENAS metadados (preço, datas, farmácia,
      * lab, notas). NÃO altera `quantity_bought`: a quantidade está amarrada ao
      * lote em `stock` (saldo + FIFO) e qualquer correção de saldo passa pelo

--- a/packages/core/src/schemas/__tests__/validation.test.js
+++ b/packages/core/src/schemas/__tests__/validation.test.js
@@ -179,14 +179,24 @@ describe('Schemas de Validação Zod', () => {
     })
 
     it('deve rejeitar quantidade muito alta', () => {
+      // Cap revisado 100→1000 (022 Fase B): 150 agora é válido (gotas); rejeita só >1000.
+      const log = {
+        medicine_id: '123e4567-e89b-12d3-a456-426614174000',
+        quantity_taken: 1500,
+        taken_at: '2024-01-15T10:00:00Z',
+      }
+      const result = validateLogCreate(log)
+      expect(result.success).toBe(false)
+      expect(result.errors[0].message).toContain('1000')
+    })
+
+    it('deve aceitar dose líquida em gotas acima do antigo cap-100', () => {
       const log = {
         medicine_id: '123e4567-e89b-12d3-a456-426614174000',
         quantity_taken: 150,
         taken_at: '2024-01-15T10:00:00Z',
       }
-      const result = validateLogCreate(log)
-      expect(result.success).toBe(false)
-      expect(result.errors[0].message).toContain('100')
+      expect(validateLogCreate(log).success).toBe(true)
     })
   })
 
@@ -303,6 +313,48 @@ describe('Schemas de Validação Zod', () => {
       const result = validateEntity('medicine', {}, 'invalid_op')
       expect(result.success).toBe(false)
       expect(result.error.message).toContain('não suportada')
+    })
+  })
+
+  describe('Líquidos (022 Fase B)', () => {
+    it('medicamento mg/ml SEM units_per_ml → rejeita', () => {
+      const r = validateMedicineCreate({ name: 'Dipirona Gotas', dosage_unit: 'mg/ml' })
+      expect(r.success).toBe(false)
+      expect(r.errors.some((e) => e.field === 'units_per_ml')).toBe(true)
+    })
+    it('medicamento mg/ml COM units_per_ml → aceita (dosage_per_pill opcional)', () => {
+      const r = validateMedicineCreate({ name: 'Dipirona Gotas', dosage_unit: 'mg/ml', units_per_ml: 20 })
+      expect(r.success).toBe(true)
+    })
+    it('sólido mg sem units_per_ml → aceita (não exige densidade)', () => {
+      const r = validateMedicineCreate({ name: 'Paracetamol', dosage_unit: 'mg', dosage_per_pill: 500 })
+      expect(r.success).toBe(true)
+    })
+    it('protocolo líquido (_medicineIsLiquid) sem intake_unit → rejeita', () => {
+      const r = validateProtocolCreate({
+        medicine_id: '123e4567-e89b-12d3-a456-426614174000',
+        name: 'Xarope',
+        frequency: 'diário',
+        time_schedule: ['08:00'],
+        dosage_per_intake: 2.5,
+        start_date: '2026-01-01',
+        _medicineIsLiquid: true,
+      })
+      expect(r.success).toBe(false)
+      expect(r.errors.some((e) => e.field === 'intake_unit')).toBe(true)
+    })
+    it('protocolo líquido COM intake_unit gotas + dose decimal → aceita', () => {
+      const r = validateProtocolCreate({
+        medicine_id: '123e4567-e89b-12d3-a456-426614174000',
+        name: 'Xarope',
+        frequency: 'diário',
+        time_schedule: ['08:00'],
+        dosage_per_intake: 2.5,
+        start_date: '2026-01-01',
+        _medicineIsLiquid: true,
+        intake_unit: 'gotas',
+      })
+      expect(r.success).toBe(true)
     })
   })
 })

--- a/packages/core/src/schemas/adherencePatternSchema.js
+++ b/packages/core/src/schemas/adherencePatternSchema.js
@@ -10,7 +10,7 @@ const logSchema = z.object({
   id: z.string().uuid(),
   medicine_id: z.string().uuid(),
   protocol_id: z.string().uuid().nullable().optional(),
-  quantity_taken: z.number().positive().max(100),
+  quantity_taken: z.number().positive().max(1000), // cap 100→1000 (022 Fase B, R-022)
   taken_at: z.string().datetime({ offset: true }),
 })
 

--- a/packages/core/src/schemas/costAnalysisSchema.js
+++ b/packages/core/src/schemas/costAnalysisSchema.js
@@ -76,7 +76,7 @@ export const CalculateRealCostsInputSchema = z.object({
         quantity_taken: z
           .number()
           .nonnegative('quantity_taken deve ser >= 0')
-          .max(100, 'quantity_taken não pode ser maior que 100')
+          .max(1000, 'quantity_taken não pode ser maior que 1000') // cap 100→1000 (022 Fase B, R-022)
           .nullable()
           .optional(),
       })

--- a/packages/core/src/schemas/logSchema.js
+++ b/packages/core/src/schemas/logSchema.js
@@ -33,7 +33,9 @@ export const logSchema = z.object({
   quantity_taken: z
     .number()
     .positive('Quantidade tomada deve ser maior que zero')
-    .max(100, 'Quantidade máxima por registro é 100'),
+    // Cap revisado 100→1000 (022 Fase B): cobre doses líquidas em gotas. Cap Zod = guarda
+    // anti-erro de digitação; integridade física do saldo = CHECK(quantity>=0)+FIFO (Fase A). Ver R-022.
+    .max(1000, 'Quantidade máxima por registro é 1000'),
 
   notes: z
     .string()

--- a/packages/core/src/schemas/medicineSchema.js
+++ b/packages/core/src/schemas/medicineSchema.js
@@ -8,17 +8,18 @@ import { z } from 'zod'
 // Unidades de CONCENTRAÇÃO válidas (alinhadas com MedicineForm.jsx dropdown).
 // 'ml'/'gotas' saíram da lista (viram unidade de TOMADA em protocols.intake_unit — 022 Fase A).
 // 'mg/ml'/'ui/ml' são razões massa/volume: líquido := dosage_unit LIKE '%/ml' (decisão-mãe).
-export const DOSAGE_UNITS = ['mg', 'mcg', 'g', 'ui', 'un', 'mg/ml', 'ui/ml']
+// Ordem do dropdown: sólidos base → concentrações-ratio (/ml) → ui/un.
+export const DOSAGE_UNITS = ['mg', 'mcg', 'g', 'mg/ml', 'ui/ml', 'ui', 'un']
 
-// Labels de unidade para exibição
+// Labels de unidade para exibição (ordem espelha DOSAGE_UNITS)
 export const DOSAGE_UNIT_LABELS = {
   mg: 'mg',
   mcg: 'mcg',
   g: 'g',
-  ui: 'UI',
-  un: 'un.',
   'mg/ml': 'mg/ml',
   'ui/ml': 'UI/ml',
+  ui: 'UI',
+  un: 'un.',
 }
 
 // Tipos de medicamento

--- a/packages/core/src/schemas/medicineSchema.js
+++ b/packages/core/src/schemas/medicineSchema.js
@@ -5,18 +5,20 @@ import { z } from 'zod'
  * Baseado na tabela 'medicines' do Supabase
  */
 
-// Unidades de dosagem válidas (alinhadas com MedicineForm.jsx dropdown)
-export const DOSAGE_UNITS = ['mg', 'mcg', 'g', 'ml', 'ui', 'un', 'gotas']
+// Unidades de CONCENTRAÇÃO válidas (alinhadas com MedicineForm.jsx dropdown).
+// 'ml'/'gotas' saíram da lista (viram unidade de TOMADA em protocols.intake_unit — 022 Fase A).
+// 'mg/ml'/'ui/ml' são razões massa/volume: líquido := dosage_unit LIKE '%/ml' (decisão-mãe).
+export const DOSAGE_UNITS = ['mg', 'mcg', 'g', 'ui', 'un', 'mg/ml', 'ui/ml']
 
 // Labels de unidade para exibição
 export const DOSAGE_UNIT_LABELS = {
   mg: 'mg',
   mcg: 'mcg',
   g: 'g',
-  ml: 'ml',
   ui: 'UI',
   un: 'un.',
-  gotas: 'gotas',
+  'mg/ml': 'mg/ml',
+  'ui/ml': 'UI/ml',
 }
 
 // Tipos de medicamento
@@ -26,6 +28,28 @@ export const MEDICINE_TYPES = ['medicamento', 'suplemento']
 export const MEDICINE_TYPE_LABELS = {
   medicamento: 'Medicamento',
   suplemento: 'Suplemento',
+}
+
+// Forma farmacêutica (additiva — ADR-058; alinha MEDICINE_TYPES do produto).
+// Sincronizada com CHECK medicines_presentation_check (R-082/R-271). Valores PT (R-021).
+export const PRESENTATIONS = [
+  'comprimido',
+  'capsula',
+  'liquido',
+  'injecao',
+  'pomada',
+  'spray',
+  'outro',
+]
+
+export const PRESENTATION_LABELS = {
+  comprimido: 'Comprimido',
+  capsula: 'Cápsula',
+  liquido: 'Líquido',
+  injecao: 'Injeção',
+  pomada: 'Pomada',
+  spray: 'Spray',
+  outro: 'Outro',
 }
 
 export const REGULATORY_CATEGORIES = [
@@ -57,7 +81,10 @@ export const REGULATORY_CATEGORY_LABELS = {
 // Aqui mantemos apenas overrides específicos quando regra de negócio exige texto
 // diferente do padrão (ex: "máx 200 caracteres" — informação útil, não jargão).
 
-export const medicineSchema = z.object({
+// Objeto base (ZodObject) — preserva .partial()/.extend(). O refine de líquido
+// é aplicado SEPARADAMENTE em medicineSchema/medicineFullSchema (ZodEffects não
+// expõe .partial()/.extend()).
+const medicineObject = z.object({
   name: z
     .string()
     .min(2, 'O nome precisa de pelo menos 2 caracteres')
@@ -78,12 +105,28 @@ export const medicineSchema = z.object({
     .nullable()
     .transform((val) => val || null),
 
+  // Concentração (mg/cp p/ sólidos; mg ou UI por ml p/ líquidos). NULLABLE: líquidos
+  // legados migrados (022 Fase A) têm dosage_per_pill NULL — massa ativa só exibida
+  // quando o usuário preenche; decremento/adesão não dependem dela.
   dosage_per_pill: z.coerce
     .number()
     .positive('A dose deve ser maior que zero')
-    .max(10000, 'A dose parece muito alta. Verifique o valor'),
+    .max(10000, 'A dose parece muito alta. Verifique o valor')
+    .nullable()
+    .optional(),
 
   dosage_unit: z.enum(DOSAGE_UNITS),
+
+  // Razão→ml genérica (ADR-058): gotas/ml=20, UI/ml=100. Obrigatória p/ líquidos
+  // (validada no superRefine). NUMERIC (aceita fração).
+  units_per_ml: z.coerce
+    .number()
+    .positive('Densidade (unidades por ml) deve ser maior que zero')
+    .nullable()
+    .optional(),
+
+  // Forma farmacêutica (additiva — ADR-058). Default 'comprimido' espelha o DEFAULT do DB.
+  presentation: z.enum(PRESENTATIONS).default('comprimido'),
 
   type: z.enum(MEDICINE_TYPES).default('medicamento'),
 
@@ -101,25 +144,41 @@ export const medicineSchema = z.object({
     .transform((val) => val || null),
 })
 
+// Refine de líquido: unidade terminando em '/ml' exige units_per_ml (padrão 20 na UI).
+const requireUnitsPerMlForLiquid = (data, ctx) => {
+  if (data.dosage_unit?.endsWith('/ml') && data.units_per_ml == null) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['units_per_ml'],
+      message: 'Densidade (unidades por ml) é obrigatória para medicamentos líquidos (padrão 20).',
+    })
+  }
+}
+
+export const medicineSchema = medicineObject.superRefine(requireUnitsPerMlForLiquid)
+
 /**
  * Schema para criação de medicamento (sem id)
  */
 export const medicineCreateSchema = medicineSchema
 
 /**
- * Schema para atualização de medicamento (campos opcionais)
+ * Schema para atualização de medicamento (campos opcionais).
+ * Base no objeto (não no refined) — updates parciais não reavaliam o refine de líquido.
  */
-export const medicineUpdateSchema = medicineSchema.partial()
+export const medicineUpdateSchema = medicineObject.partial()
 
 /**
  * Schema completo com ID (para validação de dados do backend)
  */
-export const medicineFullSchema = medicineSchema.extend({
-  id: z.string().uuid('ID do medicamento deve ser um UUID válido'),
-  user_id: z.string().uuid('ID do usuário deve ser um UUID válido'),
-  created_at: z.string().datetime({ offset: true }).optional(),
-  updated_at: z.string().datetime({ offset: true }).optional(),
-})
+export const medicineFullSchema = medicineObject
+  .extend({
+    id: z.string().uuid('ID do medicamento deve ser um UUID válido'),
+    user_id: z.string().uuid('ID do usuário deve ser um UUID válido'),
+    created_at: z.string().datetime({ offset: true }).optional(),
+    updated_at: z.string().datetime({ offset: true }).optional(),
+  })
+  .superRefine(requireUnitsPerMlForLiquid)
 
 /**
  * Valida um objeto de medicamento

--- a/packages/core/src/schemas/medicineSchema.js
+++ b/packages/core/src/schemas/medicineSchema.js
@@ -109,22 +109,30 @@ const medicineObject = z.object({
   // Concentração (mg/cp p/ sólidos; mg ou UI por ml p/ líquidos). NULLABLE: líquidos
   // legados migrados (022 Fase A) têm dosage_per_pill NULL — massa ativa só exibida
   // quando o usuário preenche; decremento/adesão não dependem dela.
-  dosage_per_pill: z.coerce
-    .number()
-    .positive('A dose deve ser maior que zero')
-    .max(10000, 'A dose parece muito alta. Verifique o valor')
-    .nullable()
-    .optional(),
+  // z.preprocess('' → null): forms web enviam '' ao limpar o campo; sem isso z.coerce
+  // converteria '' → 0 e .positive() bloquearia a limpeza (review #651).
+  dosage_per_pill: z.preprocess(
+    (val) => (val === '' ? null : val),
+    z.coerce
+      .number()
+      .positive('A dose deve ser maior que zero')
+      .max(10000, 'A dose parece muito alta. Verifique o valor')
+      .nullable()
+      .optional()
+  ),
 
   dosage_unit: z.enum(DOSAGE_UNITS),
 
   // Razão→ml genérica (ADR-058): gotas/ml=20, UI/ml=100. Obrigatória p/ líquidos
-  // (validada no superRefine). NUMERIC (aceita fração).
-  units_per_ml: z.coerce
-    .number()
-    .positive('Densidade (unidades por ml) deve ser maior que zero')
-    .nullable()
-    .optional(),
+  // (validada no superRefine). NUMERIC (aceita fração). preprocess '' → null (idem dosage_per_pill).
+  units_per_ml: z.preprocess(
+    (val) => (val === '' ? null : val),
+    z.coerce
+      .number()
+      .positive('Densidade (unidades por ml) deve ser maior que zero')
+      .nullable()
+      .optional()
+  ),
 
   // Forma farmacêutica (additiva — ADR-058). Default 'comprimido' espelha o DEFAULT do DB.
   presentation: z.enum(PRESENTATIONS).default('comprimido'),

--- a/packages/core/src/schemas/protocolSchema.js
+++ b/packages/core/src/schemas/protocolSchema.js
@@ -69,6 +69,16 @@ export const titrationStageSchema = z.object({
 /**
  * Schema base para protocolo
  */
+// Unidades de TOMADA (físicas) p/ líquidos — 022. Sincronizado com CHECK
+// protocols_intake_unit_check ('gotas','ml','UI') (R-082/R-271). 'UI' maiúsculo.
+export const INTAKE_UNITS = ['gotas', 'ml', 'UI']
+
+export const INTAKE_UNIT_LABELS = {
+  gotas: 'gotas',
+  ml: 'ml',
+  UI: 'UI',
+}
+
 export const protocolSchema = z.object({
   medicine_id: z.string().uuid('ID do medicamento deve ser um UUID válido'),
 
@@ -159,12 +169,32 @@ export const protocolSchema = z.object({
     .default([]),
 
   critical_alarm: z.boolean().default(false),
+
+  // Unidade física da tomada (gotas/ml/UI) — só p/ líquidos; NULL p/ sólidos (022).
+  intake_unit: z.enum(INTAKE_UNITS).nullable().optional(),
+
+  // Flag de contexto transiente injetado pelo form (derivado de dosage_unit LIKE '%/ml').
+  // NÃO persistido — services selecionam campos explícitos. Existe só p/ o refine de líquido ver.
+  _medicineIsLiquid: z.boolean().optional(),
 })
 
 /**
  * Schema para criação de protocolo
  */
 export const protocolCreateSchema = protocolSchema
+  .refine(
+    (data) => {
+      // Líquido (form injeta _medicineIsLiquid) exige intake_unit (gotas/ml/UI).
+      if (data._medicineIsLiquid === true) {
+        return !!data.intake_unit
+      }
+      return true
+    },
+    {
+      message: 'Defina a unidade de tomada (gotas, ml ou UI) para medicamentos líquidos.',
+      path: ['intake_unit'],
+    }
+  )
   .refine(
     (data) => {
       // Se tem titration_schedule, deve ter stage_started_at

--- a/packages/core/src/schemas/reminderOptimizerSchema.js
+++ b/packages/core/src/schemas/reminderOptimizerSchema.js
@@ -16,7 +16,7 @@ export const AnalyzeReminderTimingInputSchema = z.object({
       id: z.string(),
       protocol_id: z.string().nullable().optional(),
       medicine_id: z.string(),
-      quantity_taken: z.number().positive().max(100).nullable().optional(),
+      quantity_taken: z.number().positive().max(1000).nullable().optional(), // cap 100→1000 (022 Fase B, R-022)
       taken_at: z.string().datetime({ offset: true }), // ISO timestamp
     })
   ),

--- a/packages/core/src/utils/__tests__/doseUnit.test.js
+++ b/packages/core/src/utils/__tests__/doseUnit.test.js
@@ -2,10 +2,36 @@ import { describe, it, expect } from 'vitest'
 import {
   pluralizeDoseUnit,
   formatDoseUnit,
+  formatDose,
   formatActiveIngredientHint,
   formatActiveIngredientFormula,
   formatActiveIngredientShort,
 } from '../doseUnit.js'
+
+describe('formatDose (unidade de tomada — líquidos 022)', () => {
+  it('gotas: plural e singular', () => {
+    expect(formatDose(15, 'gotas')).toBe('15 gotas')
+    expect(formatDose(1, 'gotas')).toBe('1 gota')
+  })
+  it('ml: vírgula decimal PT-BR', () => {
+    expect(formatDose(2.5, 'ml')).toBe('2,5 ml')
+    expect(formatDose(10, 'ml')).toBe('10 ml')
+  })
+  it('UI: escala direta', () => {
+    expect(formatDose(10, 'UI')).toBe('10 UI')
+  })
+  it('milhar com ponto PT-BR', () => {
+    expect(formatDose(3000, 'gotas')).toBe('3.000 gotas')
+  })
+  it('null/undefined → string vazia', () => {
+    expect(formatDose(null, 'ml')).toBe('')
+    expect(formatDose(undefined, 'gotas')).toBe('')
+  })
+  it('unidade desconhecida → valor + unidade sem crash', () => {
+    expect(formatDose(5, 'xyz')).toBe('5 xyz')
+    expect(formatDose(5, null)).toBe('5')
+  })
+})
 
 describe('pluralizeDoseUnit (padronizado para unidade(s))', () => {
   it('singular quando qty === 1', () => {

--- a/packages/core/src/utils/__tests__/doseUnit.test.js
+++ b/packages/core/src/utils/__tests__/doseUnit.test.js
@@ -31,6 +31,10 @@ describe('formatDose (unidade de tomada — líquidos 022)', () => {
     expect(formatDose(5, 'xyz')).toBe('5 xyz')
     expect(formatDose(5, null)).toBe('5')
   })
+  it('string com vírgula PT-BR no singular de gota (review #651)', () => {
+    expect(formatDose('1,0', 'gotas')).toBe('1 gota')
+    expect(formatDose('2,0', 'gotas')).toBe('2 gotas')
+  })
 })
 
 describe('pluralizeDoseUnit (padronizado para unidade(s))', () => {

--- a/packages/core/src/utils/doseUnit.js
+++ b/packages/core/src/utils/doseUnit.js
@@ -74,7 +74,12 @@ export function formatDose(value, unit) {
   const v = formatNumberPtBR(value)
   if (v === '') return ''
   if (unit === 'ml') return `${v} ml`
-  if (unit === 'gotas') return `${v} ${Number(value) === 1 ? 'gota' : 'gotas'}`
+  if (unit === 'gotas') {
+    // Normaliza vírgula PT-BR ('1,0') antes do check de singular — senão Number('1,0')=NaN
+    // exibiria '1 gotas' (review #651).
+    const numVal = Number(typeof value === 'string' ? value.replace(',', '.') : value)
+    return `${v} ${numVal === 1 ? 'gota' : 'gotas'}`
+  }
   if (unit === 'UI') return `${v} UI`
   return `${v} ${unit || ''}`.trim()
 }

--- a/packages/core/src/utils/doseUnit.js
+++ b/packages/core/src/utils/doseUnit.js
@@ -59,6 +59,27 @@ export function formatDoseUnit(qty) {
 }
 
 /**
+ * Formata dose na UNIDADE DE TOMADA real (líquidos — 022). Vírgula decimal PT-BR
+ * (reusa formatNumberPtBR). `gotas` tem singular/plural próprio; `pluralizeDoseUnit`
+ * só serve p/ "unidade(s)", por isso o plural de gotas é inline.
+ *
+ * @example formatDose(15, 'gotas') → '15 gotas'
+ * @example formatDose(1, 'gotas')  → '1 gota'
+ * @example formatDose(2.5, 'ml')   → '2,5 ml'
+ * @example formatDose(10, 'UI')    → '10 UI'
+ * @example formatDose(null, 'ml')  → ''
+ */
+export function formatDose(value, unit) {
+  if (value === undefined || value === null) return ''
+  const v = formatNumberPtBR(value)
+  if (v === '') return ''
+  if (unit === 'ml') return `${v} ml`
+  if (unit === 'gotas') return `${v} ${Number(value) === 1 ? 'gota' : 'gotas'}`
+  if (unit === 'UI') return `${v} UI`
+  return `${v} ${unit || ''}`.trim()
+}
+
+/**
  * Retorna apenas o valor de concentração do princípio ativo correspondente.
  * Usado para hints em linhas separadas (como nos indicadores do Estoque).
  *

--- a/plans/specs/022-liquid-medications/analysis.md
+++ b/plans/specs/022-liquid-medications/analysis.md
@@ -135,3 +135,52 @@ Gaps resolvidos → reality check **PASS**. Escopo Fase A revisado: A.1 ADD CHEC
 | sólido | — | caminho linear inteiro | ✅ teste |
 
 Teste: harness `BEGIN … ROLLBACK` no DB ao vivo (prod intocado), incluindo os casos que **devem** levantar exceção (dose minúscula confirmado RAISE).
+
+---
+
+## C1 Reality Check — Fase B (Core) — 2026-06-07
+
+**Evidence table (verificado on-disk):**
+| Claim do plan | Real repo | Verified? | Nota |
+|---------------|-----------|-----------|------|
+| `DOSAGE_UNITS` em medicineSchema:9 | `['mg','mcg','g','ml','ui','un','gotas']` | ✅ | vira `['mg','mcg','g','ui','un','mg/ml','ui/ml']` |
+| `dosage_per_intake .max(1000)` já existe | protocolSchema:105 `.max(1000)` | ✅ | NÃO mexer cap; só ADD `intake_unit` |
+| cap-100 `logSchema:36` | `.max(100,'…100')` | ✅ | →1000 |
+| cap-100 `costAnalysisSchema:79` | `.max(100,'…')` | ✅ | →1000 |
+| cap-100 `adherencePatternSchema:13` | `.max(100)` | ✅ | →1000 |
+| cap-100 `reminderOptimizerSchema:19` | `.max(100)` | ✅ | →1000 |
+| `doseUnit.js` tem `formatNumberPtBR`+`pluralizeDoseUnit` | ✅ | ✅ | `formatDose` estende |
+| **FR-010 alvo**: `stockService.js` (web+mobile) | wrappers thin; `createPurchase` definido em **`packages/core/src/repositories/createPurchaseRepository.js:122`** | ❌→corrigido | ver gap B1 |
+
+**Gaps Fase B:**
+| # | Sev | Gap | Correção |
+|---|-----|-----|----------|
+| B1 | HIGH | Desmembramento miraria os 2 `stockService` (apps), mas a lógica vive no **core** `createPurchaseRepository`; duplicar nos apps viola fonte-única. Web mapeia métodos explícito; mobile usa spread `{...purchaseRepo}`. | Novo método `createLiquidPurchase` **no core repo**; web wrapper +1 linha passthrough; mobile herda via spread. |
+| B2 | MEDIUM | `validation.test.js:181` ('rejeitar quantidade muito alta') usa `quantity_taken:150` + msg '100' → quebra com cap→1000 | Atualizar teste: `quantity_taken: 1500` + msg '1000' (preserva intenção do cap) |
+| B3 | MEDIUM | `stockSchema` (validateStockCreate) pode capar `quantity`/exigir campos — desmembramento passa `quantity=volumePerBottle` (ex: 100/1000 ml) | Confirmar stockSchema aceita volume ml ao codar; ajustar se houver cap restritivo |
+| B4 | LOW | cross-validação `_medicineIsLiquid` no protocolSchema (form injeta) vs service | injetar `_medicineIsLiquid` no form (Fase C); documentar |
+
+## Failure Modes & Degenerate Inputs — funções novas Fase B (R-270)
+
+**`formatDose(value, unit)`** (doseUnit.js):
+| Input | Degenerado | Esperado |
+|-------|-----------|----------|
+| value | `null`/`undefined` | `''` (não 'NaN') |
+| value | `1` + unit `gotas` | `'1 gota'` (singular) |
+| value | decimal `2.5` | `'2,5 ml'` (vírgula via formatNumberPtBR) |
+| value | `3000` | `'3.000 …'` (milhar, não `.replace` ingênuo) |
+| unit | desconhecido/`null` | `'<n> <unit||''>'.trim()` sem crash |
+
+**`createLiquidPurchase`** (core repo):
+| Input | Degenerado | Esperado |
+|-------|-----------|----------|
+| numBottles | `0`/negativo | rejeitar (loop não roda; sem div/0 em `total/numBottles`) |
+| numBottles | `1` | 1 chamada, sem compensação |
+| totalPrice | divisão inexata (R$10/3) | 2× `round`, último compensa centavo → Σ = total exato |
+| volumePerBottle | `0` | rejeitar (evita unit_price = price/0) |
+| validateStockCreate | falha Zod | throw com msg (não silencioso) |
+
+**medicineSchema.superRefine** (`/ml` ⇒ units_per_ml obrigatório): unit `mg/ml` sem units_per_ml → issue; `dosage_per_pill` NULL tolerado (legado).
+**protocolSchema.superRefine** (líquido ⇒ intake_unit): `_medicineIsLiquid=true` sem intake_unit → issue; sólido → intake_unit NULL ok.
+
+Cada modo → teste unitário (vitest core, T014). Reality check **PASS** com B1 corrigido (target = core repo).


### PR DESCRIPTION
## Épico 022 — Medicamentos Líquidos · Fase B (Core/Validações/Serviços)

Depende da Fase A (mergeada, migração aplicada). Camada core compartilhada web↔mobile.

### Mudanças
- **`medicineSchema`**: `DOSAGE_UNITS` +`mg/ml`/`ui/ml` −`ml`/`gotas` (viram tomada); `units_per_ml` (razão→ml, ADR-058) + `presentation` (+`PRESENTATIONS`); `dosage_per_pill` nullable (líquidos legados migrados); refatorado p/ base-object + `superRefine` (preserva `.partial()`/`.extend()`); refine `/ml` ⇒ `units_per_ml` obrigatório.
- **`protocolSchema`**: `intake_unit` (`gotas`/`ml`/`UI`, `INTAKE_UNITS`) + refine líquido ⇒ `intake_unit` (via flag transiente `_medicineIsLiquid`).
- **Cap `quantity_taken` 100→1000** em `logSchema`/`costAnalysisSchema`/`adherencePatternSchema`/`reminderOptimizerSchema` (R-022 revisado; segurança física = CHECK+FIFO da Fase A).
- **`formatDose(value, unit)`** em `doseUnit.js` (vírgula PT-BR via `formatNumberPtBR`; singular `gota`).
- **`createLiquidPurchase`** em `createPurchaseRepository` (core): N frascos × volume × preço total → N lotes via `create_purchase_with_stock`, centavos compensados no último. Web wrapper +1 passthrough; **mobile herda via spread** `{...purchaseRepo}`.

### Reality check (C1.5 + R-270 preflight — 1º uso)
- **B1 (HIGH)**: alvo do desmembramento corrigido — lógica vai no **core** repo, não duplicada nos 2 `stockService` (apps são thin wrappers).
- **B2 (MEDIUM)**: teste de cap quebrava em **2 arquivos-espelho** (`packages/core` + `apps/web` `validation.test.js`) — ambos corrigidos (AP-215 read-path duplicado).
- **Failure-modes table** (R-270) preenchida antes de codar → `createLiquidPurchase` nasceu com guards: `numBottles≤0`/não-inteiro, `volume≤0` (div/0), `totalPrice<0`.

### Testes
`formatDose` (gotas/ml/UI/singular/null/milhar) · `createLiquidPurchase` (desmembramento, compensação de centavos R$10/3, 1 frasco, todos os guards) · schemas líquidos (mg/ml sem units_per_ml rejeita; protocolo líquido sem intake_unit rejeita). **validate:agent 1134/1134** · lint 0.

### SQP (R-221)
Shared/Core + Web (wrapper) · `minor` · CHANGELOG `[Unreleased]` atualizado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AI Review Response (gemini-code-assist)

| Sugestão | Pri | Decisão | Commit |
|---|---|---|---|
| unit_price negativo (centavos baixos) | High | Aplicada | f8c8a005 (Math.floor) |
| dosage_per_pill: '' → 0 | Medium | Aplicada | f8c8a005 (preprocess) |
| units_per_ml: '' → 0 | Medium | Aplicada | f8c8a005 (preprocess) |
| formatDose vírgula → NaN no plural | Medium | Aplicada | f8c8a005 |
