### PR TITLE
feat(measures): pressão arterial (PA) — espelho web 4.9.0 [PR B]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 ## [Unreleased]
 
 ### Adicionado
-- **Pressão arterial como medida** (spec 032, mobile `0.18.0`): registro com 2 campos
-  (sistólica "por" diastólica, mmHg), contexto opcional (ao acordar / em repouso / após exercício /
-  ao dormir / após medicação), tendência com 2 séries (sistólica + diastólica, cores neutras — sem
-  classificação de risco, SaMD) e exibição composta "120 por 80 mmHg" em toda a UI de medidas.
+- **Pressão arterial como medida** (spec 032, mobile `0.18.0` + web `4.9.0`): registro com 2 campos
+  (sistólica "por" diastólica, mmHg), contexto opcional (ao acordar / em repouso / indo dormir /
+  após exercício / após medicação), tendência com 2 séries (sistólica + diastólica, cores neutras —
+  sem classificação de risco, SaMD) e exibição composta "120 por 80 mmHg" em toda a UI de medidas
+  (mobile + web; cards mostram rótulo curto "Pressão" + data/hora no histórico).
 
 ### Alterado
 - **`biomarkers_log.context` agora é domínio extensível** (ADR-070): removido o `CHECK` do banco;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dosiq/web",
-  "version": "4.8.1",
+  "version": "4.9.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/features/measures/components/LastMeasureCard.jsx
+++ b/apps/web/src/features/measures/components/LastMeasureCard.jsx
@@ -4,14 +4,11 @@
 // SaMD (ADR-062): sem cor/copy de qualidade. Tap leva ao histórico do tipo correto (deeplink).
 
 import { Ruler, ChevronRight, Plus } from 'lucide-react'
-import { BIOMARKER_TYPE_LABELS, formatTimePtBR } from '@dosiq/core'
+import { biomarkerCardLabel, formatBiomarkerDisplay, formatTimePtBR } from '@dosiq/core'
 import './LastMeasureCard.css'
 
-function formatMeasure(m) {
-  const v = String(m.value).replace('.', ',')
-  if (m.value_secondary != null) return `${v}/${String(m.value_secondary).replace('.', ',')} ${m.unit}`
-  return `${v} ${m.unit}`
-}
+// Display "S por D unit" (PA) / "V unit" — helper core (fonte única, 032).
+const formatMeasure = formatBiomarkerDisplay
 
 /**
  * @param {Object} props
@@ -30,7 +27,7 @@ export default function LastMeasureCard({ measure, onOpenHistory, onRegister }) 
     )
   }
 
-  const label = BIOMARKER_TYPE_LABELS[measure.type] || measure.type
+  const label = biomarkerCardLabel(measure.type)
   return (
     <button type="button" className="lmc-card" onClick={() => onOpenHistory?.(measure.type)}>
       <span className="lmc-card__icon"><Ruler size={18} aria-hidden="true" /></span>

--- a/apps/web/src/features/measures/components/MeasureLogModal.css
+++ b/apps/web/src/features/measures/components/MeasureLogModal.css
@@ -83,6 +83,35 @@
   color: var(--color-on-surface-variant, #546e7a);
 }
 
+/* PA — 2 campos (sistólica "por" diastólica) */
+.mlm__value-row--pa {
+  gap: 0.75rem;
+}
+
+.mlm__pa-field {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.mlm__value--pa {
+  width: 5rem;
+  font-size: 2.5rem;
+}
+
+.mlm__pa-label {
+  font-size: 0.75rem;
+  color: var(--color-on-surface-variant, #546e7a);
+  margin-top: 0.25rem;
+}
+
+.mlm__pa-sep {
+  align-self: center;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-on-surface-variant, #546e7a);
+}
+
 /* Altura-neutra: a linha existe sempre (espaço reservado), erro não empurra o layout. */
 .mlm__error {
   min-height: 1.2rem;

--- a/apps/web/src/features/measures/components/MeasureLogModal.jsx
+++ b/apps/web/src/features/measures/components/MeasureLogModal.jsx
@@ -12,12 +12,20 @@ import {
   BIOMARKER_TYPE_LABELS,
   BIOMARKER_CONTEXTS,
   BIOMARKER_CONTEXT_LABELS,
+  BIOMARKER_PA_CONTEXTS,
+  BIOMARKER_PA_CONTEXT_LABELS,
 } from '@dosiq/core'
 import Modal from '@shared/components/ui/Modal'
 import './MeasureLogModal.css'
 
-// Tipos com UI no v1. PA/batimentos não entram aqui (schema-ready no core).
-const UI_TYPES = ['glicemia', 'peso']
+// Tipos com UI. PA entra na spec 032 (2 campos). batimentos = schema-ready.
+const UI_TYPES = ['glicemia', 'peso', 'pressao_arterial']
+
+// Contexto por família (ADR-070). Tipos ausentes = sem contexto.
+const CONTEXTS_BY_TYPE = {
+  glicemia: { values: BIOMARKER_CONTEXTS, labels: BIOMARKER_CONTEXT_LABELS },
+  pressao_arterial: { values: BIOMARKER_PA_CONTEXTS, labels: BIOMARKER_PA_CONTEXT_LABELS },
+}
 
 /**
  * @param {Object} props
@@ -35,16 +43,23 @@ export default function MeasureLogModal({ isOpen, onClose, onSaved, editItem = n
 
   const [type, setType] = useState(fixedType || defaultType)
   const [value, setValue] = useState(editItem ? String(editItem.value).replace('.', ',') : '')
+  const [valueSec, setValueSec] = useState(
+    editItem?.value_secondary != null ? String(editItem.value_secondary).replace('.', ',') : ''
+  )
   const [context, setContext] = useState(editItem?.context ?? null)
   const [saving, setSaving] = useState(false)
   const [errorMsg, setErrorMsg] = useState(null)
 
   const unit = BIOMARKER_TYPE_UNITS[type]
-  const showContext = type === 'glicemia'
+  const isPa = type === 'pressao_arterial'
+  const ctxConfig = CONTEXTS_BY_TYPE[type] ?? null
+  const showContext = !!ctxConfig
 
   function handleSelectType(t) {
     setType(t)
-    if (t !== 'glicemia') setContext(null)
+    // Contexto é por família — trocar de tipo zera o contexto (evita inválido p/ o novo tipo).
+    setContext(null)
+    if (t !== 'pressao_arterial') setValueSec('')
     setErrorMsg(null)
   }
 
@@ -56,13 +71,22 @@ export default function MeasureLogModal({ isOpen, onClose, onSaved, editItem = n
   async function handleSave() {
     const num = coerceDecimal(value)
     if (Number.isNaN(num) || num <= 0) {
-      setErrorMsg('Digite um valor válido maior que zero.')
+      setErrorMsg(isPa ? 'Digite a sistólica (maior que zero).' : 'Digite um valor válido maior que zero.')
       return
+    }
+    // PA: diastólica obrigatória e válida (refine do core exige ambas).
+    let secNum = null
+    if (isPa) {
+      secNum = coerceDecimal(valueSec)
+      if (Number.isNaN(secNum) || secNum <= 0) {
+        setErrorMsg('Digite a diastólica (maior que zero).')
+        return
+      }
     }
     try {
       setSaving(true)
       setErrorMsg(null)
-      const payload = { type, value: num, unit, context: showContext ? context : null }
+      const payload = { type, value: num, value_secondary: secNum, unit, context: showContext ? context : null }
       // Criação: measured_at omitido → DB usa DEFAULT now() (sem new Date no app, R-020).
       const saved = await onSaved?.(isEdit ? { id: editItem.id, ...payload } : payload)
       onClose?.(saved)
@@ -97,34 +121,70 @@ export default function MeasureLogModal({ isOpen, onClose, onSaved, editItem = n
           <p className="mlm__locked-type">{BIOMARKER_TYPE_LABELS[type]}</p>
         )}
 
-        {/* Valor grande + unidade fixa (layout B) */}
-        <div className="mlm__value-row">
-          <input
-            className={`mlm__value${errorMsg ? ' mlm__value--error' : ''}`}
-            type="text"
-            inputMode="decimal"
-            value={value}
-            onChange={(e) => {
-              // Só dígitos, vírgula e ponto (coerceDecimal normaliza no salvar — R-276).
-              setValue(e.target.value.replace(/[^0-9.,]/g, ''))
-              if (errorMsg) setErrorMsg(null)
-            }}
-            placeholder="0"
-            maxLength={6}
-            autoFocus
-            disabled={saving}
-            aria-label={`Valor da medida em ${unit}`}
-          />
-          <span className="mlm__unit">{unit}</span>
-        </div>
+        {/* Valor grande + unidade fixa (layout B). PA = 2 campos (sistólica "por" diastólica). */}
+        {isPa ? (
+          <div className="mlm__value-row mlm__value-row--pa">
+            <span className="mlm__pa-field">
+              <input
+                className={`mlm__value mlm__value--pa${errorMsg ? ' mlm__value--error' : ''}`}
+                type="text"
+                inputMode="decimal"
+                value={value}
+                onChange={(e) => { setValue(e.target.value.replace(/[^0-9.,]/g, '')); if (errorMsg) setErrorMsg(null) }}
+                placeholder="120"
+                maxLength={3}
+                autoFocus
+                disabled={saving}
+                aria-label="Sistólica em mmHg"
+              />
+              <span className="mlm__pa-label">Sistólica</span>
+            </span>
+            <span className="mlm__pa-sep">por</span>
+            <span className="mlm__pa-field">
+              <input
+                className={`mlm__value mlm__value--pa${errorMsg ? ' mlm__value--error' : ''}`}
+                type="text"
+                inputMode="decimal"
+                value={valueSec}
+                onChange={(e) => { setValueSec(e.target.value.replace(/[^0-9.,]/g, '')); if (errorMsg) setErrorMsg(null) }}
+                placeholder="80"
+                maxLength={3}
+                disabled={saving}
+                aria-label="Diastólica em mmHg"
+              />
+              <span className="mlm__pa-label">Diastólica</span>
+            </span>
+            <span className="mlm__unit">{unit}</span>
+          </div>
+        ) : (
+          <div className="mlm__value-row">
+            <input
+              className={`mlm__value${errorMsg ? ' mlm__value--error' : ''}`}
+              type="text"
+              inputMode="decimal"
+              value={value}
+              onChange={(e) => {
+                // Só dígitos, vírgula e ponto (coerceDecimal normaliza no salvar — R-276).
+                setValue(e.target.value.replace(/[^0-9.,]/g, ''))
+                if (errorMsg) setErrorMsg(null)
+              }}
+              placeholder="0"
+              maxLength={6}
+              autoFocus
+              disabled={saving}
+              aria-label={`Valor da medida em ${unit}`}
+            />
+            <span className="mlm__unit">{unit}</span>
+          </div>
+        )}
 
         {/* Caption de erro — altura-neutra não empurra o layout */}
         <p className="mlm__error" role={errorMsg ? 'alert' : undefined}>{errorMsg || ' '}</p>
 
-        {/* Contexto (chips, opcional, só glicemia) */}
+        {/* Contexto (chips, opcional) — por família (glicemia/PA) */}
         {showContext && (
           <div className="mlm__contexts">
-            {BIOMARKER_CONTEXTS.map((c) => (
+            {ctxConfig.values.map((c) => (
               <button
                 key={c}
                 type="button"
@@ -132,7 +192,7 @@ export default function MeasureLogModal({ isOpen, onClose, onSaved, editItem = n
                 className={`mlm__ctx-chip${context === c ? ' mlm__ctx-chip--active' : ''}`}
                 aria-pressed={context === c}
               >
-                {BIOMARKER_CONTEXT_LABELS[c]}
+                {ctxConfig.labels[c]}
               </button>
             ))}
           </div>

--- a/apps/web/src/features/measures/components/MeasureTimelineCard.jsx
+++ b/apps/web/src/features/measures/components/MeasureTimelineCard.jsx
@@ -4,13 +4,10 @@
 // SaMD (ADR-062): cor diferencia TIPO, nunca qualidade. Read-only (registro já ocorrido).
 
 import { Ruler } from 'lucide-react'
-import { BIOMARKER_TYPE_LABELS, BIOMARKER_CONTEXT_LABELS } from '@dosiq/core'
+import { biomarkerCardLabel, formatBiomarkerContext, formatBiomarkerDisplay } from '@dosiq/core'
 
-function formatMeasure(m) {
-  const v = String(m.value).replace('.', ',')
-  if (m.value_secondary != null) return `${v}/${String(m.value_secondary).replace('.', ',')} ${m.unit}`
-  return `${v} ${m.unit}`
-}
+// Display "S por D unit" (PA) / "V unit" — helper core (fonte única, 032).
+const formatMeasure = formatBiomarkerDisplay
 
 /**
  * @param {Object} props
@@ -18,8 +15,8 @@ function formatMeasure(m) {
  * @param {string} props.scheduledTime - HH:MM local (já derivado pelo container, p/ exibição).
  */
 export default function MeasureTimelineCard({ measure, scheduledTime }) {
-  const label = BIOMARKER_TYPE_LABELS[measure.type] || measure.type
-  const ctx = measure.context ? BIOMARKER_CONTEXT_LABELS[measure.context] : null
+  const label = biomarkerCardLabel(measure.type)
+  const ctx = formatBiomarkerContext(measure.context)
 
   return (
     <div className="cronograma-dose-card cronograma-dose-card--measure">
@@ -30,7 +27,7 @@ export default function MeasureTimelineCard({ measure, scheduledTime }) {
       <div className="cronograma-dose-card__main">
         <div className="cronograma-dose-card__details">
           <div className="cronograma-dose-card__name-row">
-            <span className="cronograma-dose-card__title">{label} {formatMeasure(measure)}</span>
+            <span className="cronograma-dose-card__title">{label}: {formatMeasure(measure)}</span>
           </div>
           {ctx && (
             <div className="cronograma-dose-card__intake-row">

--- a/apps/web/src/features/measures/components/MeasuresHub.jsx
+++ b/apps/web/src/features/measures/components/MeasuresHub.jsx
@@ -5,12 +5,12 @@
 // zona/meta/linha; cor diferencia tipo, nunca qualidade.
 
 import { useState } from 'react'
-import { BIOMARKER_TYPE_LABELS, BIOMARKER_TYPE_UNITS } from '@dosiq/core'
+import { BIOMARKER_TYPE_LABELS, BIOMARKER_TYPE_UNITS, biomarkerCardLabel } from '@dosiq/core'
 import { useMeasures } from '@features/measures/hooks/useMeasures'
 import ScatterTrend from './ScatterTrend'
 import './MeasuresHub.css'
 
-const HUB_TYPES = ['glicemia', 'peso']
+const HUB_TYPES = ['glicemia', 'peso', 'pressao_arterial']
 
 export default function MeasuresHub({ initialType = 'glicemia' }) {
   const [type, setType] = useState(initialType)
@@ -39,7 +39,7 @@ export default function MeasuresHub({ initialType = 'glicemia' }) {
 
       {error && <div className="hhr-banner hhr-banner--error">{error}</div>}
 
-      <ScatterTrend items={items} unit={BIOMARKER_TYPE_UNITS[type]} typeLabel={BIOMARKER_TYPE_LABELS[type]} />
+      <ScatterTrend items={items} unit={BIOMARKER_TYPE_UNITS[type]} typeLabel={biomarkerCardLabel(type)} isPa={type === 'pressao_arterial'} />
     </div>
   )
 }

--- a/apps/web/src/features/measures/components/ScatterTrend.css
+++ b/apps/web/src/features/measures/components/ScatterTrend.css
@@ -76,6 +76,11 @@
   fill: var(--color-info, #0288d1);
 }
 
+/* PA — diastólica em cinza claro neutro; cor = série, nunca qualidade (SaMD) */
+.scatter__point--dia {
+  fill: var(--color-outline-variant, #cfd8dc);
+}
+
 .scatter__ylabels {
   position: absolute;
   left: 0;

--- a/apps/web/src/features/measures/components/ScatterTrend.jsx
+++ b/apps/web/src/features/measures/components/ScatterTrend.jsx
@@ -43,7 +43,10 @@ function fmtTick(v) {
   return Number.isInteger(v) ? String(v) : v.toFixed(1).replace('.', ',')
 }
 
-export default function ScatterTrend({ items, unit, typeLabel = 'Medida' }) {
+// PA = 2 séries (sistólica + diastólica). Cor diferencia SÉRIE, nunca qualidade (SaMD, ADR-062).
+const mean = (arr) => (arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : null)
+
+export default function ScatterTrend({ items, unit, typeLabel = 'Medida', isPa = false }) {
   const [weekOffset, setWeekOffset] = useState(0)
 
   const weekStart = useMemo(() => addDays(mondayOf(getRawNow()), weekOffset * 7), [weekOffset])
@@ -54,17 +57,24 @@ export default function ScatterTrend({ items, unit, typeLabel = 'Medida' }) {
     for (let i = 0; i < 7; i++) {
       const day = addDays(weekStart, i)
       const dayEnd = day.getTime() + DAY_MS
-      const values = (items || [])
+      const dayItems = (items || [])
         .filter((it) => { const t = parseISO(it.measured_at).getTime(); return t >= day.getTime() && t < dayEnd })
-        .map((it) => it.value)
-      arr.push({ day, values })
+      arr.push({
+        day,
+        values: dayItems.map((it) => it.value),
+        // PA: série diastólica ignora pontos sem value_secondary (dados legados/defensivo).
+        valuesSec: isPa ? dayItems.map((it) => it.value_secondary).filter((v) => v != null) : [],
+      })
     }
     return arr
-  }, [items, weekStart])
+  }, [items, weekStart, isPa])
 
-  const allValues = days.flatMap((d) => d.values)
+  const sysValues = days.flatMap((d) => d.values)
+  const diaValues = days.flatMap((d) => d.valuesSec)
+  const allValues = [...sysValues, ...diaValues] // escala unifica as 2 séries (PA)
   const hasData = allValues.length > 0
-  const avg = hasData ? allValues.reduce((a, b) => a + b, 0) / allValues.length : null
+  const avg = mean(sysValues)
+  const avgDia = mean(diaValues)
   const scale = useMemo(
     () => buildScale(hasData ? Math.min(...allValues) : NaN, hasData ? Math.max(...allValues) : NaN),
     [allValues, hasData]
@@ -98,7 +108,10 @@ export default function ScatterTrend({ items, unit, typeLabel = 'Medida' }) {
             <line key={i} x1="0" x2={VB_W} y1={yFor(t)} y2={yFor(t)} className="scatter__grid" />
           ))}
           {days.flatMap((d, i) => d.values.map((v, j) => (
-            <circle key={`${i}-${j}`} cx={xFor(i)} cy={yFor(v)} r="4" className="scatter__point" />
+            <circle key={`s${i}-${j}`} cx={xFor(i)} cy={yFor(v)} r="4" className="scatter__point" />
+          )))}
+          {days.flatMap((d, i) => d.valuesSec.map((v, j) => (
+            <circle key={`d${i}-${j}`} cx={xFor(i)} cy={yFor(v)} r="4" className="scatter__point scatter__point--dia" />
           )))}
         </svg>
         <div className="scatter__ylabels">
@@ -114,10 +127,19 @@ export default function ScatterTrend({ items, unit, typeLabel = 'Medida' }) {
 
       <div className="scatter__footer">
         {hasData ? (
-          <span className="scatter__avg">
-            Média da semana: <strong>{fmtTick(Math.round(avg * 10) / 10)} {unit}</strong>
-            <span className="scatter__count">  ·  {allValues.length} {allValues.length === 1 ? 'medida' : 'medidas'}</span>
-          </span>
+          isPa ? (
+            <span className="scatter__avg">
+              Média: <strong>SIS {fmtTick(Math.round(avg * 10) / 10)}</strong>
+              {avgDia != null ? <strong> · DIA {fmtTick(Math.round(avgDia * 10) / 10)}</strong> : null}
+              <strong> {unit}</strong>
+              <span className="scatter__count">  ·  {sysValues.length} {sysValues.length === 1 ? 'medida' : 'medidas'}</span>
+            </span>
+          ) : (
+            <span className="scatter__avg">
+              Média da semana: <strong>{fmtTick(Math.round(avg * 10) / 10)} {unit}</strong>
+              <span className="scatter__count">  ·  {allValues.length} {allValues.length === 1 ? 'medida' : 'medidas'}</span>
+            </span>
+          )
         ) : (
           <span className="scatter__empty">Sem medidas nesta semana.</span>
         )}

--- a/apps/web/src/shared/styles/layout.css
+++ b/apps/web/src/shared/styles/layout.css
@@ -342,15 +342,19 @@
 
 /* Hora alinhada à direita e DENTRO do card: o título da medida quebra linha em vez
    de empurrar a hora pra fora (mobile, valor longo "Glicemia 112 mg/dL"). */
+/* Registro (medida) pesa menos que ação (dose) na timeline — tinta, não elevação (AP-018).
+   Rebaixa o peso de valor e hora: sem bold. */
 .cronograma-dose-card--measure .cronograma-dose-card__time {
   color: var(--color-info, #0288d1);
   align-self: flex-start;
+  font-weight: 400;
 }
 
 .cronograma-dose-card--measure .cronograma-dose-card__title {
   white-space: normal;
   overflow: visible;
   text-overflow: clip;
+  font-weight: 400;
 }
 
 /* Bloco principal: info à esquerda + horário grande à direita */

--- a/apps/web/src/views/redesign/history/BiomarkerEventCard.jsx
+++ b/apps/web/src/views/redesign/history/BiomarkerEventCard.jsx
@@ -6,9 +6,9 @@
 // SaMD (ADR-062): cor diferencia TIPO, nunca qualidade do valor. Sem meta/alvo.
 
 import { Ruler, PencilLine, Trash2 } from 'lucide-react'
-import { parseISO, BIOMARKER_TYPE_LABELS, BIOMARKER_CONTEXT_LABELS } from '@dosiq/core'
+import { parseISO, biomarkerCardLabel, formatBiomarkerContext, formatBiomarkerDisplay } from '@dosiq/core'
 
-// Reconstrói a linha de biomarkers_log a partir do payload do evento (p/ edição/exclusão).
+// Reconstrói a linha de biomarkers_log a partir do payload do evento (p/ edição/exclusão + display).
 function eventToMeasure(event) {
   const p = event.payload || {}
   return {
@@ -22,15 +22,6 @@ function eventToMeasure(event) {
   }
 }
 
-/** Formata "value[/value_secondary] unit" PT-BR (PA = "12/8"; demais = valor único). */
-function formatMeasure(p) {
-  const v = String(p.value).replace('.', ',')
-  if (p.valueSecondary != null) {
-    return `${v}/${String(p.valueSecondary).replace('.', ',')} ${p.unit}`
-  }
-  return `${v} ${p.unit}`
-}
-
 /**
  * Card de um evento `biomarker` no painel do dia.
  *
@@ -40,8 +31,8 @@ function formatMeasure(p) {
  */
 export default function BiomarkerEventCard({ event, timezone = 'America/Sao_Paulo', onEditMeasure, onDeleteMeasure }) {
   const p = event.payload || {}
-  const label = BIOMARKER_TYPE_LABELS[p.biomarkerType] || p.biomarkerType
-  const ctx = p.context ? BIOMARKER_CONTEXT_LABELS[p.context] : null
+  const label = biomarkerCardLabel(p.biomarkerType)
+  const ctx = formatBiomarkerContext(p.context)
 
   const timeLabel = event.occurred_at
     ? parseISO(event.occurred_at).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit', timeZone: timezone })
@@ -54,7 +45,7 @@ export default function BiomarkerEventCard({ event, timezone = 'America/Sao_Paul
       <div className="hlc-card__info">
         <div className="hlc-card__title-row">
           <Ruler size={14} className="hlc-card__bio-icon" aria-hidden="true" />
-          <span className="hlc-card__name">{label} {formatMeasure(p)}</span>
+          <span className="hlc-card__name">{label}: {formatBiomarkerDisplay(measure)}</span>
         </div>
         {ctx && <span className="hlc-card__quantity">{ctx}</span>}
       </div>


### PR DESCRIPTION
## Spec 032 — Biomarcador Pressão Arterial · PR B (web)

Espelho web da PA (PR A mobile #669 mergeado). Reusa os helpers core já em main.

### Entregue (paridade com mobile)
- **MeasureLogModal**: 2 campos PA (sistólica *por* diastólica, mmHg) + chips de contexto PA + CSS
- **MeasuresHub**: PA no HUB_TYPES; ScatterTrend recebe isPa; título curto "PRESSÃO"
- **ScatterTrend**: 2 séries SVG (sistólica azul + diastólica cinza neutro — SaMD, cor=série), média "SIS / DIA mmHg"
- **Cards** (BiomarkerEventCard / LastMeasureCard / MeasureTimelineCard): helpers core (formatBiomarkerDisplay + formatBiomarkerContext + biomarkerCardLabel "Pressão"), consolida 4 cópias locais de formatMeasure; label com ":"
- **Polish 012** (PO): cards de medida na timeline da aba Hoje sem bold no valor/hora (registro pesa menos que dose — AP-018)

### Quality gates
- validate:agent **1352 pass** · lint 0 erros · web 4.8.1 → 4.9.0
- Smoke web PO ✅

### SaMD (ADR-062)
Preservado: sem zona/meta/classificação de risco/cor de qualidade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
