### PR TITLE
fix(stock-alert): cron conta dose em ml + frequência (012 B4 slice 1 — FR-013c/ADR-067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ## [Unreleased]
 
+### 012 Fase B4 — estoque dose-primário (slice 1: serverless)
+
+#### Backend/Infra (bot cron — serverless)
+- **Fixed** (`no-user-impact` de versão app; risco clínico, FR-013c/ADR-067): o cron de alerta de estoque (`_processUserStockAlert` em `server/bot/_reminderHelpers.js`) somava a dose na **unidade de tomada crua** (UI/gotas) contra o saldo em **ml** → `floor(ml ÷ UI)` = "0 dias" falso para insulina/GLP-1 (ex.: Lantus 5,3 ml com 10 UI/dia disparava alerta crítico quando ainda restam ~53 dias). Agora reusa `calculateDailyIntake` (converte intake→ml via `doseToMl` unit-aware + aplica `frequencyDailyFactor`) e `calculateDaysRemaining` do `@dosiq/core`. Read-path completo (R-267): selects do cron passam a trazer `protocols.intake_unit`/`active` e `medicines.units_per_ml`/`dosage_unit`/`dosage_per_pill`.
+- **Fixed** (`no-user-impact`): payload `stock_alert` exibia o saldo cru em ml rotulado como "doses" ("Restam 5,3 doses"); agora exibe a contagem real de **doses** (`floor(saldo ÷ tamanho da tomada)`, com `cleanFloat` antes do floor — R-277).
+
 ### 012 Fase B3 — units_per_ml NULL + fallback unit-aware + concentração com denominador
 
 #### Backend/Infra (DB + RPC)

--- a/server/bot/__tests__/tasks.test.js
+++ b/server/bot/__tests__/tasks.test.js
@@ -226,5 +226,48 @@ describe('Tasks Service - Wave 11 Refactor & Phase 3', () => {
         })
       });
     });
+
+    // 012 B4 / FR-013c (ADR-067): líquido em UI não pode contar ml÷UI cru.
+    it('não dispara alerta para insulina líquida com runway real alto (FR-013c)', async () => {
+      setMockData([{ user_id: 'user1', timezone: 'America/Sao_Paulo' }]);
+      // Lantus U-100: 10 UI/dia, 1x/dia, diário.
+      setMockData([
+        { user_id: 'user1', medicine_id: 'med1', time_schedule: ['22:00'], dosage_per_intake: 10, intake_unit: 'UI', frequency: 'diário', active: true }
+      ]);
+      // Saldo 5,3 ml; densidade U-100 (units_per_ml=100) → 10 UI = 0,10 ml/dia → 53 dias.
+      setMockData([
+        { user_id: 'user1', medicine_id: 'med1', quantity: 5.3, medicine: { name: 'Lantus', dosage_unit: 'ui/ml', units_per_ml: 100, dosage_per_pill: null } }
+      ]);
+
+      await checkStockAlerts({}, { correlationId: 'test-corr', notificationDispatcher: mockDispatcher });
+
+      // Antes: floor(5,3 ÷ 10 UI) = 0 dias → alerta crítico falso. Agora: 53 dias → silêncio.
+      expect(mockDispatcher.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('dispara para líquido realmente baixo exibindo DOSES (não ml cru)', async () => {
+      setMockData([{ user_id: 'user1', timezone: 'America/Sao_Paulo' }]);
+      // 25 UI/dia, density U-100 → 0,25 ml/dia (exato em binário; sem armadilha de float).
+      setMockData([
+        { user_id: 'user1', medicine_id: 'med1', time_schedule: ['22:00'], dosage_per_intake: 25, intake_unit: 'UI', frequency: 'diário', active: true }
+      ]);
+      // Saldo 1,25 ml → 0,25 ml/dia → 5 dias; doses restantes = floor(1,25 ÷ 0,25) = 5.
+      setMockData([
+        { user_id: 'user1', medicine_id: 'med1', quantity: 1.25, medicine: { name: 'Lantus', dosage_unit: 'ui/ml', units_per_ml: 100, dosage_per_pill: null } }
+      ]);
+
+      await checkStockAlerts({}, { correlationId: 'test-corr', notificationDispatcher: mockDispatcher });
+
+      expect(mockDispatcher.dispatch).toHaveBeenCalledWith({
+        userId: 'user1',
+        kind: 'stock_alert',
+        data: expect.objectContaining({
+          medicineName: 'Lantus',
+          remaining: 5,          // 5 doses, NÃO 1,25 ml rotulado "doses"
+          daysRemaining: 5
+        }),
+        context: expect.objectContaining({ jobType: 'stock_alert_dispatcher' })
+      });
+    });
   });
 });

--- a/server/bot/_reminderHelpers.js
+++ b/server/bot/_reminderHelpers.js
@@ -3,7 +3,8 @@ import { createLogger } from '../bot/logger.js';
 import { shouldSendNotification, shouldSendGroupedNotification } from '../services/notificationDeduplicator.js';
 import { getCurrentTime, getCurrentTimeInTimezone, parseLocalDate, getTodayLocal, getCurrentDatePartsInTimezone, getServerTimestamp, parseISO, parseTimestamp, addMinutes } from '../utils/dateUtils.js';
 import { partitionDoses } from './utils/partitionDoses.js';
-import { isProtocolActiveOnWeekday, getProtocolDays } from '../utils/protocolActiveHelper.js';
+import { isProtocolActiveOnWeekday } from '../utils/protocolActiveHelper.js';
+import { calculateDailyIntake, calculateDaysRemaining, isLiquidMedicine, doseToMl, cleanFloat } from '@dosiq/core';
 // Formatting helpers removed — moved to Layer 2
 
 const logger = createLogger('ReminderHelpers');
@@ -508,42 +509,50 @@ export async function runDailyDigestViaDispatcher(dispatcher, correlationId) {
 }
 
 async function _processUserStockAlert(userId, medicineId, stock, protocols, dispatcher, correlationId) {
-  const dailyConsumption = protocols.reduce((sum, p) => {
-    const intakesPerDay = (p.time_schedule || []).length;
-    const dosage = p.dosage_per_intake || 1;
-    const frequency = (p.frequency || 'diário').toLowerCase();
+  // 012 B4 / ADR-067: consumo diário via core (líquido → ml + cadência da frequência).
+  // Antes somava a dose na unidade de tomada CRUA (UI/gotas) contra o saldo em ml →
+  // `floor(ml ÷ UI)` = "0 dias" falso p/ insulina/GLP-1 (FR-013c). `calculateDailyIntake`
+  // converte intake→ml via doseToMl (ADR-065 unit-aware) e aplica frequencyDailyFactor.
+  const medicine = {
+    dosage_unit: stock.dosageUnit,
+    units_per_ml: stock.unitsPerMl,
+    dosage_per_pill: stock.dosagePerPill,
+  };
 
-    if (['diário', 'diariamente', 'daily'].includes(frequency)) {
-      return sum + (intakesPerDay * dosage);
-    } else if (['semanal', 'semanalmente', 'weekly'].includes(frequency)) {
-      const daysSource = getProtocolDays(p);
-      const daysCount = daysSource.length > 0 ? daysSource.length : 1;
-      return sum + ((intakesPerDay * dosage * daysCount) / 7);
-    } else if (['dias_alternados', 'dia_sim_dia_nao', 'every_other_day', 'alternating'].includes(frequency)) {
-      return sum + ((intakesPerDay * dosage) / 2);
-    }
-    return sum; // personalizado, quando necessário, etc.
-  }, 0);
+  const dailyIntake = calculateDailyIntake(medicineId, protocols, medicine);
+  if (dailyIntake <= 0) return;
 
-  if (dailyConsumption <= 0) return;
+  const daysRemaining = calculateDaysRemaining(stock.qty, dailyIntake);
+  if (!Number.isFinite(daysRemaining) || daysRemaining >= 7) return;
 
-  const daysRemaining = Math.floor(stock.qty / dailyConsumption);
+  // Dose-primário (ADR-067): exibir DOSES restantes (saldo ÷ tamanho de uma tomada),
+  // não o saldo cru em ml rotulado "doses". Líquido converte a dose p/ ml (mesma
+  // unidade do saldo); sólido usa unidades. Densidade ausente → doseToMl devolve a
+  // dose crua (sem chute); fallback p/ saldo cru se não houver tamanho de dose.
+  const rep = protocols[0] || {};
+  const dosePorTomada = rep.dosage_per_intake || 1;
+  const doseSize = isLiquidMedicine(medicine)
+    ? doseToMl(dosePorTomada, rep.intake_unit, medicine.units_per_ml, medicine.dosage_per_pill)
+    : dosePorTomada;
+  // cleanFloat antes do floor (R-277): sem isso a dízima de float (0,3÷0,1=2,9999…)
+  // gera off-by-one no nº de doses exibido.
+  const dosesRemaining = doseSize > 0
+    ? Math.floor(cleanFloat(stock.qty / doseSize))
+    : Math.floor(stock.qty);
 
-  if (daysRemaining < 7) {
-    logger.info(`Disparando alerta de estoque baixo: ${stock.name} (${daysRemaining} dias restantes)`, {
-      userId, medicineId, correlationId
-    });
+  logger.info(`Disparando alerta de estoque baixo: ${stock.name} (${daysRemaining} dias / ${dosesRemaining} doses)`, {
+    userId, medicineId, correlationId
+  });
 
-    const data = {
-      medicineName: stock.name,
-      remaining: stock.qty,
-      daysRemaining
-    };
+  const data = {
+    medicineName: stock.name,
+    remaining: dosesRemaining,
+    daysRemaining
+  };
 
-    await dispatcher.dispatch({
-      userId, kind: 'stock_alert', data, context: { correlationId, jobType: 'stock_alert_dispatcher' }
-    });
-  }
+  await dispatcher.dispatch({
+    userId, kind: 'stock_alert', data, context: { correlationId, jobType: 'stock_alert_dispatcher' }
+  });
 }
 
 function _buildProtocolsAndStockMaps(allProtocols, allStock) {
@@ -557,7 +566,18 @@ function _buildProtocolsAndStockMaps(allProtocols, allStock) {
   const stockByMedicine = {};
   for (const s of allStock || []) {
     const key = `${s.user_id}_${s.medicine_id}`;
-    if (!stockByMedicine[key]) stockByMedicine[key] = { qty: 0, name: s.medicine?.name || 'Medicamento' };
+    if (!stockByMedicine[key]) {
+      // Campos do medicine p/ conversão líquida (012 B4 / R-267): unitsPerMl/dosageUnit/
+      // dosagePerPill alimentam calculateDailyIntake + doseToMl no alerta de estoque.
+      const med = s.medicine || {};
+      stockByMedicine[key] = {
+        qty: 0,
+        name: med.name || 'Medicamento',
+        unitsPerMl: med.units_per_ml,
+        dosageUnit: med.dosage_unit,
+        dosagePerPill: med.dosage_per_pill,
+      };
+    }
     stockByMedicine[key].qty += Number(s.quantity || 0);
   }
 
@@ -631,15 +651,18 @@ export async function checkStockAlertsViaDispatcher(dispatcher, correlationId) {
     const userIds = users.map(u => u.user_id);
     logger.info(`Verificando alertas de estoque para ${userIds.length} usuários`, { correlationId });
 
+    // R-267 read-path: intake_unit + active (calculateDailyIntake filtra p.active e
+    // converte por intake_unit); units_per_ml/dosage_unit/dosage_per_pill p/ a conversão
+    // líquida (ADR-065/ADR-067 — antes o cron contava UI cru contra ml).
     const { data: allProtocols } = await supabase
       .from('protocols')
-      .select('user_id, medicine_id, time_schedule, dosage_per_intake, frequency, weekdays')
+      .select('user_id, medicine_id, time_schedule, dosage_per_intake, intake_unit, frequency, weekdays, active')
       .eq('active', true)
       .in('user_id', userIds);
 
     const { data: allStock } = await supabase
       .from('stock')
-      .select('user_id, medicine_id, quantity, opened_at, medicine:medicines(name, shelf_life_days)')
+      .select('user_id, medicine_id, quantity, opened_at, medicine:medicines(name, shelf_life_days, units_per_ml, dosage_unit, dosage_per_pill)')
       .in('user_id', userIds);
 
     const { protocolsByMedicine, stockByMedicine } = _buildProtocolsAndStockMaps(allProtocols, allStock);


### PR DESCRIPTION
## Contexto
012 Fase B4 — **slice 1 (serverless)**, fatiado para mergear antes do core/web/mobile.
ADR-067 (estoque dose-primário) absorve a regressão FR-013c.

## Problema (risco clínico)
O cron de alerta de estoque (`_processUserStockAlert`) somava a dose na **unidade de tomada crua** (UI/gotas) contra o saldo em **ml** → `floor(ml ÷ UI)` = **"0 dias" falso** para insulina/GLP-1.
Ex.: **Lantus 5,3 ml** com 10 UI/dia disparava alerta crítico quando ainda restam **~53 dias**; o push exibia "Restam 5,3 doses" (ml rotulado errado).

## Correção
- Cron reusa `calculateDailyIntake` (converte intake→ml via `doseToMl` unit-aware ADR-065 + aplica `frequencyDailyFactor`) e `calculateDaysRemaining` do `@dosiq/core` — fim do cálculo paralelo divergente.
- **Read-path R-267**: selects do cron passam a trazer `protocols.intake_unit`/`active` e `medicines.units_per_ml`/`dosage_unit`/`dosage_per_pill`.
- Payload `stock_alert` exibe **doses reais** (`floor(saldo ÷ tamanho da tomada)` com `cleanFloat` antes do floor — R-277), não ml rotulado "doses". Shape do schema inalterado (não-breaking).

## Testes
`server/bot/__tests__/tasks.test.js` (vitest) — **5/5**:
- Lantus 5,3 ml/10 UI/dia → 53 dias → **não dispara** (antes: 0 dias falso)
- líquido baixo (1,25 ml, 25 UI/dia) → dispara exibindo **5 doses**, 5 dias
- Aspirina sólido (existente) → sem regressão

Lint 0 errors.

## SQP (R-221)
Backend/serverless (bot cron) · **no-user-impact** de versão app · CHANGELOG \[Unreleased] 012 B4 slice-1 (2 Fixed) · serverless não roda em dev → cobertura por teste obrigatória.

🤖 Generated with [Claude Code](https://claude.com/claude-code)