### PR TITLE
feat(012-fase-b3): concentração com denominador + densidade unit-aware + reorder form

### DIFF
--- a/.agent/memory/decisions/data_and_schema/ADR-065.md
+++ b/.agent/memory/decisions/data_and_schema/ADR-065.md
@@ -1,6 +1,6 @@
 # ADR-065 — `units_per_ml` default NULL + fallback unit-aware (substitui o blanket 20)
 
-**Status:** proposed
+**Status:** accepted
 **Data:** 2026-06-12
 **Contexto:** 012 Fase B3 (débito FR-013b exposto no smoke da B2)
 **Relaciona:** ADR-058 (define `units_per_ml`), AP-225, R-104, R-270, R-271

--- a/.agent/memory/decisions/data_and_schema/ADR-066.md
+++ b/.agent/memory/decisions/data_and_schema/ADR-066.md
@@ -1,6 +1,6 @@
 # ADR-066 — Concentração com denominador via coluna `concentration_volume_ml` (seed do modelo amount/volume)
 
-**Status:** proposed
+**Status:** accepted
 **Data:** 2026-06-12
 **Contexto:** 012 Fase B3 / FR-031 (anti-armadilha Mounjaro)
 **Relaciona:** ADR-058, ADR-065

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 - **Added** (`minor`, FR-024): helper `densityFor(intakeUnit, unitsPerMl)` — densidade unit-aware (explícita > gotas 20 > UI 100 > null). `doseToMl` e `formatIntakeDose` passam a usá-lo (fim do fallback 20 cego).
 - **Changed** (`minor`, FR-031): `formatConcentrationLabel(mgPerMl, volumeMl=1)` reconstrói "amount mg em volume mL" (Mounjaro razão 5 + volume 0,5 → "2,5 mg em 0,5 mL"); compatível com a Fase B2 (volume 1). Schema `medicineSchema` + `concentration_volume_ml` (nullable, R-082).
 
-#### Web (4.5.0) / Mobile (0.4.0)
+#### Web (4.5.0) / Mobile (0.4.0) / App (0.16.3)
 - **Added** (`patch`, FR-031): form de medicamento ganha campo "Volume da concentração (mL no rótulo)" para líquidos (default 1 mL; muda só p/ Mounjaro etc.). Normaliza `dosage_per_pill = amount ÷ denominador` ao salvar e reexibe o `amount` do rótulo na edição. Validação impede denominador ≤ 0. Inputs decimais PT-BR (R-276).
 
 ### 012 Fase B2 — correções do smoke (2026-06-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ## [Unreleased]
 
+### 012 Fase B3 — units_per_ml NULL + fallback unit-aware + concentração com denominador
+
+#### Backend/Infra (DB + RPC)
+- **Changed** (`minor`, ADR-065): migração `20260613_b3_units_per_ml_null_denominador.sql` (prod) — `medicines.units_per_ml` perde o DEFAULT `20` (blanket) e nasce `NULL`; backfill derivado da unidade de tomada do tratamento (UI→100, gotas→20, demais→NULL). `consume_stock_fifo` converte gotas/UI com densidade **unit-aware** (gotas≈20, UI≈100) em vez do `COALESCE(...,20)` cego — corrige conversão de insulina (UI) 5× errada quando a densidade falta. Assinatura intacta.
+- **Added** (`minor`, ADR-066/FR-031): coluna `medicines.concentration_volume_ml` (NUMERIC, nullable; NULL = "por 1 mL") — volume do rótulo da concentração; seed do modelo (amount, volume) futuro.
+
+#### Core (@dosiq/core)
+- **Added** (`minor`, FR-024): helper `densityFor(intakeUnit, unitsPerMl)` — densidade unit-aware (explícita > gotas 20 > UI 100 > null). `doseToMl` e `formatIntakeDose` passam a usá-lo (fim do fallback 20 cego).
+- **Changed** (`minor`, FR-031): `formatConcentrationLabel(mgPerMl, volumeMl=1)` reconstrói "amount mg em volume mL" (Mounjaro razão 5 + volume 0,5 → "2,5 mg em 0,5 mL"); compatível com a Fase B2 (volume 1). Schema `medicineSchema` + `concentration_volume_ml` (nullable, R-082).
+
+#### Web (4.5.0) / Mobile (0.4.0)
+- **Added** (`patch`, FR-031): form de medicamento ganha campo "Volume da concentração (mL no rótulo)" para líquidos (default 1 mL; muda só p/ Mounjaro etc.). Normaliza `dosage_per_pill = amount ÷ denominador` ao salvar e reexibe o `amount` do rótulo na edição. Validação impede denominador ≤ 0. Inputs decimais PT-BR (R-276).
+
 ### 012 Fase B2 — correções do smoke (2026-06-12)
 
 #### Core (@dosiq/core)

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -5,7 +5,7 @@
 
 const BUILD_PROFILE = process.env.EAS_BUILD_PROFILE || 'production'
 
-const APP_VERSION = '0.16.2' // R-182: versão semântica (sem prefixo 'v')
+const APP_VERSION = '0.16.3' // R-182: versão semântica (sem prefixo 'v')
 const [major, minor, patch] = APP_VERSION.split('.').map(Number)
 // buildNumber/versionCode derivado da versão semântica: major*10000 + minor*100 + patch
 // 0.2.4 → 204 | 0.3.0 → 300 | 1.0.0 → 10000

--- a/apps/mobile/src/features/dashboard/services/dashboardService.js
+++ b/apps/mobile/src/features/dashboard/services/dashboardService.js
@@ -81,7 +81,7 @@ export async function getMedicinesData(medicineIds) {
 
   const { data, error } = await supabase
     .from('medicines')
-    .select('id, name, dosage_per_pill, dosage_unit, units_per_ml')
+    .select('id, name, dosage_per_pill, dosage_unit, concentration_volume_ml, units_per_ml')
     .in('id', medicineIds)
 
   if (error) throw error

--- a/apps/mobile/src/features/dose/components/BulkDoseRegisterModal.jsx
+++ b/apps/mobile/src/features/dose/components/BulkDoseRegisterModal.jsx
@@ -144,7 +144,7 @@ function BulkDoseProtocolList({ items, selected, loading, onToggle, isComplex })
             {item.protocol.medicine?.dosage_per_pill && (
               <View style={styles.dosageBadge}>
                 <Text style={styles.dosageBadgeText}>
-                  {formatConcentration(item.protocol.medicine.dosage_per_pill, item.protocol.medicine.dosage_unit)}
+                  {formatConcentration(item.protocol.medicine.dosage_per_pill, item.protocol.medicine.dosage_unit, item.protocol.medicine.concentration_volume_ml)}
                 </Text>
               </View>
             )}

--- a/apps/mobile/src/features/medications/components/MedicineCard.jsx
+++ b/apps/mobile/src/features/medications/components/MedicineCard.jsx
@@ -14,6 +14,7 @@ export default function MedicineCard({ medicine, onPress }) {
     type,
     dosage_per_pill,
     dosage_unit,
+    concentration_volume_ml,
     active_ingredient,
     protocols_count = 0,
   } = medicine ?? {}
@@ -50,7 +51,7 @@ export default function MedicineCard({ medicine, onPress }) {
         {hasDose && (
           <View style={styles.dosagePill}>
             <Text style={styles.dosagePillText}>
-              {formatConcentration(dosage_per_pill, dosage_unit)}
+              {formatConcentration(dosage_per_pill, dosage_unit, concentration_volume_ml)}
             </Text>
           </View>
         )}

--- a/apps/mobile/src/features/medications/screens/MedicineDetailScreen.jsx
+++ b/apps/mobile/src/features/medications/screens/MedicineDetailScreen.jsx
@@ -78,8 +78,7 @@ export default function MedicineDetailScreen() {
 
   const doseLabel = useMemo(() => {
     if (!data?.dosage_per_pill) return null
-    const unit = data.dosage_unit ?? ''
-    return `${data.dosage_per_pill}${unit ? ` ${unit}` : ''}`
+    return formatConcentration(data.dosage_per_pill, data.dosage_unit, data.concentration_volume_ml)
   }, [data])
 
   const protocols = useMemo(() => {
@@ -304,7 +303,7 @@ export default function MedicineDetailScreen() {
               label="Concentração"
               value={
                 data.dosage_per_pill
-                  ? formatConcentration(data.dosage_per_pill, data.dosage_unit)
+                  ? formatConcentration(data.dosage_per_pill, data.dosage_unit, data.concentration_volume_ml)
                   : null
               }
               isLast

--- a/apps/mobile/src/features/medications/screens/MedicineFormScreen.jsx
+++ b/apps/mobile/src/features/medications/screens/MedicineFormScreen.jsx
@@ -77,11 +77,20 @@ export default function MedicineFormScreen() {
   // ao carregar para edição. Outros campos number-like seguem mesma regra.
   const initialValues = useMemo(() => {
     if (!medicine) return DEFAULT_INITIAL
+    // FR-031 (ADR-066): o campo exibe o `amount` do rótulo = razão × volume; transforma só
+    // quando há denominador salvo (≠ null). Senão exibe a razão crua (volume 1).
+    const denom = Number(medicine.concentration_volume_ml)
+    const ratio = Number(medicine.dosage_per_pill)
+    const amountStr =
+      medicine.dosage_per_pill !== null && medicine.dosage_per_pill !== undefined
+        ? String(denom > 0 ? ratio * denom : medicine.dosage_per_pill)
+        : ''
     return {
       ...medicine,
-      dosage_per_pill:
-        medicine.dosage_per_pill !== null && medicine.dosage_per_pill !== undefined
-          ? String(medicine.dosage_per_pill)
+      dosage_per_pill: amountStr,
+      concentration_volume_ml:
+        medicine.concentration_volume_ml !== null && medicine.concentration_volume_ml !== undefined
+          ? String(medicine.concentration_volume_ml)
           : '',
       shelf_life_days:
         medicine.shelf_life_days !== null && medicine.shelf_life_days !== undefined
@@ -122,13 +131,14 @@ export default function MedicineFormScreen() {
   // Normaliza vírgula→ponto em tempo real (PT-BR digita 1,5; JS/Postgres esperam 1.5).
   // Aceita apenas dígitos + um separador decimal único.
   const handleDoseChange = useCallback(
-    (_name, value) => {
+    (name, value) => {
       const cleaned = String(value ?? '')
         .replace(',', '.')
         .replace(/[^\d.]/g, '')
         // colapsa múltiplos pontos no primeiro
         .replace(/^(\d*\.\d*).*$/, '$1')
-      form.handleChange('dosage_per_pill', cleaned)
+      // FormInput passa o name; fallback dosage_per_pill p/ chamadas legadas.
+      form.handleChange(name || 'dosage_per_pill', cleaned)
     },
     [form]
   )
@@ -187,10 +197,21 @@ export default function MedicineFormScreen() {
       )
       return
     }
+    // FR-031 (ADR-066): normaliza amount→razão. Líquido c/ denominador ≠ 1 → dosage_per_pill =
+    // amount ÷ denominador + grava concentration_volume_ml; senão passthrough (coluna null).
+    const isLiquid = isLiquidUnit(form.values.dosage_unit)
+    const rawDenom = isLiquid ? Number(String(form.values.concentration_volume_ml ?? '').replace(',', '.')) : NaN
+    const denom = rawDenom > 0 ? rawDenom : 1
+    const amount = Number(String(form.values.dosage_per_pill ?? '').replace(',', '.'))
+    const payload = {
+      ...form.values,
+      dosage_per_pill: Number.isFinite(amount) ? amount / denom : form.values.dosage_per_pill,
+      concentration_volume_ml: denom !== 1 ? denom : null,
+    }
     if (isEditing) {
-      await update(medicine.id, form.values, { goBack: true })
+      await update(medicine.id, payload, { goBack: true })
     } else {
-      await create(form.values, { goBack: true })
+      await create(payload, { goBack: true })
     }
   }, [form, isEditing, medicine, create, update])
 
@@ -255,6 +276,18 @@ export default function MedicineFormScreen() {
               />
             </View>
           </View>
+          {/* FR-031 (ADR-066): denominador do rótulo. Default 1 mL; muda só p/ Mounjaro etc. */}
+          {isLiquidUnit(form.values.dosage_unit) && (
+            <FormInput
+              name="concentration_volume_ml"
+              label="Volume da concentração (mL no rótulo)"
+              keyboardType="decimal-pad"
+              placeholder="1"
+              helperText='Padrão é 1 mL (ou só mL). Mude se o rótulo trouxer outro volume, ex.: "Mounjaro 2,5 mg / 0,5 mL" — preencha 0,5.'
+              {...formProps(form, 'concentration_volume_ml')}
+              onChange={handleDoseChange}
+            />
+          )}
           {form.values.dosage_unit === 'un' && Number(form.values.dosage_per_pill) > 1 && (
             <View style={styles.warningBox}>
               <Text style={styles.warningText}>

--- a/apps/mobile/src/features/medications/screens/MedicineFormScreen.jsx
+++ b/apps/mobile/src/features/medications/screens/MedicineFormScreen.jsx
@@ -18,6 +18,7 @@ import {
   PRESENTATION_LABELS,
   REGULATORY_CATEGORIES,
   REGULATORY_CATEGORY_LABELS,
+  cleanFloat,
 } from '@dosiq/core'
 import { useFormState } from '@shared/hooks/useFormState'
 import FormInput from '@shared/components/form/FormInput'
@@ -83,7 +84,7 @@ export default function MedicineFormScreen() {
     const ratio = Number(medicine.dosage_per_pill)
     const amountStr =
       medicine.dosage_per_pill !== null && medicine.dosage_per_pill !== undefined
-        ? String(denom > 0 ? ratio * denom : medicine.dosage_per_pill)
+        ? String(denom > 0 ? cleanFloat(ratio * denom) : medicine.dosage_per_pill)
         : ''
     return {
       ...medicine,
@@ -202,10 +203,14 @@ export default function MedicineFormScreen() {
     const isLiquid = isLiquidUnit(form.values.dosage_unit)
     const rawDenom = isLiquid ? Number(String(form.values.concentration_volume_ml ?? '').replace(',', '.')) : NaN
     const denom = rawDenom > 0 ? rawDenom : 1
-    const amount = Number(String(form.values.dosage_per_pill ?? '').replace(',', '.'))
+    // Gemini #661: dosage_per_pill vazio (permitido p/ suplemento) → Number('')=0 salvaria 0
+    // em vez de null, corrompendo o dado. Só converte quando há valor preenchido.
+    const rawAmount = form.values.dosage_per_pill
+    const hasAmount = rawAmount !== '' && rawAmount !== null && rawAmount !== undefined
+    const amount = hasAmount ? Number(String(rawAmount).replace(',', '.')) : NaN
     const payload = {
       ...form.values,
-      dosage_per_pill: Number.isFinite(amount) ? amount / denom : form.values.dosage_per_pill,
+      dosage_per_pill: hasAmount && Number.isFinite(amount) ? cleanFloat(amount / denom) : null,
       concentration_volume_ml: denom !== 1 ? denom : null,
     }
     if (isEditing) {

--- a/apps/mobile/src/features/stock/components/PurchaseMedicineSheet.jsx
+++ b/apps/mobile/src/features/stock/components/PurchaseMedicineSheet.jsx
@@ -44,7 +44,7 @@ function normalize(s) {
 // dentro do limite max-lines-per-function.
 function MedicineRow({ item, onPress }) {
   const dosageLabel = item.dosage_per_pill
-    ? formatConcentration(item.dosage_per_pill, item.dosage_unit)
+    ? formatConcentration(item.dosage_per_pill, item.dosage_unit, item.concentration_volume_ml)
     : null
 
   return (

--- a/apps/mobile/src/features/stock/components/StockItem.jsx
+++ b/apps/mobile/src/features/stock/components/StockItem.jsx
@@ -17,6 +17,7 @@ export default function StockItem({ medicine }) {
     hasPurchases,
     dosage_unit,
     dosage_per_pill,
+    concentration_volume_ml,
     status,
     daysRemaining,
     hasActiveProtocol,
@@ -38,7 +39,7 @@ export default function StockItem({ medicine }) {
           {dosage_per_pill && (
             <View style={styles.dosagePill}>
               <Text style={styles.dosagePillText}>
-                {formatConcentration(dosage_per_pill, dosage_unit)}
+                {formatConcentration(dosage_per_pill, dosage_unit, concentration_volume_ml)}
               </Text>
             </View>
           )}

--- a/apps/mobile/src/features/stock/screens/PurchaseHistoryScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/PurchaseHistoryScreen.jsx
@@ -194,7 +194,7 @@ export default function PurchaseHistoryScreen({ route, navigation }) {
                   {medicine?.dosage_per_pill ? (
                     <View style={styles.dosePill}>
                       <Text style={styles.dosePillText}>
-                        {formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit)}
+                        {formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit, medicine.concentration_volume_ml)}
                       </Text>
                     </View>
                   ) : null}

--- a/apps/mobile/src/features/stock/screens/StockAdjustmentScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockAdjustmentScreen.jsx
@@ -166,7 +166,7 @@ export default function StockAdjustmentScreen() {
   // Dose pill da ficha (sempre que houver medicine com dosagem).
   const dosePill =
     medicine?.dosage_per_pill != null
-      ? formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit)
+      ? formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit, medicine.concentration_volume_ml)
       : null
 
   // Preview "APÓS AJUSTE" — cor do delta: verde se positivo, vermelho se negativo.

--- a/apps/mobile/src/features/stock/screens/StockDetailScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockDetailScreen.jsx
@@ -226,7 +226,7 @@ export default function StockDetailScreen({ navigation }) {
   const name = medicine?.name ?? medicineName ?? 'Medicamento'
   const dosePill =
     medicine?.dosage_per_pill != null
-      ? formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit)
+      ? formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit, medicine.concentration_volume_ml)
       : null
   const heroColor = isSupplement ? colors.supplement[500] : colors.primary[500]
   const heroBg = isSupplement ? colors.supplement[50] : colors.primary[50]

--- a/apps/mobile/src/features/stock/services/stockService.js
+++ b/apps/mobile/src/features/stock/services/stockService.js
@@ -55,6 +55,7 @@ export async function getStockData(userId) {
         laboratory,
         dosage_unit,
         dosage_per_pill,
+        concentration_volume_ml,
         shelf_life_days,
         medicine_stock_summary!left (
           total_quantity

--- a/apps/mobile/src/features/treatments/components/MedicineSelectorRow.jsx
+++ b/apps/mobile/src/features/treatments/components/MedicineSelectorRow.jsx
@@ -28,7 +28,7 @@ export default function MedicineSelectorRow({ medicine, onPress, error }) {
 
   const dosageLabel =
     !isEmpty && medicine.dosage_per_pill
-      ? formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit)
+      ? formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit, medicine.concentration_volume_ml)
       : null
 
   const accessibilityLabel = isEmpty

--- a/apps/mobile/src/features/treatments/components/MedicineSelectorSheet.jsx
+++ b/apps/mobile/src/features/treatments/components/MedicineSelectorSheet.jsx
@@ -128,7 +128,7 @@ export default function MedicineSelectorSheet({
             {item.dosage_per_pill ? (
               <View style={styles.dosagePill}>
                 <Text style={styles.dosagePillText}>
-                  {formatConcentration(item.dosage_per_pill, item.dosage_unit)}
+                  {formatConcentration(item.dosage_per_pill, item.dosage_unit, item.concentration_volume_ml)}
                 </Text>
               </View>
             ) : null}

--- a/apps/mobile/src/features/treatments/components/TreatmentCard.jsx
+++ b/apps/mobile/src/features/treatments/components/TreatmentCard.jsx
@@ -113,7 +113,7 @@ export default function TreatmentCard({ treatment, onPress, tabStatus = 'ativo',
           {medicine?.dosage_per_pill && (
             <View style={[styles.dosagePill, (isPaused || isFinished) && styles.textMutedOpacity]}>
               <Text style={styles.dosagePillText}>
-                {formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit)}
+                {formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit, medicine.concentration_volume_ml)}
               </Text>
             </View>
           )}

--- a/apps/mobile/src/features/treatments/screens/ProtocolDetailScreen.jsx
+++ b/apps/mobile/src/features/treatments/screens/ProtocolDetailScreen.jsx
@@ -394,7 +394,7 @@ function ProtocolHero({ protocol, goToMedicine, inUseDays }) {
           {medicine.dosage_per_pill ? (
             <View style={styles.dosagePill}>
               <Text style={styles.dosagePillText}>
-                {formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit)}
+                {formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit, medicine.concentration_volume_ml)}
               </Text>
             </View>
           ) : null}

--- a/apps/mobile/src/features/treatments/services/treatmentsService.js
+++ b/apps/mobile/src/features/treatments/services/treatmentsService.js
@@ -46,6 +46,7 @@ export async function getAllTreatments(userId) {
           type,
           dosage_per_pill,
           dosage_unit,
+          concentration_volume_ml,
           units_per_ml,
           therapeutic_class
         )

--- a/apps/web/src/features/dashboard/components/CronogramaDoseItem.jsx
+++ b/apps/web/src/features/dashboard/components/CronogramaDoseItem.jsx
@@ -65,7 +65,7 @@ export default function CronogramaDoseItem({ dose, onRegister, stockDays, stockS
             <span className="cronograma-dose-card__title">{dose.medicineName}</span>
             {dose.dosagePerPill && dose.dosageUnit && (
               <span className="cronograma-dose-card__strength">
-                {formatConcentration(dose.dosagePerPill, dose.dosageUnit)}
+                {formatConcentration(dose.dosagePerPill, dose.dosageUnit, dose.concentrationVolumeMl)}
               </span>
             )}
           </div>

--- a/apps/web/src/features/medications/components/MedicineCard.jsx
+++ b/apps/web/src/features/medications/components/MedicineCard.jsx
@@ -1,5 +1,6 @@
 // MedicineCard.jsx
 import React from 'react'
+import { formatMedicineConcentration } from '@dosiq/core'
 import Card from '@shared/components/ui/Card'
 import Button from '@shared/components/ui/Button'
 import './MedicineCard.css' // Make sure this path is correct
@@ -34,7 +35,7 @@ function MedicineCard({ medicine, onEdit, onDelete, hasDependencies }) {
           <div className="detail-item">
             <span className="detail-label">💊 Dosagem:</span>
             <span className="detail-value">
-              {medicine.dosage_per_pill} {medicine.dosage_unit || 'mg'}
+              {formatMedicineConcentration(medicine)}
             </span>
           </div>
         )}

--- a/apps/web/src/features/medications/components/MedicineForm.css
+++ b/apps/web/src/features/medications/components/MedicineForm.css
@@ -4,6 +4,17 @@
   gap: var(--space-5);
 }
 
+/* Subtítulo de seção (012 Fase B3): dá ritmo/agrupamento ao form, espelhando
+   as FormSection do mobile (Identificação · Dosagem · Classificação). */
+.medicine-form__section-title {
+  margin: var(--space-3) 0 0 0;
+  font-size: var(--font-size-sm, 0.875rem);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-secondary, #64748b);
+}
+
 .medicine-form h3 {
   margin: 0 0 var(--space-4) 0;
   color: var(--text-primary);

--- a/apps/web/src/features/medications/components/__tests__/_medicineFormUtils.denominador.test.js
+++ b/apps/web/src/features/medications/components/__tests__/_medicineFormUtils.denominador.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildMedicinePayload,
+  getInitialFormData,
+  validateMedicineForm,
+} from '../_medicineFormUtils.js'
+
+// 012 Fase B3 (FR-031/ADR-066): concentração com denominador.
+const baseLiquid = {
+  name: 'Mounjaro', laboratory: '', active_ingredient: '',
+  dosage_unit: 'mg/ml', units_per_ml: '', presentation: 'injetavel', type: 'medicamento',
+}
+
+describe('buildMedicinePayload — denominador', () => {
+  it('Mounjaro 2,5 mg / 0,5 mL → razão 5 + volume 0,5', () => {
+    const p = buildMedicinePayload({ ...baseLiquid, dosage_per_pill: '2,5', concentration_volume_ml: '0,5' })
+    expect(p.dosage_per_pill).toBe(5)
+    expect(p.concentration_volume_ml).toBe(0.5)
+  })
+  it('denominador default (vazio) → passthrough + coluna null', () => {
+    const p = buildMedicinePayload({ ...baseLiquid, dosage_per_pill: '5', concentration_volume_ml: '' })
+    expect(p.dosage_per_pill).toBe(5)
+    expect(p.concentration_volume_ml).toBeNull()
+  })
+  it('denominador 1 explícito → coluna null (não polui)', () => {
+    const p = buildMedicinePayload({ ...baseLiquid, dosage_per_pill: '5', concentration_volume_ml: '1' })
+    expect(p.dosage_per_pill).toBe(5)
+    expect(p.concentration_volume_ml).toBeNull()
+  })
+  it('sólido ignora denominador (sempre null)', () => {
+    const p = buildMedicinePayload({
+      name: 'Dipirona', laboratory: '', active_ingredient: '',
+      dosage_per_pill: '500', dosage_unit: 'mg', concentration_volume_ml: '0,5',
+      presentation: 'comprimido', type: 'medicamento', units_per_ml: '',
+    })
+    expect(p.dosage_per_pill).toBe(500)
+    expect(p.concentration_volume_ml).toBeNull()
+  })
+})
+
+describe('getInitialFormData — reexibe amount do rótulo', () => {
+  it('razão 5 + volume 0,5 → campo mostra amount 2,5', () => {
+    const f = getInitialFormData({ dosage_per_pill: 5, concentration_volume_ml: 0.5, dosage_unit: 'mg/ml' })
+    expect(Number(f.dosage_per_pill)).toBe(2.5)
+    expect(String(f.concentration_volume_ml)).toBe('0.5')
+  })
+  it('sem volume → exibe a razão crua', () => {
+    const f = getInitialFormData({ dosage_per_pill: 40, dosage_unit: 'mg/ml' })
+    expect(Number(f.dosage_per_pill)).toBe(40)
+    expect(f.concentration_volume_ml).toBe('')
+  })
+})
+
+describe('validateMedicineForm — denominador > 0', () => {
+  it('denominador 0 → erro (não divide por zero)', () => {
+    const e = validateMedicineForm({ ...baseLiquid, dosage_per_pill: '2,5', concentration_volume_ml: '0' })
+    expect(e.concentration_volume_ml).toBeTruthy()
+  })
+  it('denominador vazio → sem erro (default 1)', () => {
+    const e = validateMedicineForm({ ...baseLiquid, dosage_per_pill: '5', concentration_volume_ml: '' })
+    expect(e.concentration_volume_ml).toBeUndefined()
+  })
+})

--- a/apps/web/src/features/medications/components/_medicineFormUtils.js
+++ b/apps/web/src/features/medications/components/_medicineFormUtils.js
@@ -1,5 +1,5 @@
 import { toTitleCase, toSentenceCase } from '@utils/stringUtils.js'
-import { LIQUID_PRESENTATIONS, coerceDecimal } from '@dosiq/core'
+import { LIQUID_PRESENTATIONS, coerceDecimal, cleanFloat } from '@dosiq/core'
 
 // Líquido := dosage_unit termina em '/ml' (decisão-mãe 022). Único ponto de verdade na UI web.
 export const isLiquidUnit = (dosageUnit) => Boolean(dosageUnit?.endsWith('/ml'))
@@ -29,7 +29,7 @@ export const getInitialFormData = (medicine = {}) => {
   const denom = Number(concentration_volume_ml)
   const amountDisplay =
     dosage_per_pill !== '' && dosage_per_pill != null && denom > 0
-      ? String(Number(dosage_per_pill) * denom)
+      ? String(cleanFloat(Number(dosage_per_pill) * denom))
       : dosage_per_pill
 
   return {
@@ -91,7 +91,7 @@ export const buildMedicinePayload = (formData) => {
     name: formData.name.trim(),
     laboratory: formData.laboratory.trim() || null,
     active_ingredient: formData.active_ingredient.trim() || null,
-    dosage_per_pill: amount != null ? amount / denom : null,
+    dosage_per_pill: amount != null ? cleanFloat(amount / denom) : null,
     concentration_volume_ml: denom !== 1 ? denom : null,
     type: formData.type,
     dosage_unit: formData.dosage_unit,

--- a/apps/web/src/features/medications/components/_medicineFormUtils.js
+++ b/apps/web/src/features/medications/components/_medicineFormUtils.js
@@ -16,20 +16,31 @@ export const getInitialFormData = (medicine = {}) => {
     type = 'medicamento',
     dosage_unit = 'mg',
     units_per_ml = '',
+    concentration_volume_ml = null,
     presentation = 'comprimido',
     therapeutic_class = null,
     regulatory_category = null,
     shelf_life_days = null,
   } = medicine
 
+  // FR-031 (ADR-066): o campo exibe o `amount` do rótulo, não a razão normalizada.
+  // amount = dosage_per_pill (razão mg/mL) × concentration_volume_ml. Só transforma quando
+  // há denominador salvo (≠ null); senão exibe a razão crua (volume = 1, caso comum).
+  const denom = Number(concentration_volume_ml)
+  const amountDisplay =
+    dosage_per_pill !== '' && dosage_per_pill != null && denom > 0
+      ? String(Number(dosage_per_pill) * denom)
+      : dosage_per_pill
+
   return {
     name,
     laboratory,
     active_ingredient,
-    dosage_per_pill,
+    dosage_per_pill: amountDisplay,
     type,
     dosage_unit,
     units_per_ml: units_per_ml ?? '',
+    concentration_volume_ml: concentration_volume_ml ?? '',
     presentation,
     therapeutic_class,
     regulatory_category,
@@ -48,6 +59,15 @@ export const validateMedicineForm = (formData) => {
     newErrors.dosage_per_pill = 'Deve ser um número'
   }
 
+  // FR-031: denominador do rótulo (concentration_volume_ml) — se informado, deve ser > 0
+  // (não dividir por zero/negativo). Vazio = 1 (caso comum), sem erro.
+  if (formData.concentration_volume_ml !== '' && formData.concentration_volume_ml != null) {
+    const denom = coerceDecimal(formData.concentration_volume_ml)
+    if (isNaN(denom) || denom <= 0) {
+      newErrors.concentration_volume_ml = 'O volume (mL) deve ser maior que zero'
+    }
+  }
+
   // Densidade (units_per_ml) NÃO é capturada no cadastro do medicamento (022 Fase C):
   // pertence ao tratamento (intake_unit=gotas/UI). Sem validação aqui.
 
@@ -61,11 +81,18 @@ export const buildMedicinePayload = (formData) => {
   const presentation = isLiquid
     ? (LIQUID_PRESENTATIONS.includes(formData.presentation) ? formData.presentation : 'liquido')
     : formData.presentation || 'comprimido'
+  // FR-031 (ADR-066): o usuário digita o `amount` do rótulo; normaliza p/ a razão mg/mL.
+  // denominador (concentration_volume_ml) só p/ líquido; vazio/1 → razão = amount (passthrough)
+  // e coluna NULL. ≠1 → grava razão = amount ÷ denominador + o denominador.
+  const rawDenom = isLiquid ? coerceDecimal(formData.concentration_volume_ml) : NaN
+  const denom = rawDenom > 0 ? rawDenom : 1
+  const amount = formData.dosage_per_pill ? coerceDecimal(formData.dosage_per_pill) : null
   return {
     name: formData.name.trim(),
     laboratory: formData.laboratory.trim() || null,
     active_ingredient: formData.active_ingredient.trim() || null,
-    dosage_per_pill: formData.dosage_per_pill ? coerceDecimal(formData.dosage_per_pill) : null,
+    dosage_per_pill: amount != null ? amount / denom : null,
+    concentration_volume_ml: denom !== 1 ? denom : null,
     type: formData.type,
     dosage_unit: formData.dosage_unit,
     // Líquido grava units_per_ml + presentation='liquido'; sólido zera units_per_ml.

--- a/apps/web/src/features/medications/components/redesign/MedicineCardRedesign.jsx
+++ b/apps/web/src/features/medications/components/redesign/MedicineCardRedesign.jsx
@@ -7,7 +7,7 @@ import {
   Trash2,
   AlertTriangle,
 } from 'lucide-react'
-import { PRESENTATION_LABELS } from '@dosiq/core'
+import { PRESENTATION_LABELS, formatMedicineConcentration } from '@dosiq/core'
 import MedicineIcon from '@shared/components/ui/MedicineIcon'
 import './MedicineCardRedesign.css'
 
@@ -62,7 +62,7 @@ export default function MedicineCardRedesign({ medicine, onEdit, onDelete, hasDe
               <Beaker size={14} /> Dosagem
             </span>
             <span className="sr-medicine-card__detail-value">
-              {medicine.dosage_per_pill} {medicine.dosage_unit || 'mg'}
+              {formatMedicineConcentration(medicine)}
             </span>
           </div>
         )}

--- a/apps/web/src/features/medications/components/sections/MedicineFormBasicInfo.jsx
+++ b/apps/web/src/features/medications/components/sections/MedicineFormBasicInfo.jsx
@@ -1,9 +1,11 @@
 import React from 'react'
-import { MEDICINE_TYPES } from '@schemas/medicineSchema.js'
 import { getFieldDescribedBy } from '@utils/formUtils.js'
 import ShakeEffect from '@shared/components/ui/animations/ShakeEffect.jsx'
 import MedicineAutocomplete from '@features/medications/components/MedicineAutocomplete.jsx'
 
+// Ordem dos campos espelha o form mobile (012 Fase B3): Identificação no topo
+// (nome + princípio ativo), prioritários primeiro. Tipo/Classe migraram p/ a
+// seção "Classificação" (MedicineFormDosageInfo).
 export default function MedicineFormBasicInfo({
   formData,
   errors,
@@ -19,22 +21,7 @@ export default function MedicineFormBasicInfo({
 }) {
   return (
     <>
-      <div className="form-group">
-        <label htmlFor="type">Tipo</label>
-        <select
-          id="type"
-          name="type"
-          value={formData.type}
-          onChange={handleChange}
-          disabled={isSubmitting}
-        >
-          {MEDICINE_TYPES.map((type) => (
-            <option key={type} value={type}>
-              {type === 'medicamento' ? 'Medicamento' : 'Suplemento'}
-            </option>
-          ))}
-        </select>
-      </div>
+      <h4 className="medicine-form__section-title">Identificação</h4>
 
       <div className="form-group">
         <label htmlFor="name">
@@ -92,27 +79,6 @@ export default function MedicineFormBasicInfo({
         <small id="active_ingredient-hint" className="field-hint">
           Preenchido automaticamente ao selecionar medicamento
         </small>
-      </div>
-
-      <div className="form-group">
-        <label htmlFor="therapeutic_class">
-          Classe Terapêutica
-          {formData.therapeutic_class && !medicine?.therapeutic_class && (
-            <span className="autocomplete-badge" title="Preenchido via Base ANVISA">
-              Fonte: ANVISA
-            </span>
-          )}
-        </label>
-        <input
-          type="text"
-          id="therapeutic_class"
-          name="therapeutic_class"
-          value={formData.therapeutic_class || ''}
-          onChange={handleChange}
-          placeholder="Ex: Analgésicos não narcóticos"
-          disabled={isSubmitting}
-          maxLength={100}
-        />
       </div>
     </>
   )

--- a/apps/web/src/features/medications/components/sections/MedicineFormDosageInfo.jsx
+++ b/apps/web/src/features/medications/components/sections/MedicineFormDosageInfo.jsx
@@ -9,6 +9,7 @@ import {
   PRESENTATION_LABELS,
   LIQUID_PRESENTATIONS,
   coerceDecimal,
+  cleanFloat,
   formatNumberPtBR,
 } from '@dosiq/core'
 import { isLiquidUnit } from '@features/medications/components/_medicineFormUtils.js'
@@ -143,7 +144,9 @@ export default function MedicineFormDosageInfo({
                 const a = coerceDecimal(formData.dosage_per_pill)
                 const d = coerceDecimal(formData.concentration_volume_ml)
                 if (!(a > 0) || !(d > 0) || d === 1) return null
-                return ` → razão armazenada ${formatNumberPtBR(a / d)} mg/mL`
+                const baseUnit = (formData.dosage_unit || 'mg/ml').split('/')[0]
+                const baseLabel = DOSAGE_UNIT_LABELS[baseUnit] || baseUnit
+                return ` → razão armazenada ${formatNumberPtBR(cleanFloat(a / d))} ${baseLabel}/mL`
               })()}
             </small>
             {errors.concentration_volume_ml && (

--- a/apps/web/src/features/medications/components/sections/MedicineFormDosageInfo.jsx
+++ b/apps/web/src/features/medications/components/sections/MedicineFormDosageInfo.jsx
@@ -2,17 +2,23 @@ import React from 'react'
 import {
   DOSAGE_UNITS,
   DOSAGE_UNIT_LABELS,
+  MEDICINE_TYPES,
   REGULATORY_CATEGORIES,
   REGULATORY_CATEGORY_LABELS,
   PRESENTATIONS,
   PRESENTATION_LABELS,
   LIQUID_PRESENTATIONS,
+  coerceDecimal,
+  formatNumberPtBR,
 } from '@dosiq/core'
 import { isLiquidUnit } from '@features/medications/components/_medicineFormUtils.js'
 import { getFieldDescribedBy } from '@utils/formUtils.js'
 import ShakeEffect from '@shared/components/ui/animations/ShakeEffect.jsx'
 import LaboratoryAutocomplete from '@features/medications/components/LaboratoryAutocomplete.jsx'
 
+// Ordem dos campos espelha o form mobile (012 Fase B3): Dosagem (prioritária) no
+// topo, depois Classificação (tipo, apresentação, validade, classe, categoria,
+// laboratório). Tipo e Classe Terapêutica migraram da seção Identificação p/ cá.
 export default function MedicineFormDosageInfo({
   formData,
   errors,
@@ -56,110 +62,12 @@ export default function MedicineFormDosageInfo({
 
   return (
     <>
-      <div className="form-group">
-        <label htmlFor="laboratory">Marca / Laboratório</label>
-        <LaboratoryAutocomplete
-          value={formData.laboratory}
-          onChange={(value) => {
-            setFormData((prev) => ({ ...prev, laboratory: value }))
-            if (saveSuccess) setSaveSuccess(false)
-          }}
-          onSelect={handleLaboratorySelect}
-          inputId="laboratory"
-          placeholder="Ex: EMS, Medley ou digite para buscar..."
-          disabled={isSubmitting}
-          ariaDescribedBy="laboratory-hint"
-        />
-        <small id="laboratory-hint" className="field-hint">
-          Opcional. Base ANVISA com 278 laboratórios registrados
-        </small>
-      </div>
-
-      <div className="form-group">
-        <label htmlFor="regulatory_category">
-          Categoria Regulatória
-          {formData.regulatory_category && !medicine?.regulatory_category && (
-            <span className="autocomplete-badge" title="Preenchido via Base ANVISA">
-              Fonte: ANVISA
-            </span>
-          )}
-        </label>
-        <select
-          id="regulatory_category"
-          name="regulatory_category"
-          value={formData.regulatory_category || ''}
-          onChange={handleChange}
-          disabled={isSubmitting}
-          aria-describedby="regulatory_category-hint"
-        >
-          <option value="">Selecione (opcional)</option>
-          {REGULATORY_CATEGORIES.map((category) => (
-            <option key={category} value={category}>
-              {REGULATORY_CATEGORY_LABELS[category] || category}
-            </option>
-          ))}
-        </select>
-        <small id="regulatory_category-hint" className="field-hint">
-          Preenchido via ANVISA e usado no fluxo de compras do estoque redesign.
-        </small>
-      </div>
-
-      {/* ── Apresentação farmacêutica (012 Fase A) ── */}
-      <div className="form-group">
-        <label htmlFor="presentation">Apresentação</label>
-        <select
-          id="presentation"
-          name="presentation"
-          value={effectivePresentation}
-          onChange={handlePresentationChange}
-          disabled={isSubmitting}
-          aria-describedby="presentation-hint"
-        >
-          {presentationOptions.map((p) => (
-            <option key={p} value={p}>
-              {PRESENTATION_LABELS[p] || p}
-            </option>
-          ))}
-        </select>
-        <small id="presentation-hint" className="field-hint">
-          {liquid
-            ? 'Unidade /ml: escolha Líquido ou Injetável (injetável habilita validade após aberto).'
-            : 'Forma farmacêutica do medicamento (comprimido, injeção, pomada etc.).'}
-        </small>
-      </div>
-
-      {/* ── Validade após aberto — apenas para injetavel (012 Fase A) ── */}
-      {effectivePresentation === 'injetavel' && (
-        <div className="form-group">
-          <label htmlFor="shelf_life_days">Validade após aberto (dias)</label>
-          <input
-            type="number"
-            id="shelf_life_days"
-            name="shelf_life_days"
-            value={formData.shelf_life_days ?? ''}
-            onChange={handleChange}
-            className={errors.shelf_life_days ? 'error' : ''}
-            placeholder="28"
-            min="1"
-            step="1"
-            disabled={isSubmitting}
-            aria-describedby="shelf_life_days-hint"
-            aria-invalid={Boolean(errors.shelf_life_days)}
-          />
-          <small id="shelf_life_days-hint" className="field-hint">
-            Dias de uso após abrir o frasco/caneta — confira a bula.
-          </small>
-          {errors.shelf_life_days && (
-            <span id="shelf_life_days-error" className="error-message">
-              {errors.shelf_life_days}
-            </span>
-          )}
-        </div>
-      )}
+      {/* ──────────────── Dosagem (prioritária) ──────────────── */}
+      <h4 className="medicine-form__section-title">Dosagem</h4>
 
       <div className="form-group">
         <label htmlFor="dosage_per_pill">
-          Concentração <strong>(Específica da sua prescrição)</strong>
+          Concentração <strong>(igual ao rótulo)</strong>
           {liquid && (
             <span
               className="autocomplete-badge"
@@ -202,12 +110,46 @@ export default function MedicineFormDosageInfo({
           </select>
         </div>
         <small id="dosage_per_pill-hint" className="field-hint">
-          Preencha com a dosagem prescrita pelo seu médico
+          Preencha com a dosagem escrita no rótulo do seu medicamento.
         </small>
         {errors.dosage_per_pill && (
           <span id="dosage_per_pill-error" className="error-message">
             {errors.dosage_per_pill}
           </span>
+        )}
+
+        {/* FR-031 (ADR-066): denominador do rótulo. Default 1 mL; muda só p/ Mounjaro etc.
+            Armazena a razão normalizada em dosage_per_pill + o volume em concentration_volume_ml. */}
+        {liquid && (
+          <div style={{ marginTop: 8 }}>
+            <label htmlFor="concentration_volume_ml" style={{ fontSize: 13 }}>
+              Medida do volume (número junto do mL no rótulo)
+            </label>
+            <input
+              type="text"
+              inputMode="decimal"
+              autoComplete="off"
+              id="concentration_volume_ml"
+              name="concentration_volume_ml"
+              value={formData.concentration_volume_ml}
+              onChange={handleChange}
+              className={errors.concentration_volume_ml ? 'error' : ''}
+              placeholder="1"
+              disabled={isSubmitting}
+            />
+            <small className="field-hint" style={{ display: 'block' }}>
+              Padrão é 1 mL (ou só mL). Mude se o rótulo trouxer outro volume, ex.: &quot;Mounjaro 2,5mg / 0,5mL&quot; — preencha 0,5.
+              {(() => {
+                const a = coerceDecimal(formData.dosage_per_pill)
+                const d = coerceDecimal(formData.concentration_volume_ml)
+                if (!(a > 0) || !(d > 0) || d === 1) return null
+                return ` → razão armazenada ${formatNumberPtBR(a / d)} mg/mL`
+              })()}
+            </small>
+            {errors.concentration_volume_ml && (
+              <span className="error-message">{errors.concentration_volume_ml}</span>
+            )}
+          </div>
         )}
         {formData.dosage_unit === 'un' && Number(formData.dosage_per_pill) > 1 && (
           <div
@@ -226,6 +168,148 @@ export default function MedicineFormDosageInfo({
             ⚠️ Dica: Para a unidade genérica 'un.', a concentração deveria ser 1. Caso seu medicamento tenha dosagem química ativa (ex: 500 mg), altere a unidade ao lado para 'mg', 'ui', etc.
           </div>
         )}
+      </div>
+
+      {/* ──────────────── Classificação ──────────────── */}
+      <h4 className="medicine-form__section-title">Classificação</h4>
+
+      <div className="form-group">
+        <label htmlFor="type">Tipo</label>
+        <select
+          id="type"
+          name="type"
+          value={formData.type}
+          onChange={handleChange}
+          disabled={isSubmitting}
+        >
+          {MEDICINE_TYPES.map((type) => (
+            <option key={type} value={type}>
+              {type === 'medicamento' ? 'Medicamento' : 'Suplemento'}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* ── Apresentação farmacêutica (012 Fase A) ── */}
+      <div className="form-group">
+        <label htmlFor="presentation">Apresentação</label>
+        <select
+          id="presentation"
+          name="presentation"
+          value={effectivePresentation}
+          onChange={handlePresentationChange}
+          disabled={isSubmitting}
+          aria-describedby="presentation-hint"
+        >
+          {presentationOptions.map((p) => (
+            <option key={p} value={p}>
+              {PRESENTATION_LABELS[p] || p}
+            </option>
+          ))}
+        </select>
+        <small id="presentation-hint" className="field-hint">
+          {liquid
+            ? 'Escolha Líquido ou Injetável (injetável possui validade após aberto).'
+            : 'Forma de apresentação do seu medicamento (comprimido, injeção, pomada etc.).'}
+        </small>
+      </div>
+
+      {/* ── Validade após aberto — apenas para injetavel (012 Fase A) ── */}
+      {effectivePresentation === 'injetavel' && (
+        <div className="form-group">
+          <label htmlFor="shelf_life_days">Validade após aberto (dias)</label>
+          <input
+            type="number"
+            id="shelf_life_days"
+            name="shelf_life_days"
+            value={formData.shelf_life_days ?? ''}
+            onChange={handleChange}
+            className={errors.shelf_life_days ? 'error' : ''}
+            placeholder="28"
+            min="1"
+            step="1"
+            disabled={isSubmitting}
+            aria-describedby="shelf_life_days-hint"
+            aria-invalid={Boolean(errors.shelf_life_days)}
+          />
+          <small id="shelf_life_days-hint" className="field-hint">
+            Dias de uso após abrir o frasco/caneta — confira a bula.
+          </small>
+          {errors.shelf_life_days && (
+            <span id="shelf_life_days-error" className="error-message">
+              {errors.shelf_life_days}
+            </span>
+          )}
+        </div>
+      )}
+
+      <div className="form-group">
+        <label htmlFor="therapeutic_class">
+          Classe Terapêutica
+          {formData.therapeutic_class && !medicine?.therapeutic_class && (
+            <span className="autocomplete-badge" title="Preenchido via Base ANVISA">
+              Fonte: ANVISA
+            </span>
+          )}
+        </label>
+        <input
+          type="text"
+          id="therapeutic_class"
+          name="therapeutic_class"
+          value={formData.therapeutic_class || ''}
+          onChange={handleChange}
+          placeholder="Ex: Analgésicos não narcóticos"
+          disabled={isSubmitting}
+          maxLength={100}
+        />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="regulatory_category">
+          Categoria Regulatória
+          {formData.regulatory_category && !medicine?.regulatory_category && (
+            <span className="autocomplete-badge" title="Preenchido via Base ANVISA">
+              Fonte: ANVISA
+            </span>
+          )}
+        </label>
+        <select
+          id="regulatory_category"
+          name="regulatory_category"
+          value={formData.regulatory_category || ''}
+          onChange={handleChange}
+          disabled={isSubmitting}
+          aria-describedby="regulatory_category-hint"
+        >
+          <option value="">Selecione (opcional)</option>
+          {REGULATORY_CATEGORIES.map((category) => (
+            <option key={category} value={category}>
+              {REGULATORY_CATEGORY_LABELS[category] || category}
+            </option>
+          ))}
+        </select>
+        <small id="regulatory_category-hint" className="field-hint">
+          Preenchido via busca na base da ANVISA.
+        </small>
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="laboratory">Marca / Laboratório</label>
+        <LaboratoryAutocomplete
+          value={formData.laboratory}
+          onChange={(value) => {
+            setFormData((prev) => ({ ...prev, laboratory: value }))
+            if (saveSuccess) setSaveSuccess(false)
+          }}
+          onSelect={handleLaboratorySelect}
+          inputId="laboratory"
+          placeholder="Ex: EMS, Medley ou digite para buscar..."
+          disabled={isSubmitting}
+          ariaDescribedBy="laboratory-hint"
+        />
+        <small id="laboratory-hint" className="field-hint">
+          Opcional. Fonte: Busca na base da ANVISA
+        </small>
       </div>
     </>
   )

--- a/apps/web/src/features/protocols/components/ProtocolCard.jsx
+++ b/apps/web/src/features/protocols/components/ProtocolCard.jsx
@@ -118,7 +118,7 @@ export default function ProtocolCard({ protocol, onEdit, onToggleActive, onDelet
           <span className="protocol-medicine">
             {protocol.medicine?.name}
             {protocol.medicine?.dosage_per_pill
-              ? ` (${formatConcentration(protocol.medicine.dosage_per_pill, protocol.medicine.dosage_unit)})`
+              ? ` (${formatConcentration(protocol.medicine.dosage_per_pill, protocol.medicine.dosage_unit, protocol.medicine.concentration_volume_ml)})`
               : ''}
           </span>
         </div>

--- a/apps/web/src/features/protocols/components/steps/TreatmentWizardStep1.jsx
+++ b/apps/web/src/features/protocols/components/steps/TreatmentWizardStep1.jsx
@@ -2,6 +2,7 @@ import MedicineAutocomplete from '@medications/components/MedicineAutocomplete'
 import LaboratoryAutocomplete from '@medications/components/LaboratoryAutocomplete'
 import Button from '@shared/components/ui/Button'
 import { DOSAGE_UNITS, DOSAGE_UNIT_LABELS, REGULATORY_CATEGORIES, REGULATORY_CATEGORY_LABELS, PRESENTATIONS, PRESENTATION_LABELS, LIQUID_PRESENTATIONS } from '@schemas/medicineSchema'
+import { formatConcentration } from '@dosiq/core'
 
 /** Renderiza o formulário de cadastro de novo medicamento. */
 function NewMedicineForm({ medicineData, updateMedicine, handleMedicineSelect, handleLaboratorySelect }) {
@@ -208,7 +209,7 @@ export default function TreatmentWizardStep1({
             {medicines.map((m) => (
               <option key={m.id} value={m.id}>
                 {m.name}
-                {m.dosage_per_pill ? ` ${m.dosage_per_pill}${m.dosage_unit}` : ''}
+                {m.dosage_per_pill ? ` ${formatConcentration(m.dosage_per_pill, m.dosage_unit, m.concentration_volume_ml)}` : ''}
               </option>
             ))}
           </select>

--- a/apps/web/src/features/protocols/hooks/_treatmentListUtils.js
+++ b/apps/web/src/features/protocols/hooks/_treatmentListUtils.js
@@ -98,7 +98,7 @@ function _computeNextDoseTime(timeSchedule) {
 
 function _computeConcentrationLabel(medicine) {
   if (!medicine?.dosage_per_pill || !medicine?.dosage_unit) return null
-  return formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit)
+  return formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit, medicine.concentration_volume_ml)
 }
 
 function _computeTreatmentPlanInfo(treatmentPlan) {

--- a/apps/web/src/features/stock/components/redesign/StockCardRedesign.jsx
+++ b/apps/web/src/features/stock/components/redesign/StockCardRedesign.jsx
@@ -142,7 +142,7 @@ export default function StockCardRedesign({ item, isComplex, onAddStock, predict
             <h3 className="stock-card-r__name">{medicine.name}</h3>
             {medicine.dosage_per_pill && (
               <span className="stock-card-r__dosage">
-                {formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit)}
+                {formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit, medicine.concentration_volume_ml)}
               </span>
             )}
           </div>

--- a/apps/web/src/features/stock/components/sections/StockFormMedicineDetails.jsx
+++ b/apps/web/src/features/stock/components/sections/StockFormMedicineDetails.jsx
@@ -1,5 +1,5 @@
 import { getFieldDescribedBy } from '@utils/formUtils'
-import { formatActiveIngredientFormula, INJECTION_CONTAINERS, INJECTION_CONTAINER_LABELS } from '@dosiq/core'
+import { formatActiveIngredientFormula, formatConcentration, INJECTION_CONTAINERS, INJECTION_CONTAINER_LABELS } from '@dosiq/core'
 
 export default function StockFormMedicineDetails({
   formData,
@@ -35,7 +35,7 @@ export default function StockFormMedicineDetails({
             <option key={medicine.id} value={medicine.id}>
               {medicine.name}{' '}
               {medicine.dosage_per_pill
-                ? `(${medicine.dosage_per_pill}${medicine.dosage_unit || 'mg'})`
+                ? `(${formatConcentration(medicine.dosage_per_pill, medicine.dosage_unit, medicine.concentration_volume_ml)})`
                 : ''}
             </option>
           ))}

--- a/apps/web/src/features/stock/hooks/_stockDataTransformer.js
+++ b/apps/web/src/features/stock/hooks/_stockDataTransformer.js
@@ -99,6 +99,7 @@ export function transformStockItems(medicines, protocols, stockMap, purchaseHist
         name: medicine.name,
         dosage_per_pill: medicine.dosage_per_pill,
         dosage_unit: medicine.dosage_unit || 'mg',
+        concentration_volume_ml: medicine.concentration_volume_ml ?? null,
         units_per_ml: medicine.units_per_ml ?? null,
         type: medicine.type || 'medicamento',
         // Forma farmacêutica p/ ícone canônico (getMedicineIconName) no card

--- a/docs/migrations/20260613_b3_units_per_ml_null_denominador.sql
+++ b/docs/migrations/20260613_b3_units_per_ml_null_denominador.sql
@@ -1,0 +1,105 @@
+-- 012 Fase B3 — units_per_ml default NULL + backfill unit-aware + coluna concentration_volume_ml
+-- + RPC consume_stock_fifo unit-aware. ADR-065 + ADR-066.
+--
+-- APLICADA EM PROD 2026-06-13 (autorização PO). Verificada: default=null; coluna criada;
+-- backfill 3 linhas 20→NULL (Durateston/Tresiba/Xarope); Dipirona=20, Lantus=100; RPC UI unit-aware.
+-- Idempotente. RPC reescrita do pg_get_functiondef AO VIVO (AP-217): assinatura intacta
+-- (AP-221 — nenhum caller muda; AP-209 — sem overload). Única mudança no corpo: densidade
+-- gotas/UI deixa de cair no blanket 20 e passa a ser unit-aware (gotas→20, UI→100).
+--
+-- Baseline prod (2026-06-13): 6 líquidos/111; backfill esperado = 3 linhas 20→NULL
+-- (Durateston=sem-trat, Xarope=ml, Tresiba=ml); Dipirona(gotas)=20 e Lantus(UI)=100 mantêm;
+-- Mounjaro(mg) já NULL.
+
+-- 1) units_per_ml: remove o DEFAULT 20 (blanket) — novas linhas nascem NULL
+ALTER TABLE public.medicines ALTER COLUMN units_per_ml DROP DEFAULT;
+
+-- 2) Backfill derivado da unidade de tomada do tratamento (ADR-065): UI→100, gotas→20,
+--    demais (mg/ml/sem-tratamento)→NULL. Só líquidos; tie-break UI>gotas. IS DISTINCT FROM
+--    evita updates no-op.
+UPDATE public.medicines m
+   SET units_per_ml = sub.new_upm
+  FROM (
+    SELECT med.id,
+           CASE
+             WHEN bool_or(lower(p.intake_unit) = 'ui')    THEN 100
+             WHEN bool_or(lower(p.intake_unit) = 'gotas')  THEN 20
+             ELSE NULL
+           END AS new_upm
+      FROM public.medicines med
+      LEFT JOIN public.protocols p ON p.medicine_id = med.id
+     WHERE med.dosage_unit LIKE '%/ml'
+     GROUP BY med.id
+  ) sub
+ WHERE m.id = sub.id
+   AND m.units_per_ml IS DISTINCT FROM sub.new_upm;
+
+-- 3) Coluna concentration_volume_ml (FR-031/ADR-066): volume do rótulo (NULL = "por 1 mL").
+--    Grants/RLS já existem na tabela (medicines pré-30/10/2026). Validação > 0 no Zod.
+ALTER TABLE public.medicines ADD COLUMN IF NOT EXISTS concentration_volume_ml NUMERIC DEFAULT NULL;
+
+-- 4) RPC consume_stock_fifo — densidade gotas/UI unit-aware (FR-024). Corpo idêntico ao
+--    live EXCETO: (a) SELECT traz units_per_ml cru (NULLIF, sem COALESCE 20); (b) ramos
+--    gotas e UI separados com default 20/100. mg (dosage_per_pill) e ml inalterados.
+CREATE OR REPLACE FUNCTION public.consume_stock_fifo(p_user_id uuid, p_medicine_id uuid, p_quantity numeric, p_medicine_log_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+DECLARE
+  v_user_id UUID := p_user_id; v_is_liquid BOOLEAN; v_units_per_ml NUMERIC; v_intake_unit TEXT;
+  v_concentration NUMERIC; v_remaining NUMERIC; v_total_available NUMERIC := 0; v_total_consumed NUMERIC := 0;
+  v_rows_consumed INTEGER := 0; v_to_consume NUMERIC; v_stock_row public.stock%ROWTYPE;
+BEGIN
+  IF v_user_id IS NULL THEN RAISE EXCEPTION 'user_id é obrigatório para chamadas server-side'; END IF;
+  IF p_quantity IS NULL OR p_quantity <= 0 THEN RAISE EXCEPTION 'Quantidade para consumo deve ser maior que zero'; END IF;
+  IF p_medicine_log_id IS NULL THEN RAISE EXCEPTION 'medicine_log_id é obrigatório'; END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.medicine_logs WHERE id=p_medicine_log_id AND medicine_id=p_medicine_id AND user_id=v_user_id) THEN
+    RAISE EXCEPTION 'Log de medicamento não encontrado para o usuário'; END IF;
+  -- B3: units_per_ml cru (NULLIF 0→NULL); o default por unidade aplica no ramo gotas/UI.
+  SELECT (dosage_unit LIKE '%/ml'), NULLIF(units_per_ml,0), dosage_per_pill
+    INTO v_is_liquid, v_units_per_ml, v_concentration
+    FROM public.medicines WHERE id=p_medicine_id;
+  IF COALESCE(v_is_liquid,FALSE) THEN
+    SELECT p.intake_unit INTO v_intake_unit FROM public.protocols p
+      JOIN public.medicine_logs l ON l.protocol_id=p.id WHERE l.id=p_medicine_log_id;
+    v_intake_unit := COALESCE(v_intake_unit,'ml');
+    IF lower(v_intake_unit) = 'mg' THEN
+      IF v_concentration IS NULL OR v_concentration <= 0 THEN
+        RAISE EXCEPTION 'Concentração (mg/ml) do medicamento ausente — não dá para converter mg em ml';
+      END IF;
+      v_remaining := ROUND(p_quantity/v_concentration,2);
+    ELSIF lower(v_intake_unit) = 'gotas' THEN
+      v_remaining := ROUND(p_quantity/COALESCE(v_units_per_ml,20),2);
+    ELSIF lower(v_intake_unit) = 'ui' THEN
+      v_remaining := ROUND(p_quantity/COALESCE(v_units_per_ml,100),2);
+    ELSE v_remaining := ROUND(p_quantity,2); END IF;
+    IF v_remaining<=0 THEN RAISE EXCEPTION 'Dose muito pequena para débito de estoque (arredondou para 0 ml)'; END IF;
+  ELSE v_remaining := p_quantity; END IF;
+  SELECT COALESCE(SUM(quantity),0) INTO v_total_available FROM public.stock
+    WHERE medicine_id=p_medicine_id AND user_id=v_user_id AND quantity>0 AND (entry_type IS NULL OR entry_type!='legacy_unrecoverable');
+  IF v_total_available < v_remaining THEN RAISE EXCEPTION 'Estoque insuficiente'; END IF;
+  FOR v_stock_row IN SELECT * FROM public.stock
+    WHERE medicine_id=p_medicine_id AND user_id=v_user_id AND quantity>0 AND (entry_type IS NULL OR entry_type!='legacy_unrecoverable')
+    ORDER BY purchase_date ASC, created_at ASC, id ASC FOR UPDATE LOOP
+    EXIT WHEN v_remaining<=0;
+    v_to_consume := LEAST(v_stock_row.quantity, v_remaining);
+    UPDATE public.stock SET quantity=quantity-v_to_consume,
+      opened_at = COALESCE(opened_at, now())
+      WHERE id=v_stock_row.id;
+    INSERT INTO public.stock_consumptions (user_id,medicine_log_id,medicine_id,stock_id,quantity_consumed)
+      VALUES (v_user_id,p_medicine_log_id,p_medicine_id,v_stock_row.id,v_to_consume);
+    v_remaining := v_remaining-v_to_consume; v_total_consumed := v_total_consumed+v_to_consume;
+    v_rows_consumed := v_rows_consumed+1;
+  END LOOP;
+  IF v_remaining>0 THEN RAISE EXCEPTION 'Falha de consistência: consumo FIFO incompleto'; END IF;
+  RETURN jsonb_build_object('medicine_log_id',p_medicine_log_id,'medicine_id',p_medicine_id,
+    'is_liquid',v_is_liquid,'quantity_requested',p_quantity,'quantity_consumed',v_total_consumed,
+    'consumption_rows_created',v_rows_consumed);
+END; $function$;
+
+-- Verificação pós-apply (rodar manualmente):
+-- SELECT name, dosage_unit, units_per_ml FROM public.medicines WHERE dosage_unit LIKE '%/ml' ORDER BY name;
+--   → Durateston/Xarope/Tresiba = NULL; Dipirona = 20; Lantus = 100; Mounjaro = NULL
+-- SELECT EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='medicines' AND column_name='concentration_volume_ml'); → true

--- a/packages/core/src/repositories/createStockRepository.js
+++ b/packages/core/src/repositories/createStockRepository.js
@@ -68,6 +68,7 @@ export function createStockRepository({ client, getUserId }) {
         presentation,
         dosage_unit,
         dosage_per_pill,
+        concentration_volume_ml,
         units_per_ml,
         shelf_life_days,
         medicine_stock_summary!left (

--- a/packages/core/src/schemas/medicineSchema.js
+++ b/packages/core/src/schemas/medicineSchema.js
@@ -164,6 +164,20 @@ const medicineObject = z.object({
       .optional()
   ),
 
+  // 012 Fase B3 (FR-031, ADR-066): volume (mL) que o rótulo da concentração referencia.
+  // NULL = "por 1 mL" (caso comum). Mounjaro = 0,5 (rótulo "2,5 mg/0,5 mL"). É o `volume`
+  // do par (amount, volume) — seed do modelo de concentração futuro. dosage_per_pill segue
+  // a razão normalizada mg/mL; o rótulo reexibe amount = dosage_per_pill × COALESCE(vol,1).
+  // preprocess '' → null (idem units_per_ml/dosage_per_pill).
+  concentration_volume_ml: z.preprocess(
+    (val) => (val === '' ? null : val),
+    z.coerce
+      .number()
+      .positive('Volume da concentração (mL) deve ser maior que zero')
+      .nullable()
+      .optional()
+  ),
+
   // Forma farmacêutica (additiva — ADR-058). Default 'comprimido' espelha o DEFAULT do DB.
   presentation: z.enum(PRESENTATIONS).default('comprimido'),
 

--- a/packages/core/src/utils/__tests__/cleanFloat.b3.test.js
+++ b/packages/core/src/utils/__tests__/cleanFloat.b3.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { cleanFloat } from '../formUtils.js'
+
+// 012 Fase B3 (review Gemini #661): limpa dízimas de ponto flutuante do JS.
+describe('cleanFloat', () => {
+  it('remove artefato de soma/multiplicação', () => {
+    expect(0.1 + 0.2).not.toBe(0.3) // sanity: JS expõe 0.30000000000000004
+    expect(cleanFloat(0.1 + 0.2)).toBe(0.3)
+  })
+  it('remove artefato de divisão', () => {
+    expect(cleanFloat(0.3 / 0.1)).toBe(3)
+  })
+  it('preserva valores exatos', () => {
+    expect(cleanFloat(5)).toBe(5)
+    expect(cleanFloat(2.5)).toBe(2.5)
+  })
+  it('aceita string numérica', () => {
+    expect(cleanFloat('2.5')).toBe(2.5)
+  })
+  it('não-finito passa direto (NaN)', () => {
+    expect(Number.isNaN(cleanFloat(NaN))).toBe(true)
+    expect(Number.isNaN(cleanFloat('abc'))).toBe(true)
+  })
+})

--- a/packages/core/src/utils/__tests__/densityFor.b3.test.js
+++ b/packages/core/src/utils/__tests__/densityFor.b3.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { densityFor, formatConcentrationLabel } from '../doseUnit.js'
+import { doseToMl } from '../adherenceLogic.js'
+
+// 012 Fase B3 (ADR-065): densidade unit-aware substitui o blanket 20.
+describe('densityFor (FR-024)', () => {
+  it('densidade explícita tem prioridade', () => {
+    expect(densityFor('gotas', 25)).toBe(25)
+    expect(densityFor('UI', 200)).toBe(200) // U-200
+    expect(densityFor('gotas', '0,5')).toBe(0.5) // vírgula PT-BR
+  })
+  it('padrão por unidade quando densidade ausente', () => {
+    expect(densityFor('gotas', null)).toBe(20)
+    expect(densityFor('gotas', 0)).toBe(20)
+    expect(densityFor('UI', null)).toBe(100)
+    expect(densityFor('ui', undefined)).toBe(100)
+  })
+  it('sem padrão seguro → null (ml/mg/desconhecido)', () => {
+    expect(densityFor('ml', null)).toBeNull()
+    expect(densityFor('mg', null)).toBeNull()
+    expect(densityFor(null, null)).toBeNull()
+  })
+})
+
+describe('doseToMl unit-aware (FR-024)', () => {
+  it('UI sem densidade usa 100 (não 20)', () => {
+    expect(doseToMl(100, 'UI', null)).toBe(1) // 100 UI / 100 = 1 ml
+  })
+  it('gotas sem densidade usa 20', () => {
+    expect(doseToMl(40, 'gotas', null)).toBe(2) // 40 / 20 = 2 ml
+  })
+  it('densidade explícita tem prioridade', () => {
+    expect(doseToMl(40, 'gotas', 40)).toBe(1)
+  })
+  it('mg usa concentração (dosage_per_pill), não densidade', () => {
+    expect(doseToMl(2.5, 'mg', 20, 5)).toBe(0.5)
+  })
+  it('ml é dose direta', () => {
+    expect(doseToMl(3, 'ml', null)).toBe(3)
+  })
+})
+
+// 012 Fase B3 (ADR-066): rótulo reconstruído com denominador.
+describe('formatConcentrationLabel com volume (FR-031)', () => {
+  it('volume 1 (default) — compatível com B2', () => {
+    expect(formatConcentrationLabel(0.68)).toBe('0,68 mg em 1 mL')
+    expect(formatConcentrationLabel(5, 1)).toBe('5 mg em 1 mL')
+  })
+  it('Mounjaro: razão 5, volume 0,5 → "2,5 mg em 0,5 mL"', () => {
+    expect(formatConcentrationLabel(5, 0.5)).toBe('2,5 mg em 0,5 mL')
+  })
+  it('volume inválido/0 cai para 1 mL', () => {
+    expect(formatConcentrationLabel(5, 0)).toBe('5 mg em 1 mL')
+    expect(formatConcentrationLabel(5, null)).toBe('5 mg em 1 mL')
+  })
+  it('razão inválida → string vazia', () => {
+    expect(formatConcentrationLabel(null)).toBe('')
+    expect(formatConcentrationLabel(0)).toBe('')
+  })
+})

--- a/packages/core/src/utils/__tests__/formatMedicineConcentration.b3.test.js
+++ b/packages/core/src/utils/__tests__/formatMedicineConcentration.b3.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { formatMedicineConcentration, formatConcentration } from '../doseUnit.js'
+
+// 012 Fase B3 (FR-031): card reexibe o rótulo original quando há denominador ≠ 1 mL.
+describe('formatMedicineConcentration', () => {
+  it('líquido c/ denominador 0,5 → reexibe rótulo (Mounjaro 2,5 mg / 0,5ml)', () => {
+    expect(
+      formatMedicineConcentration({ dosage_per_pill: 5, dosage_unit: 'mg/ml', concentration_volume_ml: 0.5 })
+    ).toBe('2,5 mg / 0,5ml')
+  })
+
+  it('aceita volume como string com vírgula', () => {
+    expect(
+      formatMedicineConcentration({ dosage_per_pill: '5', dosage_unit: 'mg/ml', concentration_volume_ml: '0,5' })
+    ).toBe('2,5 mg / 0,5ml')
+  })
+
+  it('unidade base UI maiúscula no rótulo', () => {
+    expect(
+      formatMedicineConcentration({ dosage_per_pill: 200, dosage_unit: 'ui/ml', concentration_volume_ml: 0.5 })
+    ).toBe('100 UI / 0,5ml')
+  })
+
+  it('volume NULL → fallback razão crua', () => {
+    expect(
+      formatMedicineConcentration({ dosage_per_pill: 100, dosage_unit: 'ui/ml', concentration_volume_ml: null })
+    ).toBe('100 UI/ml')
+  })
+
+  it('volume 1 explícito → fallback (não polui com /1 mL)', () => {
+    expect(
+      formatMedicineConcentration({ dosage_per_pill: 40, dosage_unit: 'mg/ml', concentration_volume_ml: 1 })
+    ).toBe('40 mg/ml')
+  })
+
+  it('sólido ignora denominador', () => {
+    expect(
+      formatMedicineConcentration({ dosage_per_pill: 500, dosage_unit: 'mg', concentration_volume_ml: 0.5 })
+    ).toBe('500 mg')
+  })
+
+  it('sem medicine → string vazia', () => {
+    expect(formatMedicineConcentration(null)).toBe('')
+  })
+})
+
+describe('formatConcentration — 3º arg volumeMl (motor)', () => {
+  it('2 args legado → comportamento clássico', () => {
+    expect(formatConcentration(100, 'ui/ml')).toBe('100 UI/ml')
+    expect(formatConcentration(500, 'mg')).toBe('500 mg')
+  })
+  it('volume ≠ 1 reexibe rótulo', () => {
+    expect(formatConcentration(5, 'mg/ml', 0.5)).toBe('2,5 mg / 0,5ml')
+  })
+  it('volume em sólido ignorado', () => {
+    expect(formatConcentration(500, 'mg', 0.5)).toBe('500 mg')
+  })
+})

--- a/packages/core/src/utils/__tests__/formatMedicineConcentration.b3.test.js
+++ b/packages/core/src/utils/__tests__/formatMedicineConcentration.b3.test.js
@@ -55,4 +55,7 @@ describe('formatConcentration — 3º arg volumeMl (motor)', () => {
   it('volume em sólido ignorado', () => {
     expect(formatConcentration(500, 'mg', 0.5)).toBe('500 mg')
   })
+  it('limpa artefato de float (Gemini #661): 1,2 × 0,3 → 0,36 (não 0,36000000000000004)', () => {
+    expect(formatConcentration(1.2, 'mg/ml', 0.3)).toBe('0,36 mg / 0,3ml')
+  })
 })

--- a/packages/core/src/utils/adherenceLogic.js
+++ b/packages/core/src/utils/adherenceLogic.js
@@ -17,6 +17,7 @@ import {
   cloneDate,
   parseTimestamp
 } from './dateUtils.js'
+import { densityFor } from './doseUnit.js'
 
 // Invariantes de Negócio (R-022, R-129)
 const TOLERANCE_WINDOW_HOURS = 2
@@ -269,9 +270,10 @@ export function doseToMl(dosage, intakeUnit, unitsPerMl, mgConcentration) {
     const c = Number(mgConcentration)
     return c > 0 ? dosage / c : dosage
   }
-  // gotas/UI → ml: divide pela razão física units_per_ml. Fallback 20 (gotas/ml) se ausente.
-  const density = unitsPerMl && unitsPerMl > 0 ? unitsPerMl : 20
-  return dosage / density
+  // gotas/UI → ml: densidade unit-aware (ADR-065 — gotas≈20, UI≈100; explícita tem prioridade).
+  // Sem densidade definível não inventa (retorna dose crua — evita conversão fantasma).
+  const density = densityFor(intakeUnit, unitsPerMl)
+  return density ? dosage / density : dosage
 }
 
 /**

--- a/packages/core/src/utils/doseUnit.js
+++ b/packages/core/src/utils/doseUnit.js
@@ -13,6 +13,7 @@
 // US. Por isso usamos replace('.', ',') manual (confiável em V8 e Hermes).
 
 import { DOSAGE_UNIT_LABELS } from '../schemas/medicineSchema.js'
+import { cleanFloat } from './formUtils.js'
 
 /**
  * Formata a concentração/apresentação do medicamento (pill) com a unidade
@@ -42,7 +43,7 @@ export function formatConcentration(value, unit, volumeMl = null) {
   ) {
     const baseUnit = (unit || 'mg/ml').split('/')[0]
     const baseLabel = DOSAGE_UNIT_LABELS[baseUnit] || baseUnit
-    return `${formatNumberPtBR(ratio * vol)} ${baseLabel} / ${formatNumberPtBR(vol)}ml`
+    return `${formatNumberPtBR(cleanFloat(ratio * vol))} ${baseLabel} / ${formatNumberPtBR(vol)}ml`
   }
   const v = formatNumberPtBR(value)
   if (v === '') return ''
@@ -141,7 +142,7 @@ export function formatConcentrationLabel(mgPerMl, volumeMl = 1) {
   if (!Number.isFinite(ratio) || ratio <= 0) return ''
   const volNum = Number(typeof volumeMl === 'string' ? volumeMl.replace(',', '.') : volumeMl)
   const vol = Number.isFinite(volNum) && volNum > 0 ? volNum : 1
-  const amount = ratio * vol
+  const amount = cleanFloat(ratio * vol)
   return `${formatNumberPtBR(amount)} mg em ${formatNumberPtBR(vol)} mL`
 }
 

--- a/packages/core/src/utils/doseUnit.js
+++ b/packages/core/src/utils/doseUnit.js
@@ -20,16 +20,50 @@ import { DOSAGE_UNIT_LABELS } from '../schemas/medicineSchema.js'
  * Centraliza o que antes era `${dosage_per_pill}${dosage_unit}` cru (mostrava
  * "ui/ml" minúsculo) espalhado por listagem, estoque, histórico e notificações.
  *
- * @param {number|string|null} value - dosage_per_pill (carga por unidade/ml)
+ * 012 Fase B3 (FR-031): quando o líquido tem denominador de rótulo ≠ 1 mL (ex:
+ * Mounjaro), reconstrói a leitura original do rótulo — `amount unidadeBase / volume mL`
+ * ('2,5 mg / 0,5 mL') em vez da razão normalizada crua ('5 mg/ml'), que confunde.
+ * Volume NULL/1 ou sólido → comportamento clássico inalterado.
+ *
+ * @param {number|string|null} value - dosage_per_pill (razão por unidade/ml)
  * @param {string|null} unit - dosage_unit ('mg', 'ui/ml', 'mg/ml', 'un', …)
- * @returns {string} ex: '100 UI/ml' · '500 mg' · '' se value vazio
+ * @param {number|string|null} [volumeMl=null] - concentration_volume_ml (denominador do rótulo)
+ * @returns {string} ex: '100 UI/ml' · '500 mg' · '2,5 mg / 0,5 mL' · '' se value vazio
  */
-export function formatConcentration(value, unit) {
+export function formatConcentration(value, unit, volumeMl = null) {
   if (value === undefined || value === null || value === '') return ''
+  const ratio = Number(typeof value === 'string' ? value.replace(',', '.') : value)
+  const vol = Number(typeof volumeMl === 'string' ? volumeMl.replace(',', '.') : volumeMl)
+  const isLiquid = Boolean(unit?.endsWith('/ml'))
+  if (
+    isLiquid &&
+    Number.isFinite(ratio) && ratio > 0 &&
+    Number.isFinite(vol) && vol > 0 && vol !== 1
+  ) {
+    const baseUnit = (unit || 'mg/ml').split('/')[0]
+    const baseLabel = DOSAGE_UNIT_LABELS[baseUnit] || baseUnit
+    return `${formatNumberPtBR(ratio * vol)} ${baseLabel} / ${formatNumberPtBR(vol)}ml`
+  }
   const v = formatNumberPtBR(value)
   if (v === '') return ''
   const label = DOSAGE_UNIT_LABELS[unit] || unit || ''
   return label ? `${v} ${label}` : v
+}
+
+/**
+ * Açúcar p/ chamar formatConcentration a partir de um objeto medicine (snake_case).
+ * Mantém call sites de card limpos (passa o objeto inteiro).
+ *
+ * @param {{dosage_per_pill?: number|string|null, dosage_unit?: string|null, concentration_volume_ml?: number|string|null}|null} medicine
+ * @returns {string}
+ */
+export function formatMedicineConcentration(medicine) {
+  if (!medicine) return ''
+  return formatConcentration(
+    medicine.dosage_per_pill,
+    medicine.dosage_unit,
+    medicine.concentration_volume_ml
+  )
 }
 
 /**
@@ -88,20 +122,27 @@ export function formatStockQuantity(qty, medicine) {
 }
 
 /**
- * Rótulo de concentração p/ o form de tratamento GLP-1 (012 Fase B2, FR-018):
- * "[X] mg em [Y] mL". Ajuda o usuário a confirmar a densidade lida na bula/caneta
- * antes de salvar (units_per_ml = mg por ml). 1 mL fixo no denominador (a leitura
- * da bula é sempre "X mg/mL"). Vírgula PT-BR. Retorna '' se densidade inválida.
+ * Rótulo de concentração: "[amount] mg em [volume] mL". Reconstrói a leitura da caixa
+ * (012 Fase B3, FR-031/ADR-066): `mgPerMl` é a razão normalizada (dosage_per_pill) e
+ * `volumeMl` é o denominador do rótulo (`concentration_volume_ml`; NULL/omitido = 1 mL).
+ * amount = mgPerMl × volume. Mounjaro (razão 5, volume 0,5) → "2,5 mg em 0,5 mL";
+ * caso comum (volume 1) → "X mg em 1 mL" (compatível com a Fase B2). Vírgula PT-BR.
+ * Retorna '' se a razão for inválida.
  *
- * @param {number|string|null} mgPerMl - densidade (units_per_ml) em mg/ml
+ * @param {number|string|null} mgPerMl - razão mg/mL (dosage_per_pill)
+ * @param {number|string|null} [volumeMl=1] - volume do rótulo (concentration_volume_ml)
  * @returns {string}
- * @example formatConcentrationLabel(0.68) → '0,68 mg em 1 mL'
- * @example formatConcentrationLabel(null) → ''
+ * @example formatConcentrationLabel(0.68)      → '0,68 mg em 1 mL'
+ * @example formatConcentrationLabel(5, 0.5)    → '2,5 mg em 0,5 mL'
+ * @example formatConcentrationLabel(null)      → ''
  */
-export function formatConcentrationLabel(mgPerMl) {
-  const n = Number(typeof mgPerMl === 'string' ? mgPerMl.replace(',', '.') : mgPerMl)
-  if (!Number.isFinite(n) || n <= 0) return ''
-  return `${formatNumberPtBR(n)} mg em 1 mL`
+export function formatConcentrationLabel(mgPerMl, volumeMl = 1) {
+  const ratio = Number(typeof mgPerMl === 'string' ? mgPerMl.replace(',', '.') : mgPerMl)
+  if (!Number.isFinite(ratio) || ratio <= 0) return ''
+  const volNum = Number(typeof volumeMl === 'string' ? volumeMl.replace(',', '.') : volumeMl)
+  const vol = Number.isFinite(volNum) && volNum > 0 ? volNum : 1
+  const amount = ratio * vol
+  return `${formatNumberPtBR(amount)} mg em ${formatNumberPtBR(vol)} mL`
 }
 
 /**
@@ -228,6 +269,28 @@ export function formatDose(value, unit) {
  * @example formatIntakeDose(100,'UI',{dosage_unit:'ui/ml',units_per_ml:100})  → '100 UI (≈ 1 ml)'
  * @example formatIntakeDose(5,'ml',{dosage_unit:'mg/ml'})                      → '5 ml'
  */
+/**
+ * Densidade (unidades por mL) para converter gotas/UI → mL, **unit-aware** (012 Fase B3,
+ * ADR-065). Substitui o fallback blanket 20: a densidade explícita (`units_per_ml`) tem
+ * prioridade; faltando, o padrão depende da UNIDADE DE TOMADA — gotas≈20/mL (conta-gotas
+ * universal), UI≈100/mL (U-100). Sem valor e sem padrão seguro → `null` (o caller decide:
+ * erro explícito ou sem conversão — Const. IX, não chuta dose). mg NÃO usa isto (usa
+ * `dosage_per_pill`); ml é dose direta.
+ *
+ * @param {string|null} intakeUnit - 'gotas' | 'UI' | 'ml' | 'mg'
+ * @param {number|string|null} unitsPerMl - densidade explícita do cadastro
+ * @returns {number|null} densidade a aplicar, ou null se indefinível
+ */
+export function densityFor(intakeUnit, unitsPerMl) {
+  const explicit = Number(typeof unitsPerMl === 'string' ? unitsPerMl.replace(',', '.') : unitsPerMl)
+  if (explicit > 0) return explicit
+  switch ((intakeUnit || '').toLowerCase()) {
+    case 'gotas': return 20
+    case 'ui': return 100
+    default: return null
+  }
+}
+
 export function formatIntakeDose(qty, intakeUnit, medicine) {
   const isLiquid = Boolean(medicine?.dosage_unit?.endsWith('/ml'))
   if (!isLiquid) {
@@ -243,15 +306,14 @@ export function formatIntakeDose(qty, intakeUnit, medicine) {
   // mg → ml: divide pela CONCENTRAÇÃO (dosage_per_pill = mg por ml; já no cadastro).
   // gotas/UI → ml: divide pela razão física units_per_ml (fallback 20).
   // São campos distintos (012 Fase B2): mg não usa units_per_ml.
+  // mg → concentração (dosage_per_pill); gotas/UI → densidade unit-aware (ADR-065).
   const divisor =
     intake === 'mg'
       ? Number(medicine?.dosage_per_pill) > 0
         ? Number(medicine.dosage_per_pill)
         : null
-      : medicine?.units_per_ml && medicine.units_per_ml > 0
-        ? medicine.units_per_ml
-        : 20
-  if (!divisor) return base // sem concentração não há como exibir ≈ml
+      : densityFor(intake, medicine?.units_per_ml)
+  if (!divisor) return base // sem concentração/densidade não há como exibir ≈ml
   // Arredonda a 2 casas — sem isso, mg ÷ concentração gera dízima ("0,3676 ml").
   const ml = Math.round((numQty / divisor) * 100) / 100
   return `${base} (≈ ${formatDose(ml, 'ml')})`

--- a/packages/core/src/utils/doseZones.js
+++ b/packages/core/src/utils/doseZones.js
@@ -142,6 +142,8 @@ function createDoseItem(instance, protocol, tz) {
     presentation: medicine.presentation ?? null,
     dosagePerPill: medicine.dosage_per_pill ?? null,
     dosageUnit: medicine.dosage_unit ?? null,
+    // 012 Fase B3 (FR-031): denominador do rótulo p/ reexibir concentração (ex: Mounjaro 0,5 mL)
+    concentrationVolumeMl: medicine.concentration_volume_ml ?? null,
     // Líquidos (022): unidade de tomada do tratamento + densidade do medicamento
     // p/ exibir dose na unidade certa (gotas/ml/UI) e converter p/ ml.
     intakeUnit: protocol.intake_unit ?? null,

--- a/packages/core/src/utils/formUtils.js
+++ b/packages/core/src/utils/formUtils.js
@@ -10,3 +10,19 @@ export const getFieldDescribedBy = (fieldName, errors, hintId = null) =>
  * @returns {number} NaN quando vazio/ inválido (deixa a validação decidir)
  */
 export const coerceDecimal = (value) => parseFloat(String(value ?? '').replace(',', '.'))
+
+/**
+ * Limpa artefatos de ponto flutuante do JS (012 Fase B3; review Gemini #661).
+ * `1.2 * 0.3 === 0.36000000000000004`; `formatNumberPtBR` não arredonda, então a
+ * dízima vazaria pro chip/card e seria persistida. `toPrecision(12)` corta o ruído
+ * de ~15-17 dígitos mantendo precisão real; `parseFloat` remove zeros à direita.
+ * Aplicar em TODA multiplicação/divisão de concentração (amount×volume, amount÷denom)
+ * antes de exibir OU persistir. Não-finito passa direto (deixa a validação decidir).
+ * @param {number|string|null|undefined} value
+ * @returns {number}
+ * @example cleanFloat(1.2 * 0.3) → 0.36
+ */
+export const cleanFloat = (value) => {
+  const n = Number(value)
+  return Number.isFinite(n) ? parseFloat(n.toPrecision(12)) : n
+}

--- a/packages/core/src/utils/index.js
+++ b/packages/core/src/utils/index.js
@@ -69,6 +69,7 @@ export {
 export {
   getFieldDescribedBy,
   coerceDecimal,
+  cleanFloat,
 } from './formUtils.js'
 
 // String utilities

--- a/packages/core/src/utils/index.js
+++ b/packages/core/src/utils/index.js
@@ -99,6 +99,7 @@ export {
   formatDoseItem,
   formatDoseHint,
   formatConcentration,
+  formatMedicineConcentration,
   formatActiveIngredientHint,
   formatActiveIngredientFormula,
   formatActiveIngredientShort,
@@ -108,6 +109,7 @@ export {
   formatStockQuantity,
   formatConcentrationLabel,
   formatStockApplications,
+  densityFor,
 } from './doseUnit.js'
 
 // Date presentation PT-BR (Fase 2)

--- a/plans/specs/012-diabetes-t2-support/analysis-b3.md
+++ b/plans/specs/012-diabetes-t2-support/analysis-b3.md
@@ -1,0 +1,56 @@
+# Analysis — 012 Fase B3 (C1.5 Reality Check)
+
+**Tier:** 2 (migração + RPC + cross-platform) · **ADRs:** ADR-065, ADR-066 (accepted)
+**Data:** 2026-06-13 · Gate: C1.5 antes do C2.
+
+## 1. Evidence Table (verificado contra repo + prod)
+
+| Claim (spec/plan) | Real (file:line / prod) | ✅ | Nota |
+|---|---|---|---|
+| `units_per_ml` tem DEFAULT 20 | prod `information_schema`: `column_default='20'` | ✅ | blanket confirmado |
+| Backfill é pequeno | prod: 6 líquidos / 111 medicines; 0 ui/ml carimbado20; 0 mg/ml sem concentração | ✅ | 3 linhas 20→NULL (Durateston, Xarope, Tresiba=ml/sem-trat); Dipirona(gotas)=20 e Lantus(UI)=100 ficam | 
+| RPC blanket 20 | `consume_stock_fifo` live: `COALESCE(NULLIF(units_per_ml,0),20)` no SELECT; ramo `IN ('gotas','ui') → p_quantity/v_units_per_ml` | ✅ | trocar por unit-aware (gotas→20, UI→100) na branch |
+| RPC mg usa concentração | live: ramo `mg` já usa `v_concentration=dosage_per_pill`, erro se NULL | ✅ | inalterado (B2) |
+| `doseToMl` blanket 20 | `adherenceLogic.js:273` `density = unitsPerMl>0 ? unitsPerMl : 20` | ✅ | unit-aware |
+| `formatIntakeDose` blanket 20 | `doseUnit.js:251` fallback `units_per_ml>0 ? ... : 20` | ✅ | unit-aware |
+| coluna `concentration_volume_ml` não existe | prod: `col_ja_existe=false` | ✅ | ADD COLUMN nullable |
+| RPC NÃO depende de `concentration_volume_ml` | live usa `dosage_per_pill` (já normalizado) | ✅ | denominador é só form+display |
+| `intake_unit` CHECK = gotas/ml/UI/mg | migração B2 (em prod) | ✅ | domínio fechado → ELSE da RPC = ml |
+| medicineSchema tem `units_per_ml` | `packages/core/src/schemas/medicineSchema.js` (B2) | ✅ | +`concentration_volume_ml` nullable (R-082/R-267) |
+
+## 2. Behavioral Failure Modes (R-270 — por função nova/alterada)
+
+### `densityFor(intakeUnit, unitsPerMl)` (novo helper core — FR-024)
+| Input | Degenerado | Esperado | Teste |
+|---|---|---|---|
+| unitsPerMl | NULL / 0 | gotas→20, UI→100, mg→(n/a, usa dpp), else→erro | T037 |
+| intakeUnit | 'ml' | sem densidade (dose direta) | T037 |
+| intakeUnit | fora do enum | não ocorre (CHECK), mas defensivo→erro | T037 |
+
+### RPC `consume_stock_fifo` ramo líquido (FR-024)
+| Input | Degenerado | Esperado | Teste |
+|---|---|---|---|
+| units_per_ml | NULL, UI | usa 100 (não 20) | T037 (pgTAP/jest BEGIN..ROLLBACK) |
+| units_per_ml | NULL, gotas | usa 20 | T037 |
+| v_concentration (mg) | NULL | RAISE (já) | T037 |
+| v_remaining | arredonda 0 | RAISE (já) | existente |
+
+### Normalização denominador (FR-031 — form)
+| Input | Degenerado | Esperado | Teste |
+|---|---|---|---|
+| denominador | 0 / vazio | erro (não divide por zero) | T037d |
+| denominador | 1 (default) | passthrough; coluna NULL | T037d |
+| denominador | vírgula '0,5' | coerceDecimal→0.5 (R-276) | T037d |
+| concentration_volume_ml | NULL na exibição | `× COALESCE(...,1)` = "por 1 mL" | T037d |
+
+## 3. Data-Migration Completeness
+- **DROP DEFAULT** `units_per_ml` + **UPDATE backfill** (derivado de `protocols.intake_unit`: UI→100, gotas→20, mg/ml-sem-trat→NULL) + **ADD COLUMN** `concentration_volume_ml NUMERIC NULL`, numa migração idempotente.
+- **Verificação** pós-apply: `SELECT units_per_ml, count(*) ... GROUP BY` (esperar 3×NULL novos, Dipirona=20, Lantus=100, Mounjaro=NULL); `col_ja_existe=true`.
+- RPC reescrita do `pg_get_functiondef` ao vivo (AP-217), **assinatura intacta** (AP-221) — sem novo arg, sem overload (AP-209).
+- Autorização explícita do PO antes de aplicar (prod mutation).
+
+## 4. Coverage (FR → task)
+FR-023→T031/T032/T033 · FR-024→T034/T035/T037 · FR-025→T036 · FR-031→T037b(migr)/T037c(form)/T037d(test). SC-002c (B4) não entra aqui.
+
+## Resultado
+Sem CRITICAL/HIGH. Evidência ✅; cross-file consistente; migração de dados completa com verificação; failure modes mapeados com teste. **Apto a C2.** Riscos MEDIUM: tie-break multi-tratamento no backfill (mitigado — dados atuais não têm o caso) e UI→100 default silencioso (mitigado por FR-025 form obrigatório).


### PR DESCRIPTION
# 📦 feat(012-fase-b3): concentração com denominador + densidade unit-aware + reorder form

## 🎯 Resumo

Fase B3 do épico 012 (DMT2). Suporta líquidos cuja concentração é rotulada com denominador ≠ 1 mL (ex: Mounjaro `2,5mg / 0,5mL`), torna a densidade gotas/UI unit-aware (sem mais o `COALESCE(...,20)` cego) e reordena o form web de medicamento espelhando o mobile.

---

## 📋 Tarefas Implementadas

### Modelo de concentração (FR-031 / ADR-066)
- [x] Coluna `concentration_volume_ml` (NUMERIC nullable; NULL = "por 1 mL")
- [x] Form normaliza `dosage_per_pill = amount ÷ denominador`; reexibe `amount = razão × volume`
- [x] Mounjaro `0,5 mL` é a única exceção BR (default 1 mL)

### Densidade unit-aware (FR-023/024/025 / ADR-065)
- [x] `units_per_ml` default DROP (NULL); backfill derivado de `protocols.intake_unit` (UI→100, gotas→20, demais→NULL)
- [x] `densityFor()`: explícito > gotas 20 > UI 100 > mg `dosage_per_pill`; sem padrão → erro
- [x] RPC `consume_stock_fifo` reescrita do functiondef ao vivo; gotas/UI unit-aware

### Chip de concentração (sweep)
- [x] Helper central `formatConcentration(value, unit, volumeMl)` volume-aware reexibe rótulo (`2,5 mg / 0,5ml`)
- [x] Sweep em todos os call sites web+mobile (cards medicamento/tratamento/dose/estoque, dropdowns de wizard e compra, detalhes)
- [x] Plumbing do campo nos selects/transformers que o dropavam

### UX form web
- [x] Reorder espelhando mobile: Identificação → Dosagem → Classificação, com subtítulos
- [x] Hints/badges ANVISA preservados

### Testes e Qualidade
- [x] `validate:agent` — 1291 testes (82 arquivos) ✓
- [x] Lint 0 errors · build web ✓
- [x] Migração aplicada em prod 2026-06-13 (autorização PO) + verificada

---

## 🔧 Arquivos Principais

\`\`\`
packages/core/src/
├── utils/doseUnit.js            # formatConcentration 3-arg + formatMedicineConcentration + densityFor
├── utils/doseZones.js           # +concentrationVolumeMl no DoseItem (cronograma)
└── repositories/createStockRepository.js  # +concentration_volume_ml no select
apps/web/src/features/medications/components/
├── sections/MedicineFormBasicInfo.jsx     # Identificação (name + active_ingredient)
└── sections/MedicineFormDosageInfo.jsx    # Dosagem + Classificação (reorder mobile)
docs/migrations/20260613_b3_units_per_ml_null_denominador.sql  # APLICADA EM PROD
\`\`\`

---

## ✅ Checklist de Verificação

### Código
- [x] Todos os testes passam (`validate:agent` — 1291 ✓)
- [x] Lint sem erros
- [x] Build bem-sucedido

### Funcionalidade
- [x] Mounjaro exibe `2,5 mg / 0,5ml` em todos os chips (web+mobile)
- [x] Densidade gotas/UI unit-aware no débito de estoque
- [x] Form web reordenado, hints preservados

---

## 🏷️ Informações de Versionamento

**Tipo:** Minor (nova capacidade de modelagem de concentração)
**Plataformas afetadas:** Web/PWA · Mobile · Shared/Core
**Changelog:** CHANGELOG.md [Unreleased] atualizado (SQP Fase B3)

---

## 📝 Notas para Reviewers

1. **Migração:** já aplicada em prod (idempotente). RPC reescrita do `pg_get_functiondef` ao vivo (AP-217), assinatura intacta.
2. **Sweep do chip:** atenção aos selects/transformers que reconstroem objeto — campo plumbado neles (estoque web/mobile, tratamentos mobile, cronograma).
3. **Deixado clássico de propósito:** snapshots logados (histórico de doses, consulta médica, emergency card) — mostram o que foi registrado, não o cadastro.

/cc @gemini-code-assist

---

## 🤖 AI Review Response (commit 52371258)

| Sugestão | Prioridade | Decisão | Motivo |
|----------|-----------|---------|--------|
| dosage_per_pill vazio salva 0 (suplemento) | High | Aplicado | guard hasAmount → null |
| float artifact reexibe (mobile) | Medium | Aplicado | cleanFloat |
| float artifact reexibe (web) | Medium | Aplicado | cleanFloat |
| float artifact formatConcentration | Medium | Aplicado | cleanFloat |
| float artifact formatConcentrationLabel | Medium | Aplicado | cleanFloat |
| sufixo fixo mg/mL no preview | Medium | Aplicado | unidade base de dosage_unit |

Helper compartilhado `cleanFloat` (@dosiq/core) aplicado em toda mult/divisão de concentração, display + persist.