### PR TITLE
feat(diabetes): 012 Fase B — GLP-1 (titulação + tolerância semanal + carry-over)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ## [Unreleased]
 
+### Backend/Infra (cron — 012 Fase B)
+- **Added** (`minor`, Spec 012 Fase B, FR-005b): Avanço AUTOMÁTICO de etapa de titulação por cronograma no cron diário — `stage_started_at + duration_days` esgotado avança `current_stage_index` (múltiplas etapas de uma vez se vencidas; `stage_started_at` novo = fim acumulado da etapa anterior, fiel ao cronograma mesmo com cron atrasado); última etapa esgotada marca `titration_status='alvo_atingido'`. Notificação `titration_alert` agora dispara **só no evento** de avanço ("Etapa N/M iniciada conforme o cronograma", sem CTA de dose — SaMD/ADR-062).
+- **Fixed** (`patch`, Spec 012 Fase B, T009): Cron de titulação disparava `titration_alert` TODO dia para TODO protocolo em titulação (spam sem informação nova) e não carregava `stage_started_at` no select (R-267) — não tinha como saber se a transição venceu.
+
+### Core (@dosiq/core — 012 Fase B)
+- **Added** (`minor`, Spec 012 Fase B, ADR-061/FR-007): `computeTolerances` frequency-aware — frequências não-diárias usam o PERÍODO da frequência como wrap-around (semanal=10080min, dias_alternados=2880min) **sem o cap de 120min**: dose semanal única ganha tolerância 5040min (3,5 dias — cobre o perdão clínico de 72h do GLP-1). Diário inalterado (cap 120 preservado).
+- **Added** (`minor`, Spec 012 Fase B, FR-006/FP-1): `resolveTitrationStageAt(protocol, at)` — resolve a etapa de titulação vigente num instante arbitrário; o gerador de `dose_instances` congela `expected_dose` da etapa vigente NA DATA da ocorrência (instância futura nasce com a dose da etapa futura, antes do avanço formal no banco).
+- **Added** (`minor`, Spec 012 Fase B, FR-008b): `daysAgoLabel(scheduledFor, now, tz)` — rótulo relativo por data-calendário ("ontem"/"há N dias") para doses pendentes multi-dia.
+
+### Web (4.3.0 → 4.4.0)
+- **Added** (`minor`, Spec 012 Fase B, FR-008b): Carry-over multi-dia — janela de busca de ocorrências ampliada para 4 dias atrás (dose GLP-1 semanal pendente de 2-3 dias continua registrável); seção "Pendências de ontem" vira "Doses pendentes" com rótulo relativo por card ("ontem · 10:00", "há 2 dias · 10:00"). Sem re-notificação (gate `notified_at` único).
+- **Fixed** (`patch`, Spec 012 Fase B, R-270): Dose do regime de titulação (wizard) aceita vírgula PT-BR ("0,25") — input decimal com normalização no blur + no payload do protocolo (banco nunca vê string).
+
+### Mobile (0.16.0 → 0.16.1)
+- **Added** (`minor`, Spec 012 Fase B, FR-008b): Mesmo carry-over multi-dia da web — seção "Doses pendentes" com subtítulo e rótulo relativo nos cards de dose carregada.
+- **Nota de loja relevante:** "Novo: doses semanais (como canetas GLP-1) atrasadas há mais de um dia continuam visíveis e registráveis na tela inicial, com indicação de há quantos dias estão pendentes — e a tolerância de registro agora respeita o intervalo real da dose semanal."
+
 ### Backend/Infra (DB + cron — 012 Fase A)
 - **Added** (`minor`, Spec 012 Fase A, ADR-059): Migração `20260610_diabetes_a_injectable_ttl.sql` — `medicines.shelf_life_days` (TTL pós-abertura, nullable, CHECK > 0) e `stock.opened_at` (timestamptz). `consume_stock_fifo` agora infere `opened_at` na primeira tomada que debita o lote (`COALESCE(opened_at, now())` — nunca re-seta; assinatura intacta). Novo kind de notificação `stock_expiry_alert` (push/Telegram) com cadência D-3 + vencimento, no cron diário de estoque — avisa quando o frasco/caneta aberto atinge a validade pós-abertura.
 

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -5,7 +5,7 @@
 
 const BUILD_PROFILE = process.env.EAS_BUILD_PROFILE || 'production'
 
-const APP_VERSION = '0.16.0' // R-182: versão semântica (sem prefixo 'v')
+const APP_VERSION = '0.16.1' // R-182: versão semântica (sem prefixo 'v')
 const [major, minor, patch] = APP_VERSION.split('.').map(Number)
 // buildNumber/versionCode derivado da versão semântica: major*10000 + minor*100 + patch
 // 0.2.4 → 204 | 0.3.0 → 300 | 1.0.0 → 10000

--- a/apps/mobile/src/features/dashboard/components/DoseTimelineCard.jsx
+++ b/apps/mobile/src/features/dashboard/components/DoseTimelineCard.jsx
@@ -2,16 +2,38 @@ import React from 'react'
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native'
 import { Check, Clock, XCircle } from 'lucide-react-native'
 import { colors, typography, shadows } from '@shared/styles/tokens'
-import { formatIntakeDose } from '@dosiq/core'
+import { formatIntakeDose, daysAgoLabel, getRawNow, DEFAULT_TZ } from '@dosiq/core'
+
+/** Ícone de status da dose (helper de módulo — não conta p/ complexidade do componente). */
+function StatusIcon({ timelineStatus }) {
+  if (timelineStatus === 'TOMADA') return <Check size={18} color={colors.status.success} />
+  if (timelineStatus === 'PERDIDA') return <XCircle size={18} color={colors.status.error} />
+  return <Clock size={18} color={colors.neutral[300]} />
+}
+
+/**
+ * 012 Fase B (FR-008b): monta o texto do horário para doses carry-over.
+ * Para doses não registradas, prefixo relativo: "ontem · 10:00" | "há 2 dias · 10:00".
+ * Registradas/perdidas retornam apenas o horário simples.
+ * @returns {{ displayTime: string, hasLabel: boolean }}
+ */
+function resolveDisplayTime(scheduledTime, scheduledFor, isCarryOver, isTaken) {
+  if (!isCarryOver || isTaken || !scheduledFor) return { displayTime: scheduledTime, hasLabel: false }
+  const label = daysAgoLabel(scheduledFor, getRawNow(), DEFAULT_TZ)
+  if (!label) return { displayTime: scheduledTime, hasLabel: false }
+  return { displayTime: `${label} · ${scheduledTime}`, hasLabel: true }
+}
 
 /**
  * DoseTimelineCard - Item de dose para a Timeline (Epic 2)
  * @param {Object} props
  * @param {Object} props.dose - Objeto de dose com timelineStatus
  * @param {Function} props.onRegister - Handler para registrar dose
+ * @param {boolean} [props.isCarryOver] - 012 Fase B (FR-008b): quando true, prefixar
+ *   o horário com rótulo relativo p/ doses pendentes de dias anteriores (tolerância GLP-1 5040min).
  */
-export default function DoseTimelineCard({ dose, onRegister }) {
-  const { timelineStatus, scheduledTime, medicine, protocol } = dose
+export default function DoseTimelineCard({ dose, onRegister, isCarryOver = false }) {
+  const { timelineStatus, scheduledTime, scheduledFor, medicine, protocol } = dose
   const isTaken = timelineStatus === 'TOMADA'
   const isMissed = timelineStatus === 'PERDIDA'
   const isAtrasada = timelineStatus === 'ATRASADA'
@@ -20,16 +42,12 @@ export default function DoseTimelineCard({ dose, onRegister }) {
   // Muted style para tomadas ou perdidas
   const isMuted = isTaken || isMissed
 
-  const getStatusIcon = () => {
-    if (isTaken) return <Check size={18} color={colors.status.success} />
-    if (isMissed) return <XCircle size={18} color={colors.status.error} />
-    return <Clock size={18} color={colors.neutral[300]} />
-  }
+  const { displayTime, hasLabel } = resolveDisplayTime(scheduledTime, scheduledFor, isCarryOver, isTaken)
 
   return (
     <View style={[styles.card, isMuted && styles.cardMuted]}>
-      <View style={styles.timeLineContainer}>
-        <Text style={[styles.timeText, isMuted && styles.mutedText]}>{scheduledTime}</Text>
+      <View style={[styles.timeLineContainer, hasLabel && styles.timeLineContainerWide]}>
+        <Text style={[styles.timeText, isMuted && styles.mutedText, hasLabel && styles.timeTextSmall]}>{displayTime}</Text>
       </View>
 
       <View style={styles.info}>
@@ -46,15 +64,15 @@ export default function DoseTimelineCard({ dose, onRegister }) {
 
       <View style={styles.statusAction}>
         {(isAtrasada || isProxima) ? (
-          <TouchableOpacity 
-            style={styles.actionButton} 
+          <TouchableOpacity
+            style={styles.actionButton}
             onPress={() => onRegister && onRegister(protocol, scheduledTime, dose.instanceId)}
             activeOpacity={0.7}
           >
             <Text style={styles.actionButtonText}>Tomar</Text>
           </TouchableOpacity>
         ) : (
-          getStatusIcon()
+          <StatusIcon timelineStatus={timelineStatus} />
         )}
       </View>
     </View>
@@ -80,11 +98,19 @@ const styles = StyleSheet.create({
   timeLineContainer: {
     width: 60,
   },
+  // 012 Fase B (FR-008b): container mais largo quando exibe rótulo relativo ("ontem · 10:00")
+  timeLineContainerWide: {
+    width: 110,
+  },
   timeText: {
     fontSize: 16,
     fontWeight: '700',
     color: colors.text.primary,
     fontFamily: typography.fontFamily.bold || 'System',
+  },
+  // 012 Fase B (FR-008b): fonte levemente menor p/ caber o rótulo relativo sem quebra
+  timeTextSmall: {
+    fontSize: 13,
   },
   info: {
     flex: 1,

--- a/apps/mobile/src/features/dashboard/screens/TodayScreen.jsx
+++ b/apps/mobile/src/features/dashboard/screens/TodayScreen.jsx
@@ -146,15 +146,23 @@ function TodayHeader({ greeting, todayFormatted, onDevPress }) {
   )
 }
 
-function OptionalDoseSection({ title, doses, onRegister, keyPrefix }) {
+/**
+ * Seção opcional de doses (carry-over ou look-ahead).
+ *
+ * 012 Fase B (FR-008b): `isCarryOver` ativa o rótulo relativo ("ontem · 10:00") nos
+ * cards — necessário para doses semanais (GLP-1) cujo prazo de tolerância (5040min)
+ * excede "ontem" e pode recuar até 3,5 dias.
+ */
+function OptionalDoseSection({ title, subtitle, doses, onRegister, keyPrefix, isCarryOver = false }) {
   if (doses.length === 0) return null
   return (
     <View style={styles.carryOverSection}>
       <View style={styles.agendaHeader}>
         <Text style={styles.agendaTitle}>{title}</Text>
+        {subtitle ? <Text style={styles.agendaSubtitle}>{subtitle}</Text> : null}
       </View>
       {doses.map((dose) => (
-        <DoseTimelineCard key={`${keyPrefix}-${dose.id}`} dose={dose} onRegister={onRegister} />
+        <DoseTimelineCard key={`${keyPrefix}-${dose.id}`} dose={dose} onRegister={onRegister} isCarryOver={isCarryOver} />
       ))}
     </View>
   )
@@ -266,8 +274,17 @@ function TodayScreenContent({
         ) : (
           <NudgeBanner nudge={dashboardNudge} onAction={handleNudgeAction} onDismiss={dismissNudge} />
         )}
-        {/* Pendências de ontem (carry-over cross-dia, F4.3e) */}
-        <OptionalDoseSection title="Pendências de ontem" doses={carryOver} onRegister={handleOpenRegister} keyPrefix="carry" />
+        {/* Doses pendentes (carry-over cross-dia, F4.3e / 012 Fase B FR-008b):
+            título renomeado "Doses pendentes" + subtítulo p/ contexto; rótulo
+            relativo habilitado nos cards (isCarryOver) p/ GLP-1 de 2-3 dias atrás. */}
+        <OptionalDoseSection
+          title="Doses pendentes"
+          subtitle="Doses anteriores ainda no prazo de registro"
+          doses={carryOver}
+          onRegister={handleOpenRegister}
+          keyPrefix="carry"
+          isCarryOver
+        />
         <View style={styles.agendaHeader}>
           <Text style={styles.agendaTitle}>Agenda de Hoje</Text>
         </View>
@@ -538,6 +555,13 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: colors.text.primary,
     fontFamily: typography.fontFamily.bold || 'System',
+  },
+  // 012 Fase B (FR-008b): subtítulo descritivo abaixo do título da seção carry-over
+  agendaSubtitle: {
+    fontSize: 13,
+    color: colors.text.secondary,
+    marginTop: 2,
+    fontFamily: typography.fontFamily.regular || 'System',
   },
   shiftContainer: {
     marginBottom: spacing[4],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dosiq/web",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/features/dashboard/components/CronogramaDoseItem.jsx
+++ b/apps/web/src/features/dashboard/components/CronogramaDoseItem.jsx
@@ -5,7 +5,7 @@ import {
 import MedicineIcon from '@shared/components/ui/MedicineIcon'
 import { classifyDose } from '@dashboard/hooks/useDoseZones'
 
-import { formatDoseItem, formatConcentration } from '@dosiq/core'
+import { formatDoseItem, formatConcentration, daysAgoLabel } from '@dosiq/core'
 
 /**
  * Status do card a partir do instante ABSOLUTO da ocorrência + sua tolerância
@@ -83,7 +83,12 @@ export default function CronogramaDoseItem({ dose, onRegister, stockDays, stockS
         </div>
 
         <time className="cronograma-dose-card__time" dateTime={dose.scheduledTime}>
-          {dose.scheduledTime}
+          {/* 012 Fase B (FR-008b): dose semanal pendente multi-dia ganha rótulo
+              relativo — "10:00" sozinho mentiria o dia da dose carregada. */}
+          {(() => {
+            const ago = !done && now ? daysAgoLabel(dose.scheduledFor, now) : null
+            return ago ? `${ago} · ${dose.scheduledTime}` : dose.scheduledTime
+          })()}
         </time>
       </div>
 

--- a/apps/web/src/features/dashboard/hooks/useDashboardContext.jsx
+++ b/apps/web/src/features/dashboard/hooks/useDashboardContext.jsx
@@ -8,7 +8,6 @@ import {
   formatLocalDate,
   getNow,
   getTodayLocal,
-  getYesterdayLocal,
   addDays,
   getStartOfDayISO,
   getEndOfDayISO,
@@ -73,9 +72,14 @@ export function DashboardProvider({ children }) {
           const userId = await getUserId()
           if (!userId) return []
           const tomorrow = formatLocalDate(addDays(getTodayLocal(), 1))
+          // 012 Fase B (FR-008b): janela traseira de 4 dias — a tolerância semanal
+          // (ADR-061: floor(10080/2) = 5040min = 3,5d) excede o "ontem" legado; sem
+          // isso a dose GLP-1 pendente de 2-3 dias atrás sumia do carry-over.
+          // splitDayTimeline continua filtrando por tolerância (sem ruído extra).
+          const carryStart = formatLocalDate(addDays(getTodayLocal(), -4))
           return doseInstanceRepo.getWindow(
             userId,
-            getStartOfDayISO(getYesterdayLocal()),
+            getStartOfDayISO(carryStart),
             getEndOfDayISO(tomorrow)
           )
         },

--- a/apps/web/src/features/dashboard/hooks/useDashboardHandlers.js
+++ b/apps/web/src/features/dashboard/hooks/useDashboardHandlers.js
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState, useRef, useEffect } from 'react'
 import { cachedLogService as logService } from '@shared/services'
 import { analyticsService } from '@dashboard/services/analyticsService'
 import { protocolService } from '@features/protocols/services/protocolService'
@@ -9,7 +9,34 @@ import { getNow, getServerTimestamp } from '@utils/dateUtils'
 /**
  * useDashboardHandlers - Hook para gerenciar handlers do dashboard
  */
+/** Mensagem amigável para falha de registro 1-click (012 Fase B — smoke PO). */
+function friendlyRegisterError(err) {
+  const msg = String(err?.message || '')
+  if (msg.includes('Estoque insuficiente')) {
+    return 'Estoque insuficiente para registrar esta dose. Reponha o estoque ou registre pela tela de doses para ajustar a quantidade.'
+  }
+  if (msg.includes('Dose muito pequena')) {
+    return 'Dose muito pequena para débito de estoque — confira a densidade (gotas/UI por ml) do medicamento.'
+  }
+  return 'Não foi possível registrar a dose. Tente novamente.'
+}
+
 export function useDashboardHandlers({ refresh, reminderSuggestionData, protocols, setSnoozedAlerts, setDismissedSuggestionId }) {
+  // Erro de ação 1-click (Tomar/Confirmar agora): antes morria num throw sem
+  // consumidor — usuário clicava e nada acontecia (smoke PO 2026-06-11).
+  const [actionError, setActionError] = useState(null)
+  const errorTimerRef = useRef(null)
+  const showActionError = useCallback((err) => {
+    setActionError(friendlyRegisterError(err))
+    if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+    errorTimerRef.current = setTimeout(() => setActionError(null), 8000)
+  }, [])
+  const clearActionError = useCallback(() => {
+    if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+    setActionError(null)
+  }, [])
+  useEffect(() => () => clearTimeout(errorTimerRef.current), [])
+
   // Registra dose DIRETAMENTE sem modal (1-click experience)
   const handleRegisterDoseQuick = useCallback(
     async (medicineId, protocolId, dosagePerIntake, instanceId = null) => {
@@ -30,10 +57,10 @@ export function useDashboardHandlers({ refresh, reminderSuggestionData, protocol
         refresh()
       } catch (err) {
         errorLog('useDashboardHandlers', 'Erro ao registrar dose:', err)
-        throw err
+        showActionError(err)
       }
     },
-    [refresh]
+    [refresh, showActionError]
   )
 
   // Registra múltiplas doses em batch (PriorityDoseCard com 2+ doses)
@@ -60,10 +87,12 @@ export function useDashboardHandlers({ refresh, reminderSuggestionData, protocol
         refresh()
       } catch (err) {
         errorLog('useDashboardHandlers', 'Erro ao registrar doses:', err)
-        throw err
+        // refresh mesmo no erro parcial: doses já registradas do batch devem refletir
+        refresh()
+        showActionError(err)
       }
     },
-    [refresh]
+    [refresh, showActionError]
   )
 
   const handleSnoozeAlert = useCallback((alertId) => {
@@ -104,6 +133,8 @@ export function useDashboardHandlers({ refresh, reminderSuggestionData, protocol
     handleRegisterDoseQuick,
     handleRegisterDosesAll,
     handleSnoozeAlert,
-    handleReminderAccept
-  }), [handleRegisterDoseQuick, handleRegisterDosesAll, handleSnoozeAlert, handleReminderAccept])
+    handleReminderAccept,
+    actionError,
+    clearActionError
+  }), [handleRegisterDoseQuick, handleRegisterDosesAll, handleSnoozeAlert, handleReminderAccept, actionError, clearActionError])
 }

--- a/apps/web/src/features/dashboard/hooks/useDashboardHandlers.js
+++ b/apps/web/src/features/dashboard/hooks/useDashboardHandlers.js
@@ -26,6 +26,9 @@ export function useDashboardHandlers({ refresh, reminderSuggestionData, protocol
   // consumidor — usuário clicava e nada acontecia (smoke PO 2026-06-11).
   const [actionError, setActionError] = useState(null)
   const errorTimerRef = useRef(null)
+  // Ordem canônica de hooks (States → Memos → Effects → Handlers): cleanup do
+  // timer antes dos handlers, sem dependência deles.
+  useEffect(() => () => clearTimeout(errorTimerRef.current), [])
   const showActionError = useCallback((err) => {
     setActionError(friendlyRegisterError(err))
     if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
@@ -35,7 +38,6 @@ export function useDashboardHandlers({ refresh, reminderSuggestionData, protocol
     if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
     setActionError(null)
   }, [])
-  useEffect(() => () => clearTimeout(errorTimerRef.current), [])
 
   // Registra dose DIRETAMENTE sem modal (1-click experience)
   const handleRegisterDoseQuick = useCallback(

--- a/apps/web/src/features/protocols/components/ProtocolForm.css
+++ b/apps/web/src/features/protocols/components/ProtocolForm.css
@@ -177,11 +177,17 @@
   color: var(--color-error);
 }
 
-/* Titration section container (inline style override) */
-.protocol-form .form-row[style*='border'] {
-  border-color: var(--color-outline-ghost) !important;
-  background: var(--color-surface-container-low) !important;
-  border-radius: var(--radius-card) !important;
+/* Seção de titulação — container próprio, empilhado em qualquer breakpoint
+   (012 Fase B, smoke PO: .form-row global é grid 2-col e espremia o wizard). */
+.protocol-form .titration-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  margin-bottom: var(--space-4);
+  border: 1px solid var(--color-outline-ghost);
+  background: var(--color-surface-container-low);
+  border-radius: var(--radius-card);
 }
 
 /* Os demais estilos (form h3, form-group, form-row, form-actions, error-*,

--- a/apps/web/src/features/protocols/components/ProtocolForm.jsx
+++ b/apps/web/src/features/protocols/components/ProtocolForm.jsx
@@ -167,6 +167,7 @@ export default function ProtocolForm({
 
       <ProtocolFormAdvancedSection
         formData={formData}
+        medicine={medicines?.find((m) => m.id === formData.medicine_id) || null}
         handleChange={handleChange}
         enableTitration={enableTitration}
         handleTitrationEnable={handleTitrationEnable}

--- a/apps/web/src/features/protocols/components/TitrationWizard.css
+++ b/apps/web/src/features/protocols/components/TitrationWizard.css
@@ -244,3 +244,64 @@
   min-height: 44px;
   font-size: 0.875rem;
 }
+
+/* ============================================
+   012 Fase B — usabilidade (smoke PO 2026-06-11)
+   Container do form é estreito: campos empilham em vez de espremer;
+   alvos ≥44px; sufixo de unidade sempre visível; hint de equivalência.
+   ============================================ */
+
+/* Linha do add-form: lado a lado só quando cabe (≥150px por campo) */
+.stage-input-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+/* Grid das etapas existentes: mesmo comportamento responsivo */
+.stage-grid {
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.stage-grid .full-width,
+.form-group-mini.full-width {
+  grid-column: 1 / -1;
+}
+
+.input-group label {
+  font-size: 0.8rem;
+  font-weight: var(--font-weight-medium, 500);
+  color: var(--color-on-surface-variant, var(--text-secondary));
+  margin-bottom: 6px;
+}
+
+.input-with-suffix {
+  min-height: 44px;
+}
+
+.input-with-suffix input {
+  min-height: 42px;
+  font-size: 1rem;
+  padding: 8px 10px;
+  min-width: 0; /* deixa o input encolher sem expulsar o sufixo */
+}
+
+.input-with-suffix span {
+  white-space: nowrap;
+  font-size: 0.85rem;
+}
+
+.input-note {
+  min-height: 44px;
+  font-size: 0.9rem;
+}
+
+/* Hint de equivalência em princípio ativo ("✨ Equivale a 0,25 mg") */
+.dose-equivalence {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.75rem;
+  color: var(--color-primary);
+  font-weight: var(--font-weight-medium, 500);
+}

--- a/apps/web/src/features/protocols/components/TitrationWizard.jsx
+++ b/apps/web/src/features/protocols/components/TitrationWizard.jsx
@@ -1,14 +1,35 @@
 import { useState, useEffect, startTransition } from 'react'
 import Button from '@shared/components/ui/Button'
+import { formatDoseHint, isLiquidMedicine } from '@dosiq/core'
 import './TitrationWizard.css'
 
-export default function TitrationWizard({ schedule = [], onChange }) {
+/**
+ * Hint de equivalência da dose da etapa ("✨ Equivale a 0,25 mg") via formatter
+ * core (R-272). Sem medicine ou dose inválida → null (não renderiza ruído).
+ */
+function doseEquivalence(rawDosage, intakeUnit, medicine) {
+  if (!medicine) return null
+  const parsed = parseFloat(String(rawDosage ?? '').replace(',', '.'))
+  if (Number.isNaN(parsed) || parsed <= 0) return null
+  const hint = formatDoseHint(parsed, intakeUnit, medicine)
+  return hint || null
+}
+
+/** Unidade de tomada exibida nos sufixos: líquido usa intake_unit; sólido "comp.". */
+function intakeSuffix(intakeUnit, medicine) {
+  if (medicine && isLiquidMedicine(medicine)) return intakeUnit || 'ml'
+  return 'comp.'
+}
+
+export default function TitrationWizard({ schedule = [], onChange, medicine = null, intakeUnit = null }) {
   const [stages, setStages] = useState(schedule)
   // Form state for a stage
+  // Shape canônico do titrationStageSchema (Zod): duration_days/dosage/description.
+  // O wizard legado gravava days/note — nunca passava na validação (regressão T008).
   const [currentStage, setCurrentStage] = useState({
-    days: 7,
+    duration_days: 7,
     dosage: 1,
-    note: '',
+    description: '',
   })
 
   useEffect(() => {
@@ -18,11 +39,14 @@ export default function TitrationWizard({ schedule = [], onChange }) {
   }, [schedule])
 
   const handleAddStage = () => {
-    const newStages = [...stages, { ...currentStage }]
+    // R-270: normaliza a dose digitada com vírgula antes de persistir no estado
+    const dosage = parseFloat(String(currentStage.dosage ?? '').replace(',', '.'))
+    if (Number.isNaN(dosage) || dosage <= 0) return
+    const newStages = [...stages, { ...currentStage, dosage }]
     setStages(newStages)
     onChange(newStages)
     // Reset form with previous values as convenience, but clear note
-    setCurrentStage((prev) => ({ ...prev, note: '' }))
+    setCurrentStage((prev) => ({ ...prev, description: '' }))
   }
 
   const handleRemoveStage = (index) => {
@@ -38,67 +62,89 @@ export default function TitrationWizard({ schedule = [], onChange }) {
     onChange(newStages)
   }
 
-  const totalDays = stages.reduce((acc, stage) => acc + parseInt(stage.days || 0), 0)
+  // R-270 (012 Fase B): dose decimal aceita vírgula PT-BR ("0,25" → 0.25).
+  // Input text+inputMode decimal — o type=number nativo rejeita vírgula. Digitação
+  // mantém o texto cru (senão "0," vira 0 no meio da digitação); normaliza no blur.
+  const handleDosageBlur = (index, raw) => {
+    const parsed = parseFloat(String(raw ?? '').replace(',', '.'))
+    if (!Number.isNaN(parsed) && parsed > 0) handleUpdateStage(index, 'dosage', parsed)
+  }
+
+  const suffix = intakeSuffix(intakeUnit, medicine)
+  const currentHint = doseEquivalence(currentStage.dosage, intakeUnit, medicine)
+  const totalDays = stages.reduce((acc, stage) => acc + parseInt(stage.duration_days ?? stage.days ?? 0), 0)
 
   return (
     <div className="titration-wizard">
       <div className="wizard-header">
         <h4>📈 Regime de Titulação</h4>
-        <p className="wizard-subtitle">Defina a evolução da dose ao longo do tempo.</p>
+        <p className="wizard-subtitle">
+          Defina a evolução da dose ao longo do tempo, conforme a prescrição médica.
+        </p>
       </div>
 
       <div className="stages-list">
-        {stages.map((stage, index) => (
-          <div key={index} className="titration-stage-card">
-            <div className="stage-number">Etapa {index + 1}</div>
+        {stages.map((stage, index) => {
+          const stageHint = doseEquivalence(stage.dosage, intakeUnit, medicine)
+          return (
+            <div key={index} className="titration-stage-card">
+              <div className="stage-number">Etapa {index + 1}</div>
 
-            <div className="stage-grid">
-              <div className="form-group-mini">
-                <label>Duração (dias)</label>
-                <input
-                  type="number"
-                  min="1"
-                  value={stage.days}
-                  onChange={(e) => handleUpdateStage(index, 'days', parseInt(e.target.value))}
-                />
+              <div className="stage-grid">
+                <div className="form-group-mini">
+                  <label>Duração</label>
+                  <div className="input-with-suffix">
+                    <input
+                      type="number"
+                      min="1"
+                      value={stage.duration_days ?? stage.days ?? ''}
+                      onChange={(e) => handleUpdateStage(index, 'duration_days', parseInt(e.target.value))}
+                    />
+                    <span>dias</span>
+                  </div>
+                </div>
+
+                <div className="form-group-mini">
+                  <label>Dose por tomada</label>
+                  <div className="input-with-suffix">
+                    <input
+                      type="text"
+                      inputMode="decimal"
+                      value={stage.dosage}
+                      onChange={(e) => handleUpdateStage(index, 'dosage', e.target.value)}
+                      onBlur={(e) => handleDosageBlur(index, e.target.value)}
+                    />
+                    <span>{suffix}</span>
+                  </div>
+                  {stageHint && <small className="dose-equivalence">✨ {stageHint}</small>}
+                </div>
+
+                <div className="form-group-mini full-width">
+                  <label>Nota / Objetivo</label>
+                  <input
+                    type="text"
+                    placeholder="Ex: Introdução, Aumento de dose..."
+                    value={stage.description ?? stage.note ?? ''}
+                    onChange={(e) => handleUpdateStage(index, 'description', e.target.value)}
+                  />
+                </div>
               </div>
 
-              <div className="form-group-mini">
-                <label>Dose (comps)</label>
-                <input
-                  type="number"
-                  min="0.1"
-                  step="0.1"
-                  value={stage.dosage}
-                  onChange={(e) => handleUpdateStage(index, 'dosage', parseFloat(e.target.value))}
-                />
-              </div>
-
-              <div className="form-group-mini full-width">
-                <label>Nota / Objetivo</label>
-                <input
-                  type="text"
-                  placeholder="Ex: Introdução, Aumento de dose..."
-                  value={stage.note}
-                  onChange={(e) => handleUpdateStage(index, 'note', e.target.value)}
-                />
-              </div>
+              <button
+                type="button"
+                className="btn-remove-stage"
+                onClick={() => handleRemoveStage(index)}
+                title="Remover etapa"
+              >
+                🗑️
+              </button>
             </div>
-
-            <button
-              type="button"
-              className="btn-remove-stage"
-              onClick={() => handleRemoveStage(index)}
-              title="Remover etapa"
-            >
-              🗑️
-            </button>
-          </div>
-        ))}
+          )
+        })}
       </div>
 
       <div className="add-stage-form">
-        <h5>Adicionar Nova Etapa</h5>
+        <h5>Nova Etapa</h5>
         <div className="stage-input-row">
           <div className="input-group">
             <label>Duração</label>
@@ -106,9 +152,9 @@ export default function TitrationWizard({ schedule = [], onChange }) {
               <input
                 type="number"
                 min="1"
-                value={currentStage.days}
+                value={currentStage.duration_days}
                 onChange={(e) =>
-                  setCurrentStage((prev) => ({ ...prev, days: parseInt(e.target.value) }))
+                  setCurrentStage((prev) => ({ ...prev, duration_days: parseInt(e.target.value) }))
                 }
               />
               <span>dias</span>
@@ -116,34 +162,39 @@ export default function TitrationWizard({ schedule = [], onChange }) {
           </div>
 
           <div className="input-group">
-            <label>Dose</label>
+            <label>Dose por tomada</label>
             <div className="input-with-suffix">
               <input
-                type="number"
-                min="0.1"
-                step="0.1"
+                type="text"
+                inputMode="decimal"
+                placeholder="Ex: 0,25"
                 value={currentStage.dosage}
                 onChange={(e) =>
-                  setCurrentStage((prev) => ({ ...prev, dosage: parseFloat(e.target.value) }))
+                  setCurrentStage((prev) => ({ ...prev, dosage: e.target.value }))
                 }
               />
-              <span>comp.</span>
+              <span>{suffix}</span>
             </div>
+            {/* Equivalência em princípio ativo — sem isso o cuidador chuta a dose em
+                unidades e erra a titulação (feedback smoke PO 2026-06-11). */}
+            {currentHint && <small className="dose-equivalence">✨ {currentHint}</small>}
           </div>
         </div>
 
         <div className="input-group">
           <input
             type="text"
-            placeholder="Nota (opcional)"
-            value={currentStage.note}
-            onChange={(e) => setCurrentStage((prev) => ({ ...prev, note: e.target.value }))}
+            placeholder="Nota (opcional) — Ex: Introdução, Aumento de dose..."
+            value={currentStage.description}
+            onChange={(e) => setCurrentStage((prev) => ({ ...prev, description: e.target.value }))}
             className="input-note"
           />
         </div>
 
+        {/* "Gravar" (não "Adicionar"): preencher os campos NÃO cria a etapa — o clique
+            grava o card acima; o form limpo é consequência (feedback smoke PO). */}
         <Button type="button" variant="outline" onClick={handleAddStage} className="btn-add-stage">
-          ➕ Adicionar Etapa
+          ✓ Gravar Etapa
         </Button>
       </div>
 

--- a/apps/web/src/features/protocols/components/TitrationWizard.jsx
+++ b/apps/web/src/features/protocols/components/TitrationWizard.jsx
@@ -65,9 +65,11 @@ export default function TitrationWizard({ schedule = [], onChange, medicine = nu
   // R-270 (012 Fase B): dose decimal aceita vírgula PT-BR ("0,25" → 0.25).
   // Input text+inputMode decimal — o type=number nativo rejeita vírgula. Digitação
   // mantém o texto cru (senão "0," vira 0 no meio da digitação); normaliza no blur.
+  // Desmame/titulação: 0 é dose de negócio válida (etapa de pausa) → parsed >= 0.
   const handleDosageBlur = (index, raw) => {
     const parsed = parseFloat(String(raw ?? '').replace(',', '.'))
-    if (!Number.isNaN(parsed) && parsed > 0) handleUpdateStage(index, 'dosage', parsed)
+    if (!Number.isNaN(parsed) && parsed >= 0) handleUpdateStage(index, 'dosage', parsed)
+    else handleUpdateStage(index, 'dosage', '')
   }
 
   const suffix = intakeSuffix(intakeUnit, medicine)

--- a/apps/web/src/features/protocols/components/TitrationWizard.test.jsx
+++ b/apps/web/src/features/protocols/components/TitrationWizard.test.jsx
@@ -17,14 +17,14 @@ describe('TitrationWizard', () => {
     render(<TitrationWizard schedule={[]} onChange={onChange} />)
 
     expect(screen.getByText('📈 Regime de Titulação')).toBeInTheDocument()
-    expect(screen.getByText('Defina a evolução da dose ao longo do tempo.')).toBeInTheDocument()
-    expect(screen.getByText('Adicionar Nova Etapa')).toBeInTheDocument()
+    expect(screen.getByText(/Defina a evolução da dose ao longo do tempo/)).toBeInTheDocument()
+    expect(screen.getByText('Nova Etapa')).toBeInTheDocument()
   })
 
   it('renders correctly with existing schedule', () => {
     const schedule = [
-      { days: 7, dosage: 1, note: 'Introdução' },
-      { days: 14, dosage: 2, note: 'Aumento' },
+      { duration_days: 7, dosage: 1, description: 'Introdução' },
+      { duration_days: 14, dosage: 2, description: 'Aumento' },
     ]
     const onChange = vi.fn()
     render(<TitrationWizard schedule={schedule} onChange={onChange} />)
@@ -42,25 +42,44 @@ describe('TitrationWizard', () => {
     const onChange = vi.fn()
     render(<TitrationWizard schedule={[]} onChange={onChange} />)
 
-    // Find inputs in the add-stage-form section by their position
-    const addFormInputs = screen.getAllByRole('spinbutton')
-    const daysInput = addFormInputs[0]
-    const dosageInput = addFormInputs[1]
-    const noteInput = screen.getByPlaceholderText('Nota (opcional)')
+    // Dose virou input text (inputMode decimal, R-270) — busca por placeholder
+    const daysInput = screen.getAllByRole('spinbutton')[0]
+    const dosageInput = screen.getByPlaceholderText('Ex: 0,25')
+    const noteInput = screen.getByPlaceholderText(/Nota \(opcional\)/)
 
     fireEvent.change(daysInput, { target: { value: '7' } })
     fireEvent.change(dosageInput, { target: { value: '1' } })
     fireEvent.change(noteInput, { target: { value: 'Introdução' } })
 
-    fireEvent.click(screen.getByText('➕ Adicionar Etapa'))
+    fireEvent.click(screen.getByText('✓ Gravar Etapa'))
 
-    expect(onChange).toHaveBeenCalledWith([{ days: 7, dosage: 1, note: 'Introdução' }])
+    expect(onChange).toHaveBeenCalledWith([{ duration_days: 7, dosage: 1, description: 'Introdução' }])
+  })
+
+  it('aceita vírgula PT-BR na dose da nova etapa (R-270): "0,25" → 0.25', () => {
+    const onChange = vi.fn()
+    render(<TitrationWizard schedule={[]} onChange={onChange} />)
+
+    fireEvent.change(screen.getByPlaceholderText('Ex: 0,25'), { target: { value: '0,25' } })
+    fireEvent.click(screen.getByText('✓ Gravar Etapa'))
+
+    expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ dosage: 0.25 })])
+  })
+
+  it('dose inválida ou vazia não adiciona etapa', () => {
+    const onChange = vi.fn()
+    render(<TitrationWizard schedule={[]} onChange={onChange} />)
+
+    fireEvent.change(screen.getByPlaceholderText('Ex: 0,25'), { target: { value: 'abc' } })
+    fireEvent.click(screen.getByText('✓ Gravar Etapa'))
+
+    expect(onChange).not.toHaveBeenCalled()
   })
 
   it('removes a stage', () => {
     const schedule = [
-      { days: 7, dosage: 1, note: 'Introdução' },
-      { days: 14, dosage: 2, note: 'Aumento' },
+      { duration_days: 7, dosage: 1, description: 'Introdução' },
+      { duration_days: 14, dosage: 2, description: 'Aumento' },
     ]
     const onChange = vi.fn()
     render(<TitrationWizard schedule={schedule} onChange={onChange} />)
@@ -68,11 +87,11 @@ describe('TitrationWizard', () => {
     const removeButtons = screen.getAllByTitle('Remover etapa')
     fireEvent.click(removeButtons[0])
 
-    expect(onChange).toHaveBeenCalledWith([{ days: 14, dosage: 2, note: 'Aumento' }])
+    expect(onChange).toHaveBeenCalledWith([{ duration_days: 14, dosage: 2, description: 'Aumento' }])
   })
 
   it('updates a stage field', () => {
-    const schedule = [{ days: 7, dosage: 1, note: 'Introdução' }]
+    const schedule = [{ duration_days: 7, dosage: 1, description: 'Introdução' }]
     const onChange = vi.fn()
     render(<TitrationWizard schedule={schedule} onChange={onChange} />)
 
@@ -81,14 +100,16 @@ describe('TitrationWizard', () => {
     const daysInput = stageInputs[0] // First input is for the first stage
     fireEvent.change(daysInput, { target: { value: '10' } })
 
-    expect(onChange).toHaveBeenCalledWith([{ days: 10, dosage: 1, note: 'Introdução' }])
+    expect(onChange).toHaveBeenCalledWith([
+      { duration_days: 10, dosage: 1, description: 'Introdução' },
+    ])
   })
 
-  it('calculates total days correctly', () => {
+  it('calculates total days correctly (incl. fallback legado days/note)', () => {
     const schedule = [
-      { days: 7, dosage: 1, note: 'Introdução' },
-      { days: 14, dosage: 2, note: 'Aumento' },
-      { days: 21, dosage: 3, note: 'Manutenção' },
+      { duration_days: 7, dosage: 1, description: 'Introdução' },
+      { duration_days: 14, dosage: 2, description: 'Aumento' },
+      { days: 21, dosage: 3, note: 'Manutenção' }, // legado pré-canônico
     ]
     const onChange = vi.fn()
     render(<TitrationWizard schedule={schedule} onChange={onChange} />)
@@ -104,17 +125,15 @@ describe('TitrationWizard', () => {
     const onChange = vi.fn()
     render(<TitrationWizard schedule={[]} onChange={onChange} />)
 
-    // Find inputs in the add-stage-form section by their position
-    const addFormInputs = screen.getAllByRole('spinbutton')
-    const daysInput = addFormInputs[0]
-    const dosageInput = addFormInputs[1]
-    const noteInput = screen.getByPlaceholderText('Nota (opcional)')
+    const daysInput = screen.getAllByRole('spinbutton')[0]
+    const dosageInput = screen.getByPlaceholderText('Ex: 0,25')
+    const noteInput = screen.getByPlaceholderText(/Nota \(opcional\)/)
 
     fireEvent.change(daysInput, { target: { value: '7' } })
     fireEvent.change(dosageInput, { target: { value: '1' } })
     fireEvent.change(noteInput, { target: { value: 'Introdução' } })
 
-    fireEvent.click(screen.getByText('➕ Adicionar Etapa'))
+    fireEvent.click(screen.getByText('✓ Gravar Etapa'))
 
     // Note should be reset but days and dosage should remain
     expect(daysInput.value).toBe('7')
@@ -130,7 +149,7 @@ describe('TitrationWizard', () => {
 
     rerender(
       <TitrationWizard
-        schedule={[{ days: 7, dosage: 1, note: 'Introdução' }]}
+        schedule={[{ duration_days: 7, dosage: 1, description: 'Introdução' }]}
         onChange={onChange}
       />
     )

--- a/apps/web/src/features/protocols/components/sections/ProtocolFormAdvancedSection.jsx
+++ b/apps/web/src/features/protocols/components/sections/ProtocolFormAdvancedSection.jsx
@@ -2,6 +2,7 @@ import TitrationWizard from '@protocols/components/TitrationWizard'
 
 export default function ProtocolFormAdvancedSection({
   formData,
+  medicine,
   handleChange,
   enableTitration,
   handleTitrationEnable,
@@ -11,19 +12,11 @@ export default function ProtocolFormAdvancedSection({
 }) {
   return (
     <>
+      {/* Classe própria (não .form-row): o .form-row global do MedicineForm.css é
+          display:grid 2-col no desktop — espremia o wizard na coluna direita
+          (smoke PO 2026-06-11; mobile escapava pelo breakpoint 1fr). */}
       {!isSimpleMode && showTitration && (
-        <div
-          className="form-row"
-          style={{
-            flexDirection: 'column',
-            gap: 'var(--space-2)',
-            border: '1px solid var(--border-color)',
-            padding: 'var(--space-3)',
-            borderRadius: 'var(--radius-md)',
-            background: 'var(--bg-tertiary)',
-            marginBottom: 'var(--space-4)',
-          }}
-        >
+        <div className="titration-section">
           <div className="form-group checkbox-group" style={{ marginBottom: 0 }}>
             <label className="checkbox-label">
               <input
@@ -39,6 +32,8 @@ export default function ProtocolFormAdvancedSection({
             <TitrationWizard
               schedule={formData.titration_schedule}
               onChange={setTitrationSchedule}
+              medicine={medicine}
+              intakeUnit={formData.intake_unit || null}
             />
           ) : (
             <div className="form-row" style={{ marginTop: 'var(--space-2)' }}>

--- a/apps/web/src/features/protocols/components/steps/TreatmentWizardStep1.jsx
+++ b/apps/web/src/features/protocols/components/steps/TreatmentWizardStep1.jsx
@@ -121,7 +121,7 @@ function NewMedicineForm({ medicineData, updateMedicine, handleMedicineSelect, h
           ))}
         </select>
       </label>
-      {(medicineData.presentation === 'injetavel') && (
+      {(!medicineData.dosage_unit?.endsWith('/ml') && medicineData.presentation === 'injetavel') && (
         <label className="wizard__label">
           Validade após aberto (dias)
           <input

--- a/apps/web/src/features/protocols/components/steps/TreatmentWizardStep1.jsx
+++ b/apps/web/src/features/protocols/components/steps/TreatmentWizardStep1.jsx
@@ -1,7 +1,7 @@
 import MedicineAutocomplete from '@medications/components/MedicineAutocomplete'
 import LaboratoryAutocomplete from '@medications/components/LaboratoryAutocomplete'
 import Button from '@shared/components/ui/Button'
-import { DOSAGE_UNITS, DOSAGE_UNIT_LABELS, REGULATORY_CATEGORIES, REGULATORY_CATEGORY_LABELS } from '@schemas/medicineSchema'
+import { DOSAGE_UNITS, DOSAGE_UNIT_LABELS, REGULATORY_CATEGORIES, REGULATORY_CATEGORY_LABELS, PRESENTATIONS, PRESENTATION_LABELS } from '@schemas/medicineSchema'
 
 /** Renderiza o formulário de cadastro de novo medicamento. */
 function NewMedicineForm({ medicineData, updateMedicine, handleMedicineSelect, handleLaboratorySelect }) {
@@ -94,6 +94,48 @@ function NewMedicineForm({ medicineData, updateMedicine, handleMedicineSelect, h
           </select>
         </label>
       </div>
+
+      {/* 012 Fase B (smoke PO): apresentação faltava no passo 1 — sem ela injetável/
+          pomada nasciam "comprimido" e o eixo TTL nunca ativava. Unidade /ml força
+          'liquido' (mesma regra do MedicineForm). */}
+      <label className="wizard__label">
+        Apresentação
+        <select
+          className="wizard__select"
+          value={medicineData.dosage_unit?.endsWith('/ml') ? 'liquido' : medicineData.presentation || 'comprimido'}
+          disabled={medicineData.dosage_unit?.endsWith('/ml')}
+          onChange={(e) => {
+            const presentation = e.target.value
+            updateMedicine('presentation', presentation)
+            // Prefill 28 ao virar injetável (editável); limpa ao sair (valor obsoleto
+            // não pode persistir — mesma regra do MedicineForm/review #658).
+            if (presentation === 'injetavel') {
+              if (!medicineData.shelf_life_days) updateMedicine('shelf_life_days', 28)
+            } else {
+              updateMedicine('shelf_life_days', '')
+            }
+          }}
+        >
+          {PRESENTATIONS.map((pres) => (
+            <option key={pres} value={pres}>{PRESENTATION_LABELS[pres] || pres}</option>
+          ))}
+        </select>
+      </label>
+      {(medicineData.presentation === 'injetavel') && (
+        <label className="wizard__label">
+          Validade após aberto (dias)
+          <input
+            type="number"
+            className="wizard__input"
+            value={medicineData.shelf_life_days ?? ''}
+            onChange={(e) => updateMedicine('shelf_life_days', e.target.value)}
+            placeholder="28"
+            min="1"
+            step="1"
+          />
+          <small className="wizard__label-note">Dias de uso após abrir o frasco/caneta — confira a bula.</small>
+        </label>
+      )}
     </>
   )
 }

--- a/apps/web/src/features/protocols/hooks/_treatmentWizardSubmit.js
+++ b/apps/web/src/features/protocols/hooks/_treatmentWizardSubmit.js
@@ -13,6 +13,11 @@ async function resolveMedicine(existing, data) {
     // Líquido (/ml): grava densidade + presentation='liquido'; sólido zera densidade.
     units_per_ml: isLiquid && data.units_per_ml ? Number(data.units_per_ml) : null,
     presentation: isLiquid ? 'liquido' : data.presentation || 'comprimido',
+    // TTL pós-abertura: só injetável persiste (guard idêntico ao MedicineForm)
+    shelf_life_days:
+      !isLiquid && data.presentation === 'injetavel' && data.shelf_life_days !== ''
+        ? Number(data.shelf_life_days)
+        : null,
     laboratory: data.laboratory || null,
     active_ingredient: data.active_ingredient || null,
     therapeutic_class: data.therapeutic_class || null,

--- a/apps/web/src/features/protocols/hooks/_treatmentWizardSubmit.js
+++ b/apps/web/src/features/protocols/hooks/_treatmentWizardSubmit.js
@@ -15,7 +15,7 @@ async function resolveMedicine(existing, data) {
     presentation: isLiquid ? 'liquido' : data.presentation || 'comprimido',
     // TTL pós-abertura: só injetável persiste (guard idêntico ao MedicineForm)
     shelf_life_days:
-      !isLiquid && data.presentation === 'injetavel' && data.shelf_life_days !== ''
+      !isLiquid && data.presentation === 'injetavel' && data.shelf_life_days
         ? Number(data.shelf_life_days)
         : null,
     laboratory: data.laboratory || null,

--- a/apps/web/src/features/protocols/hooks/_useWizardSections.js
+++ b/apps/web/src/features/protocols/hooks/_useWizardSections.js
@@ -22,7 +22,7 @@ export function useWizardNavigation(initialStep) {
 
 const _MEDICINE_DEFAULTS = {
   name: '', type: 'medicamento', dosage_per_pill: '', dosage_unit: 'mg',
-  units_per_ml: '', presentation: 'comprimido',
+  units_per_ml: '', presentation: 'comprimido', shelf_life_days: '',
   laboratory: '', active_ingredient: '', therapeutic_class: null, regulatory_category: null,
 }
 

--- a/apps/web/src/features/protocols/hooks/protocolFormUtils.js
+++ b/apps/web/src/features/protocols/hooks/protocolFormUtils.js
@@ -163,7 +163,17 @@ export const prepareDataToSave = (formData, enableTitration) => {
     intake_unit: formData.intake_unit || null,
     target_dosage: (formData.target_dosage ?? '') !== '' ? parseFloat(formData.target_dosage) : null,
     titration_status: isTitrating ? 'titulando' : formData.titration_status,
-    titration_schedule: isTitrating ? formData.titration_schedule : [],
+    // R-270 (012 Fase B): wizard mantém o texto cru durante a digitação ("0,5");
+    // normaliza vírgula→ponto e força number aqui — o banco nunca vê string.
+    titration_schedule: isTitrating
+      ? formData.titration_schedule.map((stage) => ({
+          // Shape canônico do Zod (titrationStageSchema): duration_days/description.
+          // Migra registros legados days/note na gravação.
+          duration_days: parseInt(stage.duration_days ?? stage.days, 10) || 1,
+          dosage: parseFloat(String(stage.dosage ?? '').replace(',', '.')) || 0,
+          ...((stage.description ?? stage.note) ? { description: stage.description ?? stage.note } : {}),
+        }))
+      : [],
     notes: formData.notes.trim() || null,
     active: formData.active,
     start_date: formData.start_date || null,

--- a/apps/web/src/features/protocols/hooks/useTreatmentWizardState.js
+++ b/apps/web/src/features/protocols/hooks/useTreatmentWizardState.js
@@ -86,6 +86,7 @@ export function useTreatmentWizardState({
       dosage_unit: 'mg',
       units_per_ml: '',
       presentation: 'comprimido',
+      shelf_life_days: '',
       laboratory: '',
       active_ingredient: '',
       therapeutic_class: null,

--- a/apps/web/src/views/redesign/Dashboard.css
+++ b/apps/web/src/views/redesign/Dashboard.css
@@ -93,3 +93,29 @@
     text-align: left;
   }
 }
+
+/* Erro de ação 1-click (012 Fase B — smoke PO): banner dispensável no topo */
+.dashboard-action-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  background: #fee2e2;
+  color: #b91c1c;
+  border: 1px solid #fecaca;
+  border-radius: var(--radius-card, 12px);
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.dashboard-action-error__close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+}

--- a/apps/web/src/views/redesign/Dashboard.jsx
+++ b/apps/web/src/views/redesign/Dashboard.jsx
@@ -97,6 +97,8 @@ function useDashboardViewState(onNavigate) {
     handleRegisterDosesAll,
     handleSnoozeAlert,
     handleReminderAccept,
+    actionError,
+    clearActionError,
   } = useDashboardHandlers({
     refresh,
     reminderSuggestionData,
@@ -214,6 +216,8 @@ function useDashboardViewState(onNavigate) {
     handleRegisterDosesAll,
     handleSnoozeAlert,
     handleReminderAccept,
+    actionError,
+    clearActionError,
     setDismissedSuggestionId,
   }
 }
@@ -237,6 +241,8 @@ export default function Dashboard({ onNavigate }) {
     handleRegisterDosesAll,
     handleSnoozeAlert,
     handleReminderAccept,
+    actionError,
+    clearActionError,
     setDismissedSuggestionId,
     totals,
     now,
@@ -265,6 +271,22 @@ export default function Dashboard({ onNavigate }) {
       className="page-container dashboard-container"
       aria-label="Dashboard — Dosiq"
     >
+      {/* Erro de ação 1-click (Tomar/Confirmar agora) — ex.: estoque insuficiente.
+          Antes o throw morria sem consumidor e o clique parecia ignorado (smoke PO). */}
+      {actionError && (
+        <div className="dashboard-action-error" role="alert">
+          <span>⚠️ {actionError}</span>
+          <button
+            type="button"
+            className="dashboard-action-error__close"
+            onClick={clearActionError}
+            aria-label="Fechar aviso"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
       {/* ─── Smart Alerts (substitui StockAlertInline no topo) ─── */}
       {smartAlerts.length > 0 && (
         <section className="dashboard-alerts-section" aria-label="Alertas inteligentes">

--- a/apps/web/src/views/redesign/DashboardColumnRight.jsx
+++ b/apps/web/src/views/redesign/DashboardColumnRight.jsx
@@ -24,10 +24,12 @@ export default function DashboardColumnRight({
           pendentes dentro da tolerância. Seção própria no topo, antes do cronograma
           de hoje; não é slot de hoje (preserva o fix do slot-fantasma). */}
       {carryOverDoses.length > 0 && (
-        <section className="dashboard-carryover-section" aria-label="Pendências de ontem">
+        <section className="dashboard-carryover-section" aria-label="Doses pendentes">
           <div className="dashboard-section-header">
-            <h2 className="dashboard-section-title">Pendências de ontem</h2>
-            <p className="dashboard-section-subtitle">Doses de ontem ainda no prazo de registro</p>
+            {/* 012 Fase B (FR-008b): carry-over agora cobre multi-dia (semanal
+                tolera 3,5d) — "de ontem" mentiria pra dose de 2-3 dias atrás. */}
+            <h2 className="dashboard-section-title">Doses pendentes</h2>
+            <p className="dashboard-section-subtitle">Doses anteriores ainda no prazo de registro</p>
           </div>
           <div className="cronograma-doses cronograma-doses--simple">
             {carryOverDoses.map((dose) => (

--- a/docs/standards/CHANGELOG_AND_RELEASES.md
+++ b/docs/standards/CHANGELOG_AND_RELEASES.md
@@ -10,6 +10,20 @@ This document defines the Dosiq release logging process. Rules are written in En
 | Mobile | `apps/mobile/app.config.js` `APP_VERSION` | Android `versionCode` and iOS `buildNumber` are derived from `APP_VERSION` by R-182. |
 | Root monorepo | `package.json` `version` | Metadata only. Do not treat as product release version unless a future ADR changes this. |
 
+## Mobile 0.x Versioning Convention (PO decision 2026-06-12)
+
+While the mobile app is pre-1.0, the SemVer minor acts as the de-facto major:
+
+- **Minor (0.X.0)** = epic / store-worthy release: a delivery with a store note that end
+  users perceive as a new version. One epic = one minor line (e.g. spec 012 = `0.16.x`).
+- **Patch (0.16.X)** = intermediate epic phases, sub-features and fixes
+  (012 Fase A = 0.16.0, Fase B = 0.16.1, Fase C = 0.16.2, ...).
+- Rationale: burning a minor per sub-phase inflates the version line without matching
+  user-perceived progress. `buildNumber` derivation (R-182: major*10000+minor*100+patch)
+  supports up to 99 patches per minor.
+- Web is post-1.0 and keeps canonical SemVer (minor per feature). When mobile reaches
+  1.0.0 this convention expires and the web rule applies.
+
 ## SQP Release Checklist
 
 Every code-changing PR must follow R-221 SQP:

--- a/packages/core/src/utils/__tests__/doseInstanceGenerator.test.js
+++ b/packages/core/src/utils/__tests__/doseInstanceGenerator.test.js
@@ -165,19 +165,60 @@ describe('generateInstances — tolerância dinâmica (§6)', () => {
     expect(out[0].tolerance_minutes).toBe(120)
   })
 
-  it('semanal multi-dose: 120 fixo (não-diário não usa janela dinâmica)', () => {
+  // ── ADR-061 / FR-007 (012 Fase B): não-diário frequency-aware, SEM cap de 120 ──
+
+  it('semanal dose única: tolerância = metade do período (5040min = 3,5 dias), sem cap', () => {
+    // Perdão clínico do GLP-1 semanal: 5040min = 84h — cobre o perdão de 72h da bula.
     const out = generateInstances(
       {
         ...baseProtocol,
         frequency: 'semanal',
-        weekdays: ['domingo', 'segunda', 'terça', 'quarta', 'quinta', 'sexta', 'sábado'],
-        time_schedule: ['08:00', '09:00'],
+        weekdays: ['domingo'],
+        time_schedule: ['08:00'],
       },
       '2026-05-10T00:00:00-03:00',
       '2026-05-10T23:59:59-03:00',
       'America/Sao_Paulo'
     )
-    expect(out.every((i) => i.tolerance_minutes === 120)).toBe(true)
+    expect(out[0].tolerance_minutes).toBe(5040)
+  })
+
+  it('dias_alternados dose única: metade de 48h (1440min), sem cap', () => {
+    const out = generateInstances(
+      { ...baseProtocol, frequency: 'dias_alternados', time_schedule: ['08:00'] },
+      '2026-05-10T00:00:00-03:00',
+      '2026-05-10T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out[0].tolerance_minutes).toBe(1440)
+  })
+
+  it('semanal multi-dose: metade do menor gap adjacente, acima de 120 sem cap', () => {
+    // 08:00/20:00 no mesmo dia: gap intra-dia 720min → 360. Cap de 120 NÃO se aplica.
+    const out = generateInstances(
+      {
+        ...baseProtocol,
+        frequency: 'semanal',
+        weekdays: ['domingo'],
+        time_schedule: ['08:00', '20:00'],
+      },
+      '2026-05-10T00:00:00-03:00',
+      '2026-05-10T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out.map((i) => i.tolerance_minutes)).toEqual([360, 360])
+  })
+
+  it('frequência sem período mapeado: mantém 120 fixo (legado)', () => {
+    // 'mensal' não existe no FREQUENCY_PERIOD_MINUTES → fallback legado 120.
+    // (personalizado/PRN nunca materializam instâncias — matcher false.)
+    const out = generateInstances(
+      { ...baseProtocol, frequency: 'mensal', time_schedule: ['08:00'] },
+      '2026-05-10T00:00:00-03:00',
+      '2026-05-10T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out[0].tolerance_minutes).toBe(120)
   })
 })
 
@@ -225,5 +266,51 @@ describe('generateInstances — casos de borda', () => {
     )
     expect(out).toHaveLength(1)
     expect(wallClock(out[0].scheduled_for, 'America/Sao_Paulo')).toBe('08:00')
+  })
+})
+
+// ── 012 Fase B (FR-006/FP-1): expected_dose congela a etapa de titulação vigente ──
+describe('generateInstances — titulação congela expected_dose por etapa', () => {
+  const glp1Protocol = {
+    id: 'p-glp1',
+    user_id: 'u1',
+    frequency: 'semanal',
+    weekdays: ['domingo'],
+    time_schedule: ['08:00'],
+    dosage_per_intake: 1,
+    start_date: '2026-06-01',
+    active: true,
+    titration_schedule: [
+      { days: 28, dosage: 0.25 },
+      { days: 28, dosage: 0.5 },
+    ],
+    current_stage_index: 0,
+    stage_started_at: '2026-06-01T08:00:00.000Z',
+    titration_status: 'titulando',
+  }
+
+  it('instâncias futuras nascem com a dose da etapa vigente NA DATA (não a atual)', () => {
+    // Janela cruza a fronteira da etapa 1 (28d → 2026-06-29): domingos 07/06..05/07
+    const out = generateInstances(
+      glp1Protocol,
+      '2026-06-01T00:00:00-03:00',
+      '2026-07-05T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out.length).toBeGreaterThanOrEqual(4)
+    const byDate = Object.fromEntries(out.map((i) => [i.scheduled_for.slice(0, 10), i.expected_dose]))
+    expect(byDate['2026-06-07']).toBe(0.25) // etapa 1
+    expect(byDate['2026-06-28']).toBe(0.25) // último domingo da etapa 1
+    expect(byDate['2026-07-05']).toBe(0.5)  // etapa 2 (após 29/06)
+  })
+
+  it('sem titulação ativa (estável) → dosage_per_intake chapado', () => {
+    const out = generateInstances(
+      { ...glp1Protocol, titration_status: 'estável' },
+      '2026-06-01T00:00:00-03:00',
+      '2026-07-05T23:59:59-03:00',
+      'America/Sao_Paulo'
+    )
+    expect(out.every((i) => i.expected_dose === 1)).toBe(true)
   })
 })

--- a/packages/core/src/utils/__tests__/doseZones.carryOver.test.js
+++ b/packages/core/src/utils/__tests__/doseZones.carryOver.test.js
@@ -1,0 +1,92 @@
+// 012 Fase B (FR-008b): carry-over multi-dia — dose semanal (tolerância 5040min)
+// pendente há 2-3 dias continua actionável no carry-over, com rótulo relativo.
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { splitDayTimeline, daysAgoLabel } from '../doseZones.js'
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.clearAllTimers()
+})
+
+const TZ = 'America/Sao_Paulo'
+// "agora": 2026-06-10 10:00 SP (13:00Z)
+const NOW = new Date('2026-06-10T13:00:00.000Z')
+
+const weeklyProtocol = {
+  id: 'p-glp1',
+  medicine_id: 'm1',
+  medicine: { name: 'Semaglutida', type: 'medicamento', dosage_unit: 'mg' },
+  dosage_per_intake: 0.25,
+}
+
+function inst(overrides) {
+  return {
+    id: 'di-1',
+    protocol_id: 'p-glp1',
+    status: 'pending',
+    ...overrides,
+  }
+}
+
+describe('splitDayTimeline — carry-over multi-dia (FR-008b)', () => {
+  it('dose semanal de 2 dias atrás, dentro da tolerância 5040 → carryOver', () => {
+    // Agendada 2026-06-08 08:00 SP (11:00Z) → atraso = 2d2h = 3000min < 5040
+    const out = splitDayTimeline(
+      [inst({ scheduled_for: '2026-06-08T11:00:00.000Z', tolerance_minutes: 5040 })],
+      [weeklyProtocol],
+      { now: NOW, tz: TZ }
+    )
+    expect(out.carryOver).toHaveLength(1)
+    expect(out.today).toHaveLength(0)
+  })
+
+  it('dose semanal de 4 dias atrás, FORA da tolerância (5040 < 5880min) → some (não actionável)', () => {
+    const out = splitDayTimeline(
+      [inst({ scheduled_for: '2026-06-06T11:00:00.000Z', tolerance_minutes: 5040 })],
+      [weeklyProtocol],
+      { now: NOW, tz: TZ }
+    )
+    expect(out.carryOver).toHaveLength(0)
+  })
+
+  it('dose diária de 2 dias atrás com tolerância 120 → some (regressão: legado intacto)', () => {
+    const out = splitDayTimeline(
+      [inst({ scheduled_for: '2026-06-08T11:00:00.000Z', tolerance_minutes: 120 })],
+      [weeklyProtocol],
+      { now: NOW, tz: TZ }
+    )
+    expect(out.carryOver).toHaveLength(0)
+  })
+
+  it('dose multi-dia já taken → não entra no carryOver (não é pendência)', () => {
+    const out = splitDayTimeline(
+      [inst({ scheduled_for: '2026-06-08T11:00:00.000Z', tolerance_minutes: 5040, status: 'taken' })],
+      [weeklyProtocol],
+      { now: NOW, tz: TZ }
+    )
+    expect(out.carryOver).toHaveLength(0)
+  })
+})
+
+describe('daysAgoLabel (FR-008b)', () => {
+  it('mesmo dia local → null (sem rótulo)', () => {
+    expect(daysAgoLabel('2026-06-10T11:00:00.000Z', NOW, TZ)).toBeNull()
+  })
+
+  it('dia anterior → "ontem" (mesmo com poucas horas de distância)', () => {
+    // 2026-06-09 23:00 SP (2026-06-10T02:00Z) visto 10/06 10:00 SP = 11h de distância
+    expect(daysAgoLabel('2026-06-10T02:00:00.000Z', NOW, TZ)).toBe('ontem')
+  })
+
+  it('2+ dias → "há N dias"', () => {
+    expect(daysAgoLabel('2026-06-08T11:00:00.000Z', NOW, TZ)).toBe('há 2 dias')
+    expect(daysAgoLabel('2026-06-07T11:00:00.000Z', NOW, TZ)).toBe('há 3 dias')
+  })
+
+  it('degenerados → null: futuro, inválido, sem args', () => {
+    expect(daysAgoLabel('2026-06-12T11:00:00.000Z', NOW, TZ)).toBeNull()
+    expect(daysAgoLabel('not-a-date', NOW, TZ)).toBeNull()
+    expect(daysAgoLabel(null, NOW, TZ)).toBeNull()
+    expect(daysAgoLabel('2026-06-08T11:00:00.000Z', null, TZ)).toBeNull()
+  })
+})

--- a/packages/core/src/utils/__tests__/titrationUtils.test.js
+++ b/packages/core/src/utils/__tests__/titrationUtils.test.js
@@ -370,3 +370,84 @@ describe('calculateTitrationData', () => {
     })
   })
 })
+
+// ── 012 Fase B (FR-006/FP-1): resolução da etapa vigente num instante ──────────
+import { resolveTitrationStageAt } from '../titrationUtils'
+
+describe('resolveTitrationStageAt', () => {
+  // GLP-1 clássico: 0,25mg/28d → 0,5mg/28d → 1,0mg/28d
+  const glp1 = {
+    titration_schedule: [
+      { days: 28, dosage: 0.25 },
+      { days: 28, dosage: 0.5 },
+      { days: 28, dosage: 1.0 },
+    ],
+    current_stage_index: 0,
+    stage_started_at: '2026-06-01T08:00:00.000Z',
+    titration_status: 'titulando',
+  }
+
+  it('instante dentro da etapa atual → dose da etapa atual', () => {
+    const out = resolveTitrationStageAt(glp1, '2026-06-15T08:00:00.000Z')
+    expect(out).toEqual({ stageIndex: 0, dosage: 0.25 })
+  })
+
+  it('instante na 2ª etapa (29º dia) → dose da etapa futura (congela ANTES do avanço no banco)', () => {
+    const out = resolveTitrationStageAt(glp1, '2026-06-30T08:00:00.000Z')
+    expect(out).toEqual({ stageIndex: 1, dosage: 0.5 })
+  })
+
+  it('instante na 3ª etapa (57º dia) → caminha múltiplas etapas', () => {
+    const out = resolveTitrationStageAt(glp1, '2026-07-28T08:00:00.000Z')
+    expect(out).toEqual({ stageIndex: 2, dosage: 1.0 })
+  })
+
+  it('além do fim da última etapa → mantém dose alvo (última etapa)', () => {
+    const out = resolveTitrationStageAt(glp1, '2026-12-01T08:00:00.000Z')
+    expect(out).toEqual({ stageIndex: 2, dosage: 1.0 })
+  })
+
+  it('respeita current_stage_index como ponto de partida (avanço manual prévio)', () => {
+    const p = { ...glp1, current_stage_index: 1, stage_started_at: '2026-06-29T08:00:00.000Z' }
+    const out = resolveTitrationStageAt(p, '2026-07-01T08:00:00.000Z')
+    expect(out).toEqual({ stageIndex: 1, dosage: 0.5 })
+  })
+
+  it('instante ANTERIOR ao início da etapa atual → null (histórico já congelado)', () => {
+    expect(resolveTitrationStageAt(glp1, '2026-05-20T08:00:00.000Z')).toBeNull()
+  })
+
+  it('status estável/alvo_atingido → null (dosage_per_intake rege)', () => {
+    expect(resolveTitrationStageAt({ ...glp1, titration_status: 'estável' }, '2026-06-15T08:00:00.000Z')).toBeNull()
+    expect(resolveTitrationStageAt({ ...glp1, titration_status: 'alvo_atingido' }, '2026-06-15T08:00:00.000Z')).toBeNull()
+  })
+
+  it('degenerados → null: sem schedule, sem stage_started_at, índice fora, dose inválida, days inválido na etapa atual', () => {
+    expect(resolveTitrationStageAt(null, '2026-06-15T08:00:00.000Z')).toBeNull()
+    expect(resolveTitrationStageAt({ ...glp1, titration_schedule: [] }, '2026-06-15T08:00:00.000Z')).toBeNull()
+    expect(resolveTitrationStageAt({ ...glp1, stage_started_at: null }, '2026-06-15T08:00:00.000Z')).toBeNull()
+    expect(resolveTitrationStageAt({ ...glp1, current_stage_index: 9 }, '2026-06-15T08:00:00.000Z')).toBeNull()
+    expect(resolveTitrationStageAt({ ...glp1, titration_schedule: [{ days: 28, dosage: 0 }] }, '2026-06-15T08:00:00.000Z')).toBeNull()
+  })
+
+  it('days inválido impede SAIR da etapa, não entrar nela (caminha até ela e para)', () => {
+    const p = { ...glp1, titration_schedule: [{ days: 28, dosage: 0.25 }, { days: 0, dosage: 0.5 }] }
+    const out = resolveTitrationStageAt(p, '2026-08-01T08:00:00.000Z')
+    expect(out).toEqual({ stageIndex: 1, dosage: 0.5 })
+  })
+})
+
+describe('resolveTitrationStageAt — shape canônico duration_days', () => {
+  it('aceita duration_days (titrationStageSchema) além do legado days', () => {
+    const p = {
+      titration_schedule: [
+        { duration_days: 28, dosage: 0.25 },
+        { duration_days: 28, dosage: 0.5 },
+      ],
+      current_stage_index: 0,
+      stage_started_at: '2026-06-01T08:00:00.000Z',
+      titration_status: 'titulando',
+    }
+    expect(resolveTitrationStageAt(p, '2026-06-30T08:00:00.000Z')).toEqual({ stageIndex: 1, dosage: 0.5 })
+  })
+})

--- a/packages/core/src/utils/doseInstanceGenerator.js
+++ b/packages/core/src/utils/doseInstanceGenerator.js
@@ -26,6 +26,7 @@ import {
   parseTimestamp,
 } from './dateUtils.js'
 import { isProtocolActiveOnDate } from './adherenceLogic.js'
+import { resolveTitrationStageAt } from './titrationUtils.js'
 
 /**
  * Converte Date | ISO string | timestamp(ms) num Date absoluto.
@@ -48,6 +49,21 @@ const DAILY_FREQUENCIES = new Set(['diário', 'diariamente', 'daily'])
 const MAX_TOLERANCE_MINUTES = 120
 
 /**
+ * Período (minutos) entre ocorrências por frequência — base da tolerância
+ * não-diária (ADR-061/FR-007): a janela de perdão clínica de uma dose semanal
+ * é dias, não horas. Frequências fora do mapa (personalizado etc.) mantêm 120.
+ */
+const FREQUENCY_PERIOD_MINUTES = {
+  semanal: 10080,
+  semanalmente: 10080,
+  weekly: 10080,
+  dias_alternados: 2880,
+  dia_sim_dia_nao: 2880,
+  every_other_day: 2880,
+  alternating: 2880,
+}
+
+/**
  * Converte "HH:MM" em minutos desde a meia-noite. Retorna null se inválido.
  * @param {string} time
  * @returns {number|null}
@@ -67,29 +83,40 @@ function timeToMinutes(time) {
  *   ⚠️ Considera o wrap-around da meia-noite: como o protocolo diário repete os mesmos
  *   slots todo dia, a última dose do dia N e a primeira do dia N+1 são adjacentes no
  *   tempo real. Sem isso, doses tipo 23:30/00:30 teriam janelas de 120min sobrepostas.
- * - Não-diário ou dose única: 120 fixo (§6 MASTER_PLAN).
+ * - Não-diário com período conhecido (semanal/dias_alternados — ADR-061/FR-007):
+ *   mesma regra "metade do menor intervalo adjacente", mas o wrap-around usa o
+ *   PERÍODO da frequência (semanal=10080, alternados=2880) e **sem teto de 120**
+ *   — o perdão clínico de GLP-1 semanal é de dias (slot único → floor(10080/2)=5040,
+ *   3,5 dias). Diário mantém cap 120 (semântica de adesão do público 1×/dia).
+ * - Frequência sem período mapeado (personalizado etc.): 120 fixo (§6 MASTER_PLAN).
  *
  * @param {number[]} sortedMinutes - minutos dos slots, ordenados ascendente
- * @param {boolean} isDaily
+ * @param {string} frequency - frequência normalizada (lowercase) do protocolo
  * @returns {number[]} tolerância por slot (mesma ordem de sortedMinutes)
  */
-function computeTolerances(sortedMinutes, isDaily) {
-  if (!isDaily || sortedMinutes.length < 2) {
+function computeTolerances(sortedMinutes, frequency) {
+  const isDaily = DAILY_FREQUENCIES.has(frequency)
+  const periodMinutes = isDaily ? 1440 : FREQUENCY_PERIOD_MINUTES[frequency]
+  // Sem período conhecido (personalizado etc.): comportamento legado, 120 fixo.
+  if (!periodMinutes) return sortedMinutes.map(() => MAX_TOLERANCE_MINUTES)
+  // Diário de dose única: legado (120) — só multi-dose tem gap intra-dia.
+  if (isDaily && sortedMinutes.length < 2) {
     return sortedMinutes.map(() => MAX_TOLERANCE_MINUTES)
   }
   const len = sortedMinutes.length
-  const MINUTES_PER_DAY = 1440
   return sortedMinutes.map((minute, i) => {
-    // Para o 1º/último slot, o intervalo adjacente cruza a meia-noite (wrap-around).
+    // Para o 1º/último slot, o intervalo adjacente cruza o período (wrap-around):
+    // diário = meia-noite; semanal/alternados = próxima ocorrência do ciclo.
     const prevGap = i > 0
       ? minute - sortedMinutes[i - 1]
-      : (MINUTES_PER_DAY - sortedMinutes[len - 1]) + minute
+      : (periodMinutes - sortedMinutes[len - 1]) + minute
     const nextGap = i < len - 1
       ? sortedMinutes[i + 1] - minute
-      : (MINUTES_PER_DAY - minute) + sortedMinutes[0]
+      : (periodMinutes - minute) + sortedMinutes[0]
     const smallestAdjacent = Math.min(prevGap, nextGap)
-    // metade do menor intervalo adjacente (arredonda p/ baixo), teto 120
-    return Math.min(Math.floor(smallestAdjacent / 2), MAX_TOLERANCE_MINUTES)
+    const half = Math.floor(smallestAdjacent / 2)
+    // Teto de 120 SÓ no diário (ADR-061: não-diário sem cap).
+    return isDaily ? Math.min(half, MAX_TOLERANCE_MINUTES) : half
   })
 }
 
@@ -159,7 +186,6 @@ export function generateInstances(protocol, fromTs, toTs, tz = 'America/Sao_Paul
 
   const fromMs = fromDate.getTime()
   const toMs = toDate.getTime()
-  const isDaily = DAILY_FREQUENCIES.has(frequency)
   const expectedDose = protocol.dosage_per_intake ?? 1
 
   // Slots do dia, ordenados, com tolerância pré-computada (estável dia a dia).
@@ -169,7 +195,7 @@ export function generateInstances(protocol, fromTs, toTs, tz = 'America/Sao_Paul
     .sort((a, b) => a.minutes - b.minutes)
   if (slots.length === 0) return []
 
-  const tolerances = computeTolerances(slots.map((s) => s.minutes), isDaily)
+  const tolerances = computeTolerances(slots.map((s) => s.minutes), frequency)
 
   const instances = []
   for (const dateStr of localDateRange(fromDate, toDate, tz)) {
@@ -178,11 +204,14 @@ export function generateInstances(protocol, fromTs, toTs, tz = 'America/Sao_Paul
       const scheduledForIso = buildScheduledFor(dateStr, slot.minutes, tz)
       const scheduledMs = parseISO(scheduledForIso).getTime()
       if (scheduledMs < fromMs || scheduledMs > toMs) return
+      // 012 Fase B (FR-006/FP-1): titulação ativa congela a dose da ETAPA vigente
+      // na data da ocorrência — instância futura nasce com a dose da etapa futura.
+      const titrationStage = resolveTitrationStageAt(protocol, scheduledMs)
       instances.push({
         user_id: protocol.user_id,
         protocol_id: protocol.id,
         scheduled_for: scheduledForIso,
-        expected_dose: expectedDose,
+        expected_dose: titrationStage ? titrationStage.dosage : expectedDose,
         tolerance_minutes: tolerances[i],
         critical_alarm: protocol.critical_alarm ?? false,
       })

--- a/packages/core/src/utils/doseZones.js
+++ b/packages/core/src/utils/doseZones.js
@@ -232,6 +232,27 @@ function classifyInstanceDay(inst, dayStart, dayEnd, nowMs) {
   return null
 }
 
+/**
+ * Rótulo relativo de atraso por DATA-CALENDÁRIO no tz (012 Fase B, FR-008b).
+ * Dose semanal pendente multi-dia precisa dizer "há 2 dias", não só o horário.
+ * @param {string|Date} scheduledFor - instante da ocorrência
+ * @param {Date} now
+ * @param {string} [tz]
+ * @returns {string|null} null = mesmo dia; 'ontem'; 'há N dias'
+ */
+export function daysAgoLabel(scheduledFor, now, tz = DEFAULT_TZ) {
+  if (!scheduledFor || !(now instanceof Date)) return null
+  const sched = scheduledFor instanceof Date ? scheduledFor : parseISO(scheduledFor)
+  if (Number.isNaN(sched.getTime()) || Number.isNaN(now.getTime())) return null
+  // Diferença por data-calendário local (não janelas de 24h): dose de ontem 23:00
+  // vista hoje 01:00 é "ontem", mesmo com 2h de distância.
+  const schedDay = parseISO(formatLocalDate(getUserTime(sched, tz)) + 'T00:00:00Z').getTime()
+  const nowDay = parseISO(formatLocalDate(getUserTime(now, tz)) + 'T00:00:00Z').getTime()
+  const days = Math.round((nowDay - schedDay) / 86400000)
+  if (days <= 0) return null
+  return days === 1 ? 'ontem' : `há ${days} dias`
+}
+
 export function splitDayTimeline(instances, protocols, { now, tz = DEFAULT_TZ } = {}) {
   const list = Array.isArray(instances) ? instances : []
   // `now` ausente/inválido → fallback p/ getRawNow (respeita offset dev) + guard NaN:

--- a/packages/core/src/utils/index.js
+++ b/packages/core/src/utils/index.js
@@ -78,6 +78,7 @@ export {
 // Titration utilities
 export {
   calculateTitrationData,
+  resolveTitrationStageAt,
 } from './titrationUtils.js'
 
 // Notification utilities
@@ -157,6 +158,7 @@ export {
   classifyDose,
   buildDoseItemsFromInstances,
   splitDayTimeline,
+  daysAgoLabel,
 } from './doseZones.js'
 
 // SemVer utilities (026 — Nudges In-App)

--- a/packages/core/src/utils/titrationUtils.js
+++ b/packages/core/src/utils/titrationUtils.js
@@ -1,5 +1,57 @@
 import { getNow, parseISO } from './dateUtils.js'
 
+const MS_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * Resolve a etapa de titulação vigente num INSTANTE arbitrário (012 Fase B, FR-006).
+ *
+ * Caminha o cronograma a partir de stage_started_at/current_stage_index somando
+ * duration (days) de cada etapa — permite ao gerador de dose_instances congelar
+ * `expected_dose` da etapa vigente NA DATA da ocorrência (FP-1/ADR-050), mesmo
+ * para instâncias futuras geradas antes do avanço formal no banco.
+ *
+ * Puro e clock-free (instante injetado). Retorna null quando titulação não rege
+ * a dose: sem schedule, sem stage_started_at, status 'alvo_atingido'/'pausado',
+ * índice fora do range, ou instante anterior ao início da etapa atual.
+ *
+ * @param {Object} protocol - {titration_schedule, current_stage_index, stage_started_at, titration_status}
+ * @param {Date|string|number} at - instante da ocorrência
+ * @returns {{stageIndex: number, dosage: number}|null}
+ */
+export function resolveTitrationStageAt(protocol, at) {
+  const schedule = protocol?.titration_schedule
+  if (!Array.isArray(schedule) || schedule.length === 0) return null
+  if (!protocol.stage_started_at) return null
+  // Só 'titulando' rege a dose (consistente com isTitrationActive); 'estável'/
+  // 'alvo_atingido' → dosage_per_intake manda.
+  if (protocol.titration_status !== 'titulando') return null
+
+  let index = protocol.current_stage_index || 0
+  if (index >= schedule.length) return null
+
+  const atMs =
+    typeof at === 'number' ? at : at instanceof Date ? at.getTime() : parseISO(String(at)).getTime()
+  let stageStartMs = parseISO(protocol.stage_started_at).getTime()
+  if (Number.isNaN(atMs) || Number.isNaN(stageStartMs)) return null
+  // Ocorrência antes do início da etapa atual: histórico — não re-derivar (já congelado).
+  if (atMs < stageStartMs) return null
+
+  // Avança etapas cuja duração já se esgotou antes do instante alvo.
+  while (index < schedule.length - 1) {
+    // duration_days = canônico (titrationStageSchema); days = fallback legado
+    const days = Number(schedule[index]?.duration_days ?? schedule[index]?.days)
+    if (!Number.isFinite(days) || days <= 0) break
+    const stageEndMs = stageStartMs + days * MS_DAY
+    if (atMs < stageEndMs) break
+    stageStartMs = stageEndMs
+    index += 1
+  }
+
+  const dosage = Number(schedule[index]?.dosage)
+  if (!Number.isFinite(dosage) || dosage <= 0) return null
+  return { stageIndex: index, dosage }
+}
+
 export function calculateTitrationData(protocol) {
   if (!protocol.titration_schedule || protocol.titration_schedule.length === 0) return null
   if (!protocol.stage_started_at) return null
@@ -20,7 +72,7 @@ export function calculateTitrationData(protocol) {
 
   // Clamp day to at least 1
   const currentDay = Math.max(1, daysElapsed)
-  const totalDays = currentStage.days
+  const totalDays = currentStage.duration_days ?? currentStage.days
 
   // Calculate progress percent (capped at 100)
   const progressPercent = Math.min(100, (currentDay / totalDays) * 100)
@@ -35,7 +87,7 @@ export function calculateTitrationData(protocol) {
     totalDays: totalDays,
     progressPercent: progressPercent,
     isTransitionDue: isTransitionDue,
-    stageNote: currentStage.note,
+    stageNote: currentStage.description ?? currentStage.note,
     daysRemaining: totalDays - currentDay,
   }
 }

--- a/plans/specs/012-diabetes-t2-support/tasks.md
+++ b/plans/specs/012-diabetes-t2-support/tasks.md
@@ -23,12 +23,12 @@
 
 ## Phase B — GLP-1 (mg, semanal, titulação) (PR 2) — ADR-061
 
-- [ ] T008 [C1] **Auditar titulação existente**: criar protocolo GLP-1 `semanal` com `titration_schedule`; exercitar wizard/timeline/badge; mapear regressões pós-refactor. Registrar achados.
-- [ ] T009 [US2] Corrigir regressões de titulação encontradas em T008 (`titrationUtils`/`titrationService`/UI).
-- [ ] T010 [US2] `computeTolerances` (`doseInstanceGenerator.js:76`) frequency-aware: não-diário (`semanal`/`dias_alternados`) → `floor(período/2)` **sem `MAX_TOLERANCE`**; diário inalterado (cap 120). Passar `frequency` ao gerador.
-- [ ] T011 [US2] Gerador congela `expected_dose` da etapa de titulação vigente na data (reusa FP-1) — confirmar p/ `semanal`. **Modelo de avanço = AUTO por cronograma** (FR-005b): `stage_started_at + duration_days` esgotado → próxima etapa; evento informativo "Etapa N iniciada conforme o cronograma" (sem CTA de dose — SaMD). T008 audita se o auto-avanço existente funciona.
-- [ ] T011b [US2] UX dose semanal pendente multi-dia (FR-008b): carry-over com rótulo relativo ("há 2 dias"); PriorityCard inclui dentro da tolerância; **sem re-notificação** (`notified_at` idempotente); `missed` só após tolerância (sweep R-246). Web + mobile.
-- [ ] T012 [P] [C4] Testes: tolerância semanal > 120 (perdão 72h coberto); diário 1×/dia mantém 120; `expected_dose` correto por etapa; **auto-avanço de etapa por tempo**; sweep `pending→missed` só após janela; **rótulo relativo multi-dia**.
+- [x] T008 [C1] **Auditar titulação existente**: criar protocolo GLP-1 `semanal` com `titration_schedule`; exercitar wizard/timeline/badge; mapear regressões pós-refactor. Registrar achados.
+- [x] T009 [US2] Corrigir regressões de titulação encontradas em T008 (`titrationUtils`/`titrationService`/UI).
+- [x] T010 [US2] `computeTolerances` (`doseInstanceGenerator.js:76`) frequency-aware: não-diário (`semanal`/`dias_alternados`) → `floor(período/2)` **sem `MAX_TOLERANCE`**; diário inalterado (cap 120). Passar `frequency` ao gerador.
+- [x] T011 [US2] Gerador congela `expected_dose` da etapa de titulação vigente na data (reusa FP-1) — confirmar p/ `semanal`. **Modelo de avanço = AUTO por cronograma** (FR-005b): `stage_started_at + duration_days` esgotado → próxima etapa; evento informativo "Etapa N iniciada conforme o cronograma" (sem CTA de dose — SaMD). T008 audita se o auto-avanço existente funciona.
+- [x] T011b [US2] UX dose semanal pendente multi-dia (FR-008b): carry-over com rótulo relativo ("há 2 dias"); PriorityCard inclui dentro da tolerância; **sem re-notificação** (`notified_at` idempotente); `missed` só após tolerância (sweep R-246). Web + mobile.
+- [x] T012 [P] [C4] Testes: tolerância semanal > 120 (perdão 72h coberto); diário 1×/dia mantém 120; `expected_dose` correto por etapa; **auto-avanço de etapa por tempo**; sweep `pending→missed` só após janela; **rótulo relativo multi-dia**.
 
 ## Phase C — biomarkers_log + fast-logging + timeline híbrida (PR 3) — ADR-060
 

--- a/server/bot/__tests__/titrationAutoAdvance.test.js
+++ b/server/bot/__tests__/titrationAutoAdvance.test.js
@@ -1,0 +1,61 @@
+// 012 Fase B (FR-005b): avanço automático de titulação por cronograma.
+// Testa a função pura de detecção de etapa vencida (_titrationDueAdvance);
+// o update no banco + dispatch são exercitados via mocks no caller.
+import { describe, it, expect } from 'vitest';
+import { _titrationDueAdvance } from '../_reminderHelpers.js';
+
+const MS_DAY = 24 * 60 * 60 * 1000;
+const T0 = Date.parse('2026-06-01T08:00:00.000Z');
+
+const glp1 = {
+  titration_schedule: [
+    { days: 28, dosage: 0.25 },
+    { days: 28, dosage: 0.5 },
+    { days: 28, dosage: 1.0 },
+  ],
+  current_stage_index: 0,
+  stage_started_at: '2026-06-01T08:00:00.000Z',
+  titration_status: 'titulando',
+};
+
+describe('_titrationDueAdvance', () => {
+  it('dentro da etapa atual → null (nada vencido, sem notificação)', () => {
+    expect(_titrationDueAdvance(glp1, T0 + 10 * MS_DAY)).toBeNull();
+  });
+
+  it('etapa 1 esgotada → avança p/ etapa 2; stage_started_at = fim ACUMULADO (não now)', () => {
+    // Cron roda 2 dias atrasado em relação à fronteira (dia 30)
+    const out = _titrationDueAdvance(glp1, T0 + 30 * MS_DAY);
+    expect(out).toEqual({
+      newIndex: 1,
+      newStageStartedAt: new Date(T0 + 28 * MS_DAY).toISOString(),
+      reachedTarget: false,
+    });
+  });
+
+  it('múltiplas etapas vencidas (app fechado semanas) → caminha todas de uma vez', () => {
+    const out = _titrationDueAdvance(glp1, T0 + 60 * MS_DAY);
+    expect(out.newIndex).toBe(2);
+    expect(out.newStageStartedAt).toBe(new Date(T0 + 56 * MS_DAY).toISOString());
+    expect(out.reachedTarget).toBe(false);
+  });
+
+  it('última etapa esgotada → alvo atingido (índice congela na última)', () => {
+    const out = _titrationDueAdvance(glp1, T0 + 90 * MS_DAY);
+    expect(out.newIndex).toBe(2);
+    expect(out.reachedTarget).toBe(true);
+  });
+
+  it('status não-titulando → null (estável/alvo_atingido não avançam)', () => {
+    expect(_titrationDueAdvance({ ...glp1, titration_status: 'estável' }, T0 + 90 * MS_DAY)).toBeNull();
+    expect(_titrationDueAdvance({ ...glp1, titration_status: 'alvo_atingido' }, T0 + 90 * MS_DAY)).toBeNull();
+  });
+
+  it('degenerados → null: sem schedule, sem stage_started_at, days inválido, índice fora', () => {
+    expect(_titrationDueAdvance(null, T0)).toBeNull();
+    expect(_titrationDueAdvance({ ...glp1, titration_schedule: [] }, T0 + 90 * MS_DAY)).toBeNull();
+    expect(_titrationDueAdvance({ ...glp1, stage_started_at: null }, T0 + 90 * MS_DAY)).toBeNull();
+    expect(_titrationDueAdvance({ ...glp1, titration_schedule: [{ days: 0, dosage: 0.25 }] }, T0 + 90 * MS_DAY)).toBeNull();
+    expect(_titrationDueAdvance({ ...glp1, current_stage_index: 9 }, T0 + 90 * MS_DAY)).toBeNull();
+  });
+});

--- a/server/bot/_reminderHelpers.js
+++ b/server/bot/_reminderHelpers.js
@@ -1,7 +1,7 @@
 import { supabase } from '../services/supabase.js';
 import { createLogger } from '../bot/logger.js';
 import { shouldSendNotification, shouldSendGroupedNotification } from '../services/notificationDeduplicator.js';
-import { getCurrentTime, getCurrentTimeInTimezone, parseLocalDate, getTodayLocal, getCurrentDatePartsInTimezone, getServerTimestamp, parseISO, addMinutes } from '../utils/dateUtils.js';
+import { getCurrentTime, getCurrentTimeInTimezone, parseLocalDate, getTodayLocal, getCurrentDatePartsInTimezone, getServerTimestamp, parseISO, parseTimestamp, addMinutes } from '../utils/dateUtils.js';
 import { partitionDoses } from './utils/partitionDoses.js';
 import { isProtocolActiveOnWeekday, getProtocolDays } from '../utils/protocolActiveHelper.js';
 // Formatting helpers removed — moved to Layer 2
@@ -667,19 +667,78 @@ export async function checkStockAlertsViaDispatcher(dispatcher, correlationId) {
   }
 }
 
+// 012 Fase B (FR-005b): detecta etapas de titulação vencidas por cronograma.
+// Caminha o schedule a partir de stage_started_at somando duration (days);
+// retorna null se nada venceu. stage_started_at novo = fim ACUMULADO da etapa
+// anterior (fiel ao cronograma), não now() — atraso do cron não desloca etapas.
+export function _titrationDueAdvance(protocol, nowMs) {
+  const schedule = protocol?.titration_schedule;
+  if (!Array.isArray(schedule) || schedule.length === 0) return null;
+  if (protocol.titration_status !== 'titulando') return null;
+  if (!protocol.stage_started_at) return null;
+
+  let index = protocol.current_stage_index || 0;
+  if (index >= schedule.length) return null;
+  let startMs = parseISO(protocol.stage_started_at).getTime();
+  if (Number.isNaN(startMs)) return null;
+
+  const MS_DAY = 24 * 60 * 60 * 1000;
+  let advanced = false;
+  let reachedTarget = false;
+  while (index < schedule.length) {
+    // duration_days = canônico (titrationStageSchema); days = fallback legado
+    const days = Number(schedule[index]?.duration_days ?? schedule[index]?.days);
+    if (!Number.isFinite(days) || days <= 0) break;
+    const endMs = startMs + days * MS_DAY;
+    if (nowMs < endMs) break;
+    if (index === schedule.length - 1) {
+      // Última etapa esgotada → dose alvo atingida (índice congela na última).
+      reachedTarget = true;
+      break;
+    }
+    startMs = endMs;
+    index += 1;
+    advanced = true;
+  }
+  if (!advanced && !reachedTarget) return null;
+  return { newIndex: index, newStageStartedAt: parseTimestamp(startMs).toISOString(), reachedTarget };
+}
+
+// 012 Fase B (FR-005b): avanço AUTOMÁTICO por cronograma + notificação SÓ no
+// evento (antes o cron disparava titration_alert todo dia para todo protocolo
+// em titulação — spam sem informação nova; regressão corrigida em T009).
+// Evento informativo, sem CTA de dose (SaMD/ADR-062).
 async function _processProtocolTitration(userId, protocol, dispatcher, correlationId) {
+  const due = _titrationDueAdvance(protocol, Date.now());
+  if (!due) return;
+
+  const updatePayload = {
+    current_stage_index: due.newIndex,
+    stage_started_at: due.newStageStartedAt,
+  };
+  if (due.reachedTarget) updatePayload.titration_status = 'alvo_atingido';
+
+  const { error: updateErr } = await supabase
+    .from('protocols')
+    .update(updatePayload)
+    .eq('id', protocol.id);
+  if (updateErr) throw updateErr; // best-effort por protocolo no caller (R-245)
+
   const medicine = protocol.medicine || {};
-  const currentStage = (protocol.current_stage_index || 0) + 1;
-  const totalStages = protocol.titration_schedule?.length || 0;
-  const nextStageData = protocol.titration_schedule?.[protocol.current_stage_index + 1];
+  const schedule = protocol.titration_schedule;
+  const nextStageData = schedule?.[due.newIndex + 1];
+
+  logger.info(`Titulação avançada por cronograma: etapa ${due.newIndex + 1}/${schedule.length}${due.reachedTarget ? ' (alvo atingido)' : ''}`, {
+    userId, protocolId: protocol.id, correlationId
+  });
 
   const data = {
     medicineName: medicine.name || 'Medicamento',
-    currentStage,
-    totalStages,
-    status: protocol.titration_status === 'alvo_atingido' ? 'alvo_atingido' : 'titulando',
-    nextStage: nextStageData ? {
-      dosage: nextStageData.dosage,
+    currentStage: due.newIndex + 1,
+    totalStages: schedule.length,
+    status: due.reachedTarget ? 'alvo_atingido' : 'titulando',
+    nextStage: !due.reachedTarget && nextStageData ? {
+      dosage: String(nextStageData.dosage),
       unit: medicine.dosage_unit || 'mg',
       date: nextStageData.date
     } : undefined
@@ -704,20 +763,30 @@ export async function checkTitrationAlertsViaDispatcher(dispatcher, correlationI
     for (const user of users) {
       const userId = user.user_id;
       
+      // 012 Fase B: stage_started_at no select (R-267 — sem ele o cron não sabia
+      // se a transição venceu e notificava diariamente); só 'titulando' interessa.
       const { data: protocols } = await supabase
         .from('protocols')
         .select(`
-          id, current_stage_index, titration_schedule, titration_status,
+          id, current_stage_index, titration_schedule, titration_status, stage_started_at,
           medicine:medicine_id (name, dosage_unit)
         `)
         .eq('user_id', userId)
         .eq('status', 'ativo')
+        .eq('titration_status', 'titulando')
         .not('titration_schedule', 'is', null);
 
       if (!protocols || protocols.length === 0) continue;
 
       for (const protocol of protocols) {
-        await _processProtocolTitration(userId, protocol, dispatcher, correlationId);
+        try {
+          await _processProtocolTitration(userId, protocol, dispatcher, correlationId);
+        } catch (err) {
+          // Best-effort por protocolo (R-245): erro num avanço não derruba a varredura.
+          logger.error('Erro ao processar avanço de titulação', err, {
+            userId, protocolId: protocol?.id, correlationId
+          });
+        }
       }
     }
   } catch (err) {

--- a/server/bot/_reminderHelpers.js
+++ b/server/bot/_reminderHelpers.js
@@ -718,11 +718,18 @@ async function _processProtocolTitration(userId, protocol, dispatcher, correlati
   };
   if (due.reachedTarget) updatePayload.titration_status = 'alvo_atingido';
 
-  const { error: updateErr } = await supabase
+  // Trava otimista (AP-221): confirma que a linha ainda está na etapa esperada
+  // antes de avançar. Se o usuário mexeu na titulação manualmente entre o SELECT
+  // do cron e este UPDATE, PostgREST faz no-op (0 linhas, sem erro) → não dispara
+  // notificação de avanço sobre estado obsoleto.
+  const { data: updatedRows, error: updateErr } = await supabase
     .from('protocols')
     .update(updatePayload)
-    .eq('id', protocol.id);
+    .eq('id', protocol.id)
+    .eq('current_stage_index', protocol.current_stage_index ?? 0)
+    .select('id');
   if (updateErr) throw updateErr; // best-effort por protocolo no caller (R-245)
+  if (!updatedRows || updatedRows.length === 0) return; // etapa mudou sob o cron → aborta
 
   const medicine = protocol.medicine || {};
   const schedule = protocol.titration_schedule;

--- a/server/notifications/payloads/_payloadBuilders.js
+++ b/server/notifications/payloads/_payloadBuilders.js
@@ -191,11 +191,13 @@ export function buildTitrationAlertPayload(data) {
 
   let richMsg = `🎯 *Atualização de Titulação*\n\n`;
   richMsg += `Medicamento: **${escapeMarkdownV2(medicineName)}**\n`;
-  richMsg += `Etapa atual: ${currentStage}/${totalStages}\n\n`;
+  // 012 Fase B (FR-005b): disparado SÓ no evento de avanço — copy informativa,
+  // sem CTA de dose (SaMD/ADR-062).
+  richMsg += `Etapa ${currentStage}/${totalStages} iniciada conforme o cronograma\\.\n\n`;
 
   let plainMsg = `🎯 Atualização de Titulação\n`;
   plainMsg += `Medicamento: ${medicineName}\n`;
-  plainMsg += `Etapa atual: ${currentStage}/${totalStages}\n\n`;
+  plainMsg += `Etapa ${currentStage}/${totalStages} iniciada conforme o cronograma.\n\n`;
 
   if (status === 'alvo_atingido') {
     const success = `✅ *Parabéns\\!* Você atingiu a dose alvo\\!\nContinue com o acompanhamento médico\\.`;

--- a/server/utils/dateUtils.js
+++ b/server/utils/dateUtils.js
@@ -86,6 +86,17 @@ export function getServerTimestamp() {
 }
 
 /**
+ * Converte epoch ms em Date (espelho do parseTimestamp do core).
+ * Único lugar autorizado a construir Date a partir de número — consumidores
+ * ficam livres da regra R-020 (que barra new Date fora daqui).
+ * @param {number} ms
+ * @returns {Date}
+ */
+export function parseTimestamp(ms) {
+  return new Date(ms);
+}
+
+/**
  * Adiciona dias a uma data.
  * @param {Date|string} date 
  * @param {number} days 


### PR DESCRIPTION
## 🎯 Resumo

Fase B do épico 012 (Diabetes T2): suporte real a GLP-1 semanal — tolerância clínica sem cap de 2h, titulação consertada de ponta a ponta (estava **morta na gravação** por drift de shape) com avanço automático por cronograma, e carry-over multi-dia para dose semanal atrasada continuar registrável.

---

## 📋 Tarefas Implementadas

### ✅ Core
- [x] T010 — `computeTolerances` frequency-aware (ADR-061): semanal única = **5040min (3,5d)** sem cap; `dias_alternados` = 1440; diário intacto (cap 120)
- [x] T011 — `resolveTitrationStageAt`: `expected_dose` congela a etapa vigente **na data da ocorrência** (FP-1)
- [x] `daysAgoLabel` — rótulo relativo por data-calendário

### ✅ Titulação (T008/T009 — auditoria + regressões)
- [x] **Shape canônico** `duration_days/description`: wizard legado gravava `days/note` → nunca passava no Zod (gravação quebrada desde sempre); `prepareDataToSave` migra legado
- [x] **Auto-avanço por cronograma** (FR-005b — não existia): cron avança etapas vencidas (`stage_started_at` = fim acumulado), última → `alvo_atingido`; `titration_alert` só no evento (antes: spam diário)
- [x] Wizard: vírgula PT-BR (R-270), hint "✨ Equivale a X mg" (R-272), layout empilhado (fix `.form-row` global vazado), "Gravar Etapa"

### ✅ Carry-over multi-dia (FR-008b)
- [x] Janela web 4d atrás; seção "Doses pendentes" + rótulo "há 2 dias · 10:00" (web+mobile); sem re-notificação (`notified_at`)

### ✅ Smoke PO (JIT)
- [x] Dashboard: falha do 1-click (estoque insuficiente) vira banner — antes o clique parecia ignorado
- [x] TreatmentWizard passo 1: Apresentação + validade pós-abertura (injetável nascia "comprimido" e TTL não ativava)

---

## ✅ Checklist de Verificação
- [x] `validate:agent` — **1235 pass**
- [x] `npm run lint` — 0 erros
- [x] 60+ testes novos (tolerância, resolver, auto-avanço, carry-over, wizard)
- [x] Smoke PO web concluído (2026-06-12)

## 📝 Notas para Reviewers
1. **Push único squashed** (workflow novo pós-#658): histórico granular ficou local.
2. `_titrationDueAdvance` usa `parseTimestamp` novo no dateUtils do server — único lugar autorizado a construir Date de epoch (R-020).
3. Fallback de leitura `days/note` é intencional (linhas legadas); gravação só emite canônico.
4. 11 testes pré-existentes quebrados da 022 (copy "1 comp.") **não** são deste PR — chore separado.
5. Mobile **0.16.1** (patch): convenção 0.x nova — minor=épico, patch=fase (`docs/standards/CHANGELOG_AND_RELEASES.md`).

## 🏷️ Versionamento
**Tipo:** Minor (web) / Patch (mobile, convenção 0.x)
**Plataformas:** Web/PWA + Mobile + Core + Backend/cron
**Versões:** web 4.3.0→4.4.0 · mobile 0.16.0→0.16.1
**Changelog:** [Unreleased] atualizado por plataforma

🤖 Generated with [Claude Code](https://claude.com/claude-code)

/cc @gemini-code-assist