### PR TITLE
feat(015): Assistente IA nativo no mobile + payload cross-superfície (Onda 2)

### DIFF
--- a/.agent/state.json
+++ b/.agent/state.json
@@ -12,8 +12,8 @@
       "015 chat = full-screen + bolhas assimétricas (não cards iguais); chips + disclaimer fixo",
       "015 RC3: fetcher+builder core, descope CRUD repos full, paridade bloqueante"
     ],
-    "status": "completed",
-    "goal": "015 onda 1b — plan-grouping: buildPatientContext agrupa por treatment_plan.name (flat sem-plano primeiro, grupos depois; sem rótulo 'Sem plano'). Tier 2.",
+    "status": "coding",
+    "goal": "015 onda 2 — chat mobile e2e (greenfield): entry-point ícone IA header nas abas Hoje/Tratamentos/Estoque (header compartilhado) + <DEV> badge no título Perfil + ChatScreen full-screen bolhas assimétricas + chatbotService mobile (fetcher core) + AsyncStorage. Gate smoke antes de push. Tier 2.",
     "goal_type": "feature",
     "tier": 2,
     "spec_dir": "plans/specs/015-ai-chatbot-mobile",
@@ -22,13 +22,14 @@
     "tasks": "plans/specs/015-ai-chatbot-mobile/tasks.md",
     "linked_adrs": ["ADR-074"],
     "linked_contracts": ["CON-028"],
-    "last_pr": 684,
-    "branch": "feature/015/onda-1b-plan-grouping",
-    "mobile_version": "0.20.1"
+    "last_pr": 685,
+    "branch": "feature/015/onda-2-chat-mobile",
+    "mobile_version": "0.21.0",
+    "web_version": "4.14.0"
   },
   "memory": {
     "last_distillation": "2026-06-23T04:30:00.000Z",
-    "journal_entries_since_distillation": 8,
+    "journal_entries_since_distillation": 9,
     "rules_count": 229,
     "anti_patterns_count": 237,
     "decisions_count": 73,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ---
 
+## App v0.21.0 (mobile) + Web v4.14.0 — 2026-06-24 — Assistente IA no mobile + payload cross-superfície enriquecido (spec 015, Onda 2)
+
+> **Bump:** mobile `0.20.1 → 0.21.0` (minor — nova feature: chat IA nativo) · web `4.13.0 → 4.14.0`
+> (minor — chat ganha contexto enriquecido + guardrails). Núcleo compartilhado em `@dosiq/core`,
+> então as melhorias de payload valem web + Telegram + mobile de uma vez.
+> **Release nas lojas:** primeira versão com o Assistente IA dentro do app nativo.
+
+### 📱 Release notes — App Store / Play Store (pt-BR)
+
+```
+Novidades da versão 0.21.0
+
+Chegou o Assistente IA do Dosiq no celular:
+
+• Converse com o assistente direto do app: toque no ícone do robô no topo das telas
+  Hoje, Tratamentos e Estoque e pergunte sobre suas doses, adesão e estoque.
+• Respostas no contexto do seu tratamento — incluindo medicamentos líquidos e injetáveis
+  com a unidade certa (mL, UI, gotas) e tratamentos semanais com o dia agendado.
+• Limpe a conversa quando quiser começar do zero, com um toque.
+• O assistente não substitui orientação médica e nunca recomenda doses.
+```
+
+### ✨ Novidades
+
+- **Chat IA nativo (mobile):** `ChatScreen` full-screen com bolhas assimétricas, markdown
+  (negrito/itálico/listas), histórico local (AsyncStorage), banner offline, chips de sugestão,
+  "digitando…" animado e botão de limpar conversa. Entry-point (ícone `BotMessageSquare`) no
+  header das abas Hoje/Tratamentos/Estoque.
+- **Markdown compartilhado:** parser puro em `@dosiq/core/markdown` (tokenizer único web↔mobile).
+
+### 🐛 Correções de payload do chatbot (web + Telegram + mobile via core)
+
+- **Tratamentos semanais/PRN/personalizados** voltam a aparecer no contexto: o filtro passou a
+  ser por período de vigência (não mais "a frequência cai hoje"), com o dia da semana agendado
+  na linha do medicamento.
+- **Unidades corretas para líquidos/injetáveis:** estoque, dose e consumo deixam de ser achatados
+  em "un." — agora em mL/UI/gotas (ex.: Lantus "5,2 mL", dose "10 UI (≈ 0,1 mL)").
+- **Doses pendentes** resolvem o nome do medicamento (fim do "Desconhecido").
+- **Consumo diário** arredondado (sem dízimas).
+- **Perfil do paciente** (nome/idade) e **dia da semana** entram no contexto quando disponíveis.
+
+### 🔒 Robustez do assistente
+
+- Guardrail de **escopo do app** no system prompt: o assistente não inventa funcionalidades
+  inexistentes (ex.: "entrega de medicamentos").
+- Contexto **regional Brasil/ANVISA** + `max_tokens` 512 → 1024 (respostas longas não truncam).
+
+---
+
 ## App v0.19.1 (mobile) — 2026-06-17 — Alarme: transparência clínica + cancel cross-superfície (spec 036)
 
 > **Bump:** mobile `0.19.0 → 0.19.1` (patch — correção de bug + transparência clínica na tela cheia).

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -5,7 +5,7 @@
 
 const BUILD_PROFILE = process.env.EAS_BUILD_PROFILE || 'production'
 
-const APP_VERSION = '0.20.1' // R-182: versão semântica (sem prefixo 'v')
+const APP_VERSION = '0.21.0' // R-182: versão semântica (sem prefixo 'v')
 const [major, minor, patch] = APP_VERSION.split('.').map(Number)
 // buildNumber/versionCode derivado da versão semântica: major*10000 + minor*100 + patch
 // 0.2.4 → 204 | 0.3.0 → 300 | 1.0.0 → 10000

--- a/apps/mobile/src/features/_dev/components/DevBadge.jsx
+++ b/apps/mobile/src/features/_dev/components/DevBadge.jsx
@@ -1,0 +1,41 @@
+// DevBadge.jsx — badge dev-only (spec 015 onda 2). Abre o DevHub.
+//
+// Renderiza APENAS em __DEV__ (no-op em produção). Migrou do header de Hoje p/ o título
+// do Perfil (PO 2026-06-24), já que o top-right de Hoje/Tratamentos/Estoque passou a ser
+// do entry-point da IA. Co-locado em _dev p/ manter a preocupação dev isolada.
+
+import { TouchableOpacity, Text, StyleSheet } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
+import { colors } from '@shared/styles/tokens'
+import { ROUTES } from '@navigation/routes'
+
+export default function DevBadge() {
+  const navigation = useNavigation()
+  if (!__DEV__) return null
+  return (
+    <TouchableOpacity
+      style={styles.badge}
+      onPress={() => navigation.navigate(ROUTES.DEV_HUB)}
+      hitSlop={8}
+      accessibilityRole="button"
+      accessibilityLabel="Abrir Dev Hub"
+    >
+      <Text style={styles.text}>DEV</Text>
+    </TouchableOpacity>
+  )
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 6,
+    backgroundColor: colors.status.warning,
+  },
+  text: {
+    fontSize: 10,
+    fontWeight: '800',
+    color: colors.text.inverse,
+    letterSpacing: 1,
+  },
+})

--- a/apps/mobile/src/features/chatbot/components/ChatBubble.jsx
+++ b/apps/mobile/src/features/chatbot/components/ChatBubble.jsx
@@ -1,0 +1,79 @@
+// ChatBubble.jsx — bolha de mensagem do chat (spec 015 onda 2).
+//
+// Assimétrica: user à direita (accent/brand), bot à esquerda (surface neutro).
+// Render de markdown leve via parser PURO do @dosiq/core (paridade web↔mobile):
+// **negrito**, _itálico_, listas `-`/`*` (•) e `+` (◦ indentado).
+
+import { View, Text, StyleSheet } from 'react-native'
+import { parseMessageMarkdown } from '@dosiq/core'
+import { colors, spacing } from '@shared/styles/tokens'
+
+/** Render dos segmentos inline (bold/italic/text) → RN Text aninhado. */
+function renderSegments(segments, baseStyle) {
+  return segments.map((seg, i) => {
+    if (seg.type === 'bold') return <Text key={i} style={styles.bold}>{seg.value}</Text>
+    if (seg.type === 'italic') return <Text key={i} style={styles.italic}>{seg.value}</Text>
+    return <Text key={i} style={baseStyle}>{seg.value}</Text>
+  })
+}
+
+export default function ChatBubble({ role, content }) {
+  const isUser = role === 'user'
+  const baseTextStyle = isUser ? styles.userText : styles.botText
+  const lines = parseMessageMarkdown(content)
+
+  return (
+    <View
+      style={[styles.row, isUser ? styles.rowUser : styles.rowBot]}
+      accessibilityLabel={isUser ? 'Sua mensagem' : 'Resposta do assistente'}
+    >
+      <View style={[styles.bubble, isUser ? styles.bubbleUser : styles.bubbleBot]}>
+        {lines.map((line, i) => (
+          <Text key={i} style={[baseTextStyle, line.bullet === 'subitem' && styles.subIndent]}>
+            {line.bullet === 'item' ? '• ' : line.bullet === 'subitem' ? '◦ ' : ''}
+            {renderSegments(line.segments, baseTextStyle)}
+          </Text>
+        ))}
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    marginVertical: spacing[1],
+    paddingHorizontal: spacing[4],
+  },
+  rowUser: { justifyContent: 'flex-end' },
+  rowBot: { justifyContent: 'flex-start' },
+  bubble: {
+    maxWidth: '82%',
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[4],
+    borderRadius: 16,
+  },
+  bubbleUser: {
+    backgroundColor: colors.brand.primary,
+    borderBottomRightRadius: 4,
+  },
+  bubbleBot: {
+    backgroundColor: colors.bg.card,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+    borderBottomLeftRadius: 4,
+  },
+  userText: {
+    fontSize: 15,
+    lineHeight: 21,
+    color: colors.text.inverse,
+  },
+  botText: {
+    fontSize: 15,
+    lineHeight: 21,
+    color: colors.text.primary,
+  },
+  bold: { fontWeight: '700' },
+  italic: { fontStyle: 'italic' },
+  subIndent: { paddingLeft: spacing[4] },
+})

--- a/apps/mobile/src/features/chatbot/components/ChatEntryButton.jsx
+++ b/apps/mobile/src/features/chatbot/components/ChatEntryButton.jsx
@@ -1,0 +1,41 @@
+// ChatEntryButton.jsx — entry-point do chat IA no header (spec 015 onda 2; PO-D1).
+//
+// Ícone discreto top-right plugável nos headers das abas Hoje/Tratamentos/Estoque
+// (NÃO Perfil; NÃO é FAB — afordância de header, evita AP-W24 e colisão com o speed-dial).
+// Self-contained via useNavigation.
+
+import { TouchableOpacity, StyleSheet } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
+import { BotMessageSquare } from 'lucide-react-native'
+import { colors } from '@shared/styles/tokens'
+import { lightTap } from '@shared/utils/haptics'
+import { ROUTES } from '../../../navigation/routes'
+
+export default function ChatEntryButton({ size = 26, color = colors.text.brand }) {
+  const navigation = useNavigation()
+  return (
+    <TouchableOpacity
+      onPress={() => {
+        lightTap()
+        navigation.navigate(ROUTES.CHAT)
+      }}
+      style={styles.btn}
+      hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      accessibilityRole="button"
+      accessibilityLabel="Abrir assistente IA"
+    >
+      <BotMessageSquare size={size} color={color} strokeWidth={1.75} />
+    </TouchableOpacity>
+  )
+}
+
+const styles = StyleSheet.create({
+  btn: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.neutral[200], // teal leve — círculo de fundo (não "flutuar")
+  },
+})

--- a/apps/mobile/src/features/chatbot/config/chatbotConfig.js
+++ b/apps/mobile/src/features/chatbot/config/chatbotConfig.js
@@ -1,0 +1,36 @@
+// chatbotConfig.js (mobile) — constantes de UI do chat nativo (spec 015 onda 2).
+//
+// APENAS constantes client de apresentação (disclaimer exibido, teto de histórico,
+// chips de sugestão, welcome). A segurança REAL (systemPrompt + safetyGuard) é
+// composta SERVER-SIDE em api/chatbot.js (AP-237) — o cliente nunca a envia.
+// Textos espelham o web (R-166). NÃO importar de apps/web (apps separados).
+
+/** Teto de mensagens mantidas no histórico local (AsyncStorage) — FR-007. */
+export const CHATBOT_MAX_HISTORY = 20
+
+/** Disclaimer clínico (paridade com o web). */
+export const CHATBOT_DISCLAIMER =
+  'Não substituo orientação médica. Consulte seu médico para decisões sobre o seu tratamento.'
+
+/** Chave de persistência do histórico (AsyncStorage). */
+export const CHATBOT_HISTORY_STORAGE_KEY = 'mr_chat_history'
+
+/** Chips de sugestão exibidos no estado vazio / acima do input. */
+export const CHATBOT_QUICK_SUGGESTIONS = [
+  'Qual meu próximo remédio?',
+  'Como está minha adesão?',
+  'Algum estoque baixo?',
+]
+
+/**
+ * Mensagem de boas-vindas inicial (paridade com o web).
+ * @param {number|null} timestamp
+ * @returns {{role:string, content:string, timestamp:number|null}}
+ */
+export function createWelcomeMessage(timestamp = null) {
+  return {
+    role: 'assistant',
+    content: `Olá! Sou a assistente IA do Dosiq. Como posso te ajudar hoje? `,
+    timestamp,
+  }
+}

--- a/apps/mobile/src/features/chatbot/screens/ChatScreen.jsx
+++ b/apps/mobile/src/features/chatbot/screens/ChatScreen.jsx
@@ -1,0 +1,299 @@
+// ChatScreen.jsx — Chat IA full-screen nativo (spec 015 onda 2; PO-D2/PO-3).
+//
+// Full-screen (stack), FlatList invertido, bolhas assimétricas (ChatBubble), disclaimer
+// fixo no topo, chips de sugestão acima do input, loading branded "Iniciando IA do dosiq…"
+// (fetch-on-open, FR-012), offline desabilita envio + banner. Teclado: KeyboardAvoidingView
+// (AP-174/R-233). Segurança server-side (AP-237) — cliente só envia contexto+mensagem.
+
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react'
+import {
+  View, Text, TextInput, FlatList, TouchableOpacity, StyleSheet,
+  KeyboardAvoidingView, Platform, ActivityIndicator,
+} from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { ChevronLeft, X, Send, Trash2, BotMessageSquare } from 'lucide-react-native'
+import NetInfo from '@react-native-community/netinfo'
+import { colors, spacing } from '@shared/styles/tokens'
+import { lightTap } from '@shared/utils/haptics'
+import ChatBubble from '@features/chatbot/components/ChatBubble'
+import { buildMobilePatientContext, sendChatMessage } from '../services/chatbotService'
+import { loadHistory, saveHistory, clearHistory } from '../services/chatHistoryStore'
+import { CHATBOT_DISCLAIMER, CHATBOT_QUICK_SUGGESTIONS, createWelcomeMessage } from '../config/chatbotConfig'
+
+/** Bolha "digitando" com pontos pulsando (1→2→3→repete). Reusa o estilo do ChatBubble. */
+function TypingBubble() {
+  const [dots, setDots] = useState(1)
+  useEffect(() => {
+    const id = setInterval(() => setDots((n) => (n >= 3 ? 1 : n + 1)), 400)
+    return () => clearInterval(id)
+  }, [])
+  return <ChatBubble role="assistant" content={'.'.repeat(dots)} />
+}
+
+/** Header do chat: voltar · branding (BotMessageSquare + título) · limpar/fechar. */
+function ChatHeader({ onReset, onClose }) {
+  return (
+    <View style={styles.header}>
+      <TouchableOpacity onPress={onClose} style={styles.iconBtn} hitSlop={hit} accessibilityLabel="Voltar">
+        <ChevronLeft size={24} color={colors.text.primary} />
+      </TouchableOpacity>
+      <View style={styles.titleWrap}>
+        <BotMessageSquare size={20} color={colors.brand.primary} strokeWidth={1.75} />
+        <Text style={styles.title}>Assistente Dosiq IA</Text>
+      </View>
+      <View style={styles.headerActions}>
+        <TouchableOpacity onPress={onReset} style={styles.iconBtn} hitSlop={hit} accessibilityLabel="Limpar conversa">
+          <Trash2 size={20} color={colors.text.primary} />
+        </TouchableOpacity>
+        <TouchableOpacity onPress={onClose} style={styles.iconBtn} hitSlop={hit} accessibilityLabel="Fechar">
+          <X size={22} color={colors.text.primary} />
+        </TouchableOpacity>
+      </View>
+    </View>
+  )
+}
+
+export default function ChatScreen({ navigation }) {
+  // 1. States
+  const [messages, setMessages] = useState([])
+  const [input, setInput] = useState('')
+  const [initializing, setInitializing] = useState(true) // fetch-on-open (FR-012)
+  const [sending, setSending] = useState(false)
+  const [offline, setOffline] = useState(false)
+
+  // Refs
+  const contextRef = useRef(null) // patientContext cacheado por sessão de chat
+
+  // 2. Memos
+  const reversed = useMemo(() => [...messages].reverse(), [messages])
+  const hasUserMsg = useMemo(() => messages.some((m) => m.role === 'user'), [messages])
+  const canSend = input.trim().length > 0 && !sending && !offline && !initializing
+
+  // 3. Effects
+  // 3a. Monitor de conectividade
+  useEffect(() => {
+    const unsub = NetInfo.addEventListener((state) => {
+      setOffline(!(state.isConnected && state.isInternetReachable !== false))
+    })
+    return unsub
+  }, [])
+
+  // 3b. Fetch-on-open: carrega histórico + monta contexto via core (loading branded)
+  useEffect(() => {
+    let alive = true
+    ;(async () => {
+      const persisted = await loadHistory()
+      if (!alive) return
+      setMessages(persisted.length ? persisted : [createWelcomeMessage(Date.now())])
+      try {
+        contextRef.current = await buildMobilePatientContext()
+      } catch {
+        contextRef.current = '' // degrada: chat ainda funciona, server lida com contexto vazio
+      }
+      if (alive) setInitializing(false)
+    })()
+    return () => { alive = false }
+  }, [])
+
+  // 3c. Persistir histórico a cada mudança (best-effort)
+  useEffect(() => {
+    if (!initializing) saveHistory(messages)
+  }, [messages, initializing])
+
+  // 4. Handlers
+  const handleClose = useCallback(() => navigation?.goBack(), [navigation])
+
+  // Reseta o chat ao estado original: limpa histórico, recompõe a welcome e RE-BUSCA o
+  // contexto do paciente (paridade com o trash-2 da web) — útil p/ começar conversa limpa
+  // e p/ recarregar o payload após mudanças nos dados.
+  const handleReset = useCallback(async () => {
+    lightTap()
+    await clearHistory()
+    setInput('')
+    setMessages([createWelcomeMessage(Date.now())])
+    setInitializing(true)
+    try {
+      contextRef.current = await buildMobilePatientContext()
+    } catch {
+      contextRef.current = ''
+    }
+    setInitializing(false)
+  }, [])
+
+  const handleSend = useCallback(async (text) => {
+    const message = (text ?? input).trim()
+    if (!message || sending || offline) return
+    lightTap()
+    setInput('')
+    const userMsg = { role: 'user', content: message, timestamp: Date.now() }
+    const history = messages.map((m) => ({ role: m.role, content: m.content }))
+    setMessages((prev) => [...prev, userMsg])
+    setSending(true)
+    const { response } = await sendChatMessage({
+      message,
+      history,
+      patientContext: contextRef.current ?? '',
+    })
+    setMessages((prev) => [...prev, { role: 'assistant', content: response, timestamp: Date.now() }])
+    setSending(false)
+  }, [input, sending, offline, messages])
+
+  // Render
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'bottom']}>
+      <ChatHeader onReset={handleReset} onClose={handleClose} />
+
+      {offline && (
+        <View style={styles.offlineBanner}>
+          <Text style={styles.offlineText}>Sem conexão — o envio está desabilitado.</Text>
+        </View>
+      )}
+
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 8 : 0}
+      >
+        {initializing ? (
+          <View style={styles.initBox}>
+            <ActivityIndicator size="large" color={colors.brand.primary} />
+            <Text style={styles.initText}>Iniciando IA do Dosiq…</Text>
+          </View>
+        ) : (
+          <FlatList
+            data={reversed}
+            inverted
+            keyExtractor={(_, i) => String(i)}
+            renderItem={({ item }) => <ChatBubble role={item.role} content={item.content} />}
+            contentContainerStyle={styles.listContent}
+            ListHeaderComponent={sending ? <TypingBubble /> : null}
+            // Lista invertida: o Footer renderiza no TOPO visual (acima da 1ª mensagem) e
+            // rola junto com as bolhas — disclaimer deixa de ocupar espaço fixo (telas pequenas).
+            ListFooterComponent={
+              <View style={styles.disclaimer}>
+                <Text style={styles.disclaimerText}>⚠ {CHATBOT_DISCLAIMER}</Text>
+              </View>
+            }
+            keyboardShouldPersistTaps="handled"
+          />
+        )}
+
+        {/* Chips de sugestão (estado inicial) */}
+        {!initializing && !hasUserMsg && (
+          <View style={styles.chips}>
+            {CHATBOT_QUICK_SUGGESTIONS.map((s) => (
+              <TouchableOpacity
+                key={s}
+                style={styles.chip}
+                onPress={() => handleSend(s)}
+                disabled={offline || sending}
+                accessibilityLabel={`Sugestão: ${s}`}
+              >
+                <Text style={styles.chipText}>{s}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        )}
+
+        {/* Input */}
+        <View style={styles.inputRow}>
+          <TextInput
+            style={styles.input}
+            value={input}
+            onChangeText={setInput}
+            placeholder="Pergunte ao assistente…"
+            placeholderTextColor={colors.text.muted}
+            maxLength={500}
+            editable={!offline && !initializing}
+            multiline
+            onSubmitEditing={() => handleSend()}
+          />
+          <TouchableOpacity
+            style={[styles.sendBtn, !canSend && styles.sendBtnDisabled]}
+            onPress={() => handleSend()}
+            disabled={!canSend}
+            accessibilityLabel="Enviar mensagem"
+          >
+            <Send size={20} color={colors.text.inverse} />
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  )
+}
+
+const hit = { top: 8, bottom: 8, left: 8, right: 8 }
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg.screen },
+  flex: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[3],
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border.light,
+    backgroundColor: colors.bg.card,
+  },
+  iconBtn: { width: 40, height: 40, alignItems: 'center', justifyContent: 'center' },
+  titleWrap: { flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: spacing[2] },
+  title: { fontSize: 17, fontWeight: '700', color: colors.text.primary },
+  headerActions: { flexDirection: 'row', alignItems: 'center' },
+  disclaimer: {
+    backgroundColor: colors.status.warningLight,
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+    borderRadius: 8,
+    marginHorizontal: spacing[3],
+    marginBottom: spacing[2],
+  },
+  disclaimerText: { fontSize: 12, color: colors.status.warning, lineHeight: 16 },
+  offlineBanner: { backgroundColor: colors.status.errorLight, paddingHorizontal: spacing[4], paddingVertical: spacing[2] },
+  offlineText: { fontSize: 12, color: colors.status.error },
+  initBox: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: spacing[3] },
+  initText: { fontSize: 15, color: colors.text.secondary },
+  listContent: { paddingVertical: spacing[3] },
+  chips: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing[2], paddingHorizontal: spacing[4], paddingBottom: spacing[2] },
+  chip: {
+    backgroundColor: colors.bg.card,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+    borderRadius: 16,
+    paddingVertical: spacing[2],
+    paddingHorizontal: spacing[3],
+  },
+  chipText: { fontSize: 13, color: colors.brand.primary, fontWeight: '600' },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: spacing[2],
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    borderTopWidth: 1,
+    borderTopColor: colors.border.light,
+    backgroundColor: colors.bg.card,
+  },
+  input: {
+    flex: 1,
+    maxHeight: 120,
+    minHeight: 44,
+    backgroundColor: colors.bg.screen,
+    borderRadius: 22,
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[3],
+    paddingBottom: spacing[3],
+    fontSize: 15,
+    color: colors.text.primary,
+  },
+  sendBtn: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: colors.brand.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  sendBtnDisabled: { opacity: 0.4 },
+})

--- a/apps/mobile/src/features/chatbot/screens/ChatScreen.jsx
+++ b/apps/mobile/src/features/chatbot/screens/ChatScreen.jsx
@@ -129,12 +129,14 @@ export default function ChatScreen({ navigation }) {
     const history = messages.map((m) => ({ role: m.role, content: m.content }))
     setMessages((prev) => [...prev, userMsg])
     setSending(true)
-    const { response } = await sendChatMessage({
+    const { response, error } = await sendChatMessage({
       message,
       history,
       patientContext: contextRef.current ?? '',
     })
-    setMessages((prev) => [...prev, { role: 'assistant', content: response, timestamp: Date.now() }])
+    // isError: exibe a falha na tela mas NÃO persiste no histórico (chatHistoryStore filtra) —
+    // evita que "dificuldades técnicas" fique grudado nas próximas aberturas do chat.
+    setMessages((prev) => [...prev, { role: 'assistant', content: response, timestamp: Date.now(), isError: error }])
     setSending(false)
   }, [input, sending, offline, messages])
 
@@ -163,7 +165,7 @@ export default function ChatScreen({ navigation }) {
           <FlatList
             data={reversed}
             inverted
-            keyExtractor={(_, i) => String(i)}
+            keyExtractor={(item) => `${item.timestamp}-${item.role}`}
             renderItem={({ item }) => <ChatBubble role={item.role} content={item.content} />}
             contentContainerStyle={styles.listContent}
             ListHeaderComponent={sending ? <TypingBubble /> : null}

--- a/apps/mobile/src/features/chatbot/services/__tests__/chatHistoryStore.test.js
+++ b/apps/mobile/src/features/chatbot/services/__tests__/chatHistoryStore.test.js
@@ -44,6 +44,22 @@ describe('chatHistoryStore', () => {
     expect(saved[saved.length - 1].content).toBe(`m${CHATBOT_MAX_HISTORY + 9}`)
   })
 
+  it('saveHistory: filtra mensagens de erro (isError) — não poluem o histórico', async () => {
+    await saveHistory([msg(0), { role: 'assistant', content: 'falha técnica', timestamp: 1002, isError: true }, msg(1)])
+    const saved = JSON.parse(AsyncStorage.setItem.mock.calls[0][1])
+    expect(saved).toHaveLength(2)
+    expect(saved.some((m) => m.isError)).toBe(false)
+  })
+
+  it('loadHistory: filtra mensagens de erro (isError) persistidas anteriormente', async () => {
+    AsyncStorage.getItem.mockResolvedValue(JSON.stringify([
+      msg(0), { role: 'assistant', content: 'erro antigo', timestamp: 1002, isError: true },
+    ]))
+    const r = await loadHistory()
+    expect(r).toHaveLength(1)
+    expect(r[0].content).toBe('m0')
+  })
+
   it('saveHistory: falha de escrita não lança', async () => {
     AsyncStorage.setItem.mockRejectedValue(new Error('disk full'))
     await expect(saveHistory([msg(0)])).resolves.toBeUndefined()

--- a/apps/mobile/src/features/chatbot/services/__tests__/chatHistoryStore.test.js
+++ b/apps/mobile/src/features/chatbot/services/__tests__/chatHistoryStore.test.js
@@ -1,0 +1,56 @@
+// chatHistoryStore.test.js — persistência local do chat (spec 015 onda 2, FR-007).
+
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { loadHistory, saveHistory, clearHistory } from '../chatHistoryStore'
+import { CHATBOT_MAX_HISTORY, CHATBOT_HISTORY_STORAGE_KEY } from '../../config/chatbotConfig'
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}))
+
+const msg = (i) => ({ role: i % 2 ? 'assistant' : 'user', content: `m${i}`, timestamp: 1000 + i })
+
+afterEach(() => jest.clearAllMocks())
+
+describe('chatHistoryStore', () => {
+  it('loadHistory: sem dado → []', async () => {
+    AsyncStorage.getItem.mockResolvedValue(null)
+    expect(await loadHistory()).toEqual([])
+  })
+
+  it('loadHistory: JSON inválido → [] (degrada, sem lançar)', async () => {
+    AsyncStorage.getItem.mockResolvedValue('{ não é json')
+    expect(await loadHistory()).toEqual([])
+  })
+
+  it('loadHistory: filtra entradas malformadas', async () => {
+    AsyncStorage.getItem.mockResolvedValue(JSON.stringify([
+      msg(0), { role: 'user' }, { content: 'x', timestamp: 1 }, msg(1),
+    ]))
+    const r = await loadHistory()
+    expect(r).toHaveLength(2)
+    expect(r.map((m) => m.content)).toEqual(['m0', 'm1'])
+  })
+
+  it('saveHistory: corta para CHATBOT_MAX_HISTORY (mantém as mais recentes)', async () => {
+    const many = Array.from({ length: CHATBOT_MAX_HISTORY + 10 }, (_, i) => msg(i))
+    await saveHistory(many)
+    const [key, payload] = AsyncStorage.setItem.mock.calls[0]
+    expect(key).toBe(CHATBOT_HISTORY_STORAGE_KEY)
+    const saved = JSON.parse(payload)
+    expect(saved).toHaveLength(CHATBOT_MAX_HISTORY)
+    expect(saved[saved.length - 1].content).toBe(`m${CHATBOT_MAX_HISTORY + 9}`)
+  })
+
+  it('saveHistory: falha de escrita não lança', async () => {
+    AsyncStorage.setItem.mockRejectedValue(new Error('disk full'))
+    await expect(saveHistory([msg(0)])).resolves.toBeUndefined()
+  })
+
+  it('clearHistory: remove a chave', async () => {
+    await clearHistory()
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith(CHATBOT_HISTORY_STORAGE_KEY)
+  })
+})

--- a/apps/mobile/src/features/chatbot/services/chatHistoryStore.js
+++ b/apps/mobile/src/features/chatbot/services/chatHistoryStore.js
@@ -16,7 +16,7 @@ export async function loadHistory() {
     if (!raw) return []
     const data = JSON.parse(raw)
     if (!Array.isArray(data)) return []
-    return data.filter((m) => m && m.role && m.content && typeof m.timestamp === 'number')
+    return data.filter((m) => m && m.role && m.content && typeof m.timestamp === 'number' && !m.isError)
   } catch {
     return []
   }
@@ -28,7 +28,8 @@ export async function loadHistory() {
  */
 export async function saveHistory(messages) {
   try {
-    const trimmed = (messages || []).slice(-CHATBOT_MAX_HISTORY)
+    // Filtra mensagens de erro (isError) — falhas transitórias não devem poluir o histórico.
+    const trimmed = (messages || []).filter((m) => !m.isError).slice(-CHATBOT_MAX_HISTORY)
     await AsyncStorage.setItem(CHATBOT_HISTORY_STORAGE_KEY, JSON.stringify(trimmed))
   } catch {
     // no-op: persistência é best-effort

--- a/apps/mobile/src/features/chatbot/services/chatHistoryStore.js
+++ b/apps/mobile/src/features/chatbot/services/chatHistoryStore.js
@@ -1,0 +1,45 @@
+// chatHistoryStore.js (mobile) — persistência local do histórico do chat (spec 015 onda 2, FR-007).
+//
+// AsyncStorage com teto de CHATBOT_MAX_HISTORY mensagens. Degrada gracioso (nunca lança):
+// falha de leitura → []; falha de escrita → no-op silencioso.
+
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { CHATBOT_HISTORY_STORAGE_KEY, CHATBOT_MAX_HISTORY } from '../config/chatbotConfig'
+
+/**
+ * Carrega o histórico persistido.
+ * @returns {Promise<Array<{role:string, content:string, timestamp:number}>>}
+ */
+export async function loadHistory() {
+  try {
+    const raw = await AsyncStorage.getItem(CHATBOT_HISTORY_STORAGE_KEY)
+    if (!raw) return []
+    const data = JSON.parse(raw)
+    if (!Array.isArray(data)) return []
+    return data.filter((m) => m && m.role && m.content && typeof m.timestamp === 'number')
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Persiste o histórico (corta para as últimas CHATBOT_MAX_HISTORY mensagens).
+ * @param {Array<{role:string, content:string, timestamp:number}>} messages
+ */
+export async function saveHistory(messages) {
+  try {
+    const trimmed = (messages || []).slice(-CHATBOT_MAX_HISTORY)
+    await AsyncStorage.setItem(CHATBOT_HISTORY_STORAGE_KEY, JSON.stringify(trimmed))
+  } catch {
+    // no-op: persistência é best-effort
+  }
+}
+
+/** Limpa o histórico persistido. */
+export async function clearHistory() {
+  try {
+    await AsyncStorage.removeItem(CHATBOT_HISTORY_STORAGE_KEY)
+  } catch {
+    // no-op
+  }
+}

--- a/apps/mobile/src/features/chatbot/services/chatbotService.js
+++ b/apps/mobile/src/features/chatbot/services/chatbotService.js
@@ -37,8 +37,8 @@ export async function buildMobilePatientContext() {
  * @returns {Promise<{ response: string, error: boolean }>}
  */
 export async function sendChatMessage({ message, history = [], patientContext }) {
-  const { data: { session } } = await supabase.auth.getSession()
-  const accessToken = session?.access_token
+  const { data } = await supabase.auth.getSession()
+  const accessToken = data?.session?.access_token
   if (!accessToken) {
     return { response: 'Faça login para usar o assistente.', error: true }
   }

--- a/apps/mobile/src/features/chatbot/services/chatbotService.js
+++ b/apps/mobile/src/features/chatbot/services/chatbotService.js
@@ -1,0 +1,74 @@
+// chatbotService.js (mobile) — envia mensagem ao chatbot IA (spec 015 onda 2).
+//
+// Monta o contexto do paciente via @dosiq/core (fetcher + builder canônicos, paridade
+// web↔Telegram↔mobile) e chama o serverless `api/chatbot.js` (mesma rota do PWA).
+// SEGURANÇA (AP-237): systemPrompt + safetyGuard são compostos SERVER-SIDE; o cliente
+// só envia `patientContext` (dados) + a mensagem. O endpoint exige JWT (401 sem token).
+
+import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
+import { nativeApiBaseUrl } from '../../../platform/config/nativePublicAppConfig'
+import { fetchChatbotContextData, buildPatientContext } from '@dosiq/core'
+import { CHATBOT_MAX_HISTORY } from '../config/chatbotConfig'
+
+const CHATBOT_ENDPOINT = `${nativeApiBaseUrl}/api/chatbot`
+
+/** Resolve o id do usuário autenticado (sessão Supabase nativa). */
+async function getUserId() {
+  const { data } = await supabase.auth.getUser()
+  return data?.user?.id ?? null
+}
+
+/**
+ * Busca + monta o contexto do paciente (fetcher + builder do core).
+ * Cacheável por sessão de chat (fetch-on-open, FR-012) — quem chama decide reuso.
+ * @returns {Promise<string>} patientContext (string compacta p/ o LLM)
+ */
+export async function buildMobilePatientContext() {
+  const data = await fetchChatbotContextData({ supabase, getUserId })
+  return buildPatientContext(data)
+}
+
+/**
+ * Envia mensagem ao chatbot e retorna a resposta.
+ * @param {Object} params
+ * @param {string} params.message
+ * @param {Array<{role,content}>} [params.history]
+ * @param {string} params.patientContext - contexto já montado (cache de sessão)
+ * @returns {Promise<{ response: string, error: boolean }>}
+ */
+export async function sendChatMessage({ message, history = [], patientContext }) {
+  const { data: { session } } = await supabase.auth.getSession()
+  const accessToken = session?.access_token
+  if (!accessToken) {
+    return { response: 'Faça login para usar o assistente.', error: true }
+  }
+
+  try {
+    const res = await fetch(CHATBOT_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        message,
+        history: history.slice(-CHATBOT_MAX_HISTORY),
+        patientContext,
+      }),
+    })
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.message || `HTTP ${res.status}`)
+    }
+
+    const data = await res.json()
+    return { response: data.response, error: false }
+  } catch (error) {
+    if (__DEV__) console.warn('[chatbot] erro ao enviar mensagem:', error?.message || error)
+    return {
+      response: 'Desculpe, estou com dificuldades técnicas. Tente novamente em instantes.',
+      error: true,
+    }
+  }
+}

--- a/apps/mobile/src/features/dashboard/screens/TodayScreen.jsx
+++ b/apps/mobile/src/features/dashboard/screens/TodayScreen.jsx
@@ -30,6 +30,7 @@ import DoseTimelineCard from '@dashboard/components/DoseTimelineCard'
 import HeroDoseCard from '@dashboard/components/HeroDoseCard'
 import StockAlertInline from '@dashboard/components/StockAlertInline'
 import DoseRegisterModal from '@dose/components/DoseRegisterModal'
+import ChatEntryButton from '@features/chatbot/components/ChatEntryButton'
 import { lightTap } from '@shared/utils/haptics'
 import BulkDoseRegisterModal from '@dose/components/BulkDoseRegisterModal'
 import StaleBanner from '@shared/components/feedback/StaleBanner'
@@ -154,24 +155,15 @@ function _buildHeaderData(user) {
 }
 
 // Conteúdo principal da tela (pós-carregamento) — extrai render para reduzir complexidade
-function TodayHeader({ greeting, todayFormatted, onDevPress }) {
+// Entry-point IA top-right (spec 015 onda 2; PO-D1). O <DEV> migrou p/ o título do Perfil.
+function TodayHeader({ greeting, todayFormatted }) {
   return (
     <View style={styles.header}>
       <View style={styles.headerText}>
         <Text style={styles.greeting}>{greeting}</Text>
         <Text style={styles.date}>{todayFormatted}</Text>
       </View>
-      {__DEV__ && (
-        <TouchableOpacity
-          style={styles.devBtn}
-          onPress={onDevPress}
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          accessibilityRole="button"
-          accessibilityLabel="Abrir Dev Hub"
-        >
-          <Text style={styles.devBtnText}>DEV</Text>
-        </TouchableOpacity>
-      )}
+      <ChatEntryButton />
     </View>
   )
 }
@@ -389,7 +381,7 @@ function TodayScreenContent({
         contentContainerStyle={styles.scroll}
         refreshControl={<RefreshControl refreshing={loading && !!data} onRefresh={() => { refresh(); refreshNudge() }} tintColor={colors.status.success} />}
       >
-        <TodayHeader greeting={greeting} todayFormatted={todayFormatted} onDevPress={() => navigation?.navigate(ROUTES.DEV_HUB)} />
+        <TodayHeader greeting={greeting} todayFormatted={todayFormatted} />
         <AdherenceDayCard score={stats.score} trend={adherenceTrend} />
         <StockAlertInline alerts={stockAlerts} />
         {priorityDoses.length > 0 ? (
@@ -677,19 +669,6 @@ const styles = StyleSheet.create({
   headerText: {
     flex: 1,
     minWidth: 0,
-  },
-  devBtn: {
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-    borderRadius: 6,
-    backgroundColor: colors.status.warning,
-    marginLeft: 8,
-  },
-  devBtnText: {
-    fontSize: 11,
-    fontWeight: '800',
-    color: colors.text.inverse,
-    letterSpacing: 1,
   },
   greeting: {
     fontSize: 28,

--- a/apps/mobile/src/features/profile/screens/ProfileScreen.jsx
+++ b/apps/mobile/src/features/profile/screens/ProfileScreen.jsx
@@ -10,6 +10,7 @@ import ScreenContainer from '@shared/components/ui/ScreenContainer'
 import LoadingState from '@shared/components/states/LoadingState'
 import LogoutSheet from '@profile/components/LogoutSheet'
 import NudgeBanner from '@shared/components/ui/NudgeBanner'
+import DevBadge from '@features/_dev/components/DevBadge'
 import { useNudges } from '@profile/hooks/useNudges'
 import { colors, spacing, borderRadius, shadows, typography } from '@shared/styles/tokens'
 import { ROUTES } from '@navigation/routes'
@@ -88,7 +89,10 @@ export default function ProfileScreen() {
         }
       >
         <View style={styles.header}>
-          <Text style={styles.title}>Perfil</Text>
+          <View style={styles.titleRow}>
+            <Text style={styles.title}>Perfil</Text>
+            <DevBadge />
+          </View>
           <TouchableOpacity
             onPress={goToSettings}
             hitSlop={8}
@@ -298,6 +302,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingVertical: 16,
     marginBottom: 8,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
   },
   title: {
     fontSize: 28,

--- a/apps/mobile/src/features/stock/screens/StockScreen.jsx
+++ b/apps/mobile/src/features/stock/screens/StockScreen.jsx
@@ -15,6 +15,7 @@ import StockItem from '@stock/components/StockItem'
 import StockFilterChips from '@stock/components/StockFilterChips'
 import PurchaseMedicineSheet from '@stock/components/PurchaseMedicineSheet'
 import StaleBanner from '@shared/components/feedback/StaleBanner'
+import ChatEntryButton from '@features/chatbot/components/ChatEntryButton'
 import { colors, spacing, borderRadius, shadows, typography } from '@shared/styles/tokens'
 import { ROUTES } from '@navigation/routes'
 
@@ -33,10 +34,13 @@ function StockHeader({ filter, setFilter, counts }) {
   return (
     <View>
       <View style={styles.header}>
-        <Text style={styles.title}>Estoque</Text>
-        <Text style={styles.subtitle}>
-          Acompanhe o estoque dos medicamentos
-        </Text>
+        <View style={styles.headerTextCol}>
+          <Text style={styles.title}>Estoque</Text>
+          <Text style={styles.subtitle}>
+            Acompanhe o estoque dos medicamentos
+          </Text>
+        </View>
+        <ChatEntryButton />
       </View>
       <StockFilterChips value={filter} onChange={setFilter} counts={counts} />
     </View>
@@ -259,9 +263,15 @@ const styles = StyleSheet.create({
     paddingBottom: spacing[12],
   },
   header: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
     paddingHorizontal: spacing[5],
     paddingVertical: spacing[4],
     marginBottom: spacing[2],
+  },
+  headerTextCol: {
+    flex: 1,
   },
   title: {
     fontSize: 28,

--- a/apps/mobile/src/features/treatments/screens/TreatmentsScreen.jsx
+++ b/apps/mobile/src/features/treatments/screens/TreatmentsScreen.jsx
@@ -8,6 +8,7 @@ import ErrorState from '@shared/components/states/ErrorState'
 import EmptyState from '@shared/components/states/EmptyState'
 import TreatmentCard from '@treatments/components/TreatmentCard'
 import TreatmentPlanHeader from '@treatments/components/TreatmentPlanHeader'
+import ChatEntryButton from '@features/chatbot/components/ChatEntryButton'
 import TreatmentTabBar from '@treatments/components/TreatmentTabBar'
 import { useTreatments } from '@treatments/hooks/useTreatments'
 import { useProfile } from '@profile/hooks/useProfile'
@@ -206,8 +207,11 @@ export default function TreatmentsScreen() {
         }
       >
         <View style={styles.header}>
-          <Text style={styles.title}>Tratamentos</Text>
-          <Text style={styles.subtitle}>Acompanhe os tratamentos ativos</Text>
+          <View style={styles.headerTextCol}>
+            <Text style={styles.title}>Tratamentos</Text>
+            <Text style={styles.subtitle}>Acompanhe os tratamentos ativos</Text>
+          </View>
+          <ChatEntryButton />
         </View>
 
         {/* Link Medicamentos no topo APENAS no estado zero — destaque para onboarding.
@@ -322,9 +326,15 @@ const styles = StyleSheet.create({
     paddingBottom: spacing[10],
   },
   header: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
     paddingHorizontal: spacing[5],
     paddingVertical: spacing[4],
     marginBottom: spacing[2],
+  },
+  headerTextCol: {
+    flex: 1,
   },
   title: {
     fontSize: 28,

--- a/apps/mobile/src/navigation/Navigation.jsx
+++ b/apps/mobile/src/navigation/Navigation.jsx
@@ -25,6 +25,7 @@ import ForgotPasswordScreen from '../screens/ForgotPasswordScreen'
 import ResetPasswordScreen from '../screens/ResetPasswordScreen'
 import RootTabs from './RootTabs'
 import AlarmFullScreen from '../features/dose/screens/AlarmFullScreen'
+import ChatScreen from '../features/chatbot/screens/ChatScreen'
 import DevHubScreen from '../features/_dev/screens/DevHubScreen'
 import StockPrimitivesDemoScreen from '../features/_dev/screens/StockPrimitivesDemoScreen'
 import DosePrimitivesDemoScreen from '../features/_dev/screens/DosePrimitivesDemoScreen'
@@ -242,6 +243,8 @@ export default function Navigation() {
               component={AlarmFullScreen}
               options={{ presentation: 'fullScreenModal', gestureEnabled: false }}
             />
+            {/* Chat IA full-screen (spec 015 onda 2) — header próprio na tela */}
+            <Stack.Screen name={ROUTES.CHAT} component={ChatScreen} />
             {__DEV__ && (
               <>
                 <Stack.Screen

--- a/apps/mobile/src/navigation/routes.js
+++ b/apps/mobile/src/navigation/routes.js
@@ -68,6 +68,9 @@ export const ROUTES = {
   // Área de Medidas / biomarcadores (012 Fase C)
   MEASURES: 'Measures',
 
+  // Chat IA (spec 015 onda 2) — tela full-screen via stack
+  CHAT: 'Chat',
+
   // Dev-only (apenas __DEV__)
   DEV_HUB: 'DevHub',
   STOCK_PRIMITIVES_DEMO: 'StockPrimitivesDemo',

--- a/apps/mobile/src/platform/config/nativePublicAppConfig.js
+++ b/apps/mobile/src/platform/config/nativePublicAppConfig.js
@@ -11,3 +11,9 @@ export const nativePublicAppConfig = createPublicAppConfig({
   detectSessionInUrl: false,
   appEnv: process.env.EXPO_PUBLIC_APP_ENV ?? 'development',
 })
+
+// URL base da API serverless (Vercel) — usada p/ chamar `api/chatbot.js` do mobile (spec 015).
+// Único lugar que lê a env (AP-242: nunca hardcodar). Fallback dev = produção.
+export const nativeApiBaseUrl = (
+  process.env.EXPO_PUBLIC_API_BASE_URL ?? 'https://dosiq.app'
+).replace(/\/+$/, '')

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dosiq/web",
-  "version": "4.13.0",
+  "version": "4.14.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/features/chatbot/components/ChatMessageList.jsx
+++ b/apps/web/src/features/chatbot/components/ChatMessageList.jsx
@@ -1,47 +1,38 @@
 /**
  * ChatMessageList — Renderiza a lista de mensagens do chat.
+ *
+ * Parse de markdown via `@dosiq/core` (parser puro único web↔mobile, spec 015 onda 2);
+ * aqui só o render adapter web (tokens → JSX HTML).
  */
+import { parseMessageMarkdown } from '@dosiq/core'
 
-/**
- * Renderiza spans inline de uma linha: **bold** e _italic_.
- */
-function renderInline(text) {
-  const parts = text.split(/(\*\*[^*]+\*\*|_[^_]+_)/g)
-  return parts.filter(Boolean).map((part, i) => {
-    if (part.startsWith('**') && part.endsWith('**') && part.length > 4) {
-      return <strong key={i}>{part.slice(2, -2)}</strong>
-    }
-    if (part.startsWith('_') && part.endsWith('_') && part.length > 2) {
-      return <em key={i}>{part.slice(1, -1)}</em>
-    }
-    return <span key={i}>{part}</span>
+/** Render web dos segmentos inline (bold/italic/text) de uma linha. */
+function renderSegments(segments) {
+  return segments.map((seg, i) => {
+    if (seg.type === 'bold') return <strong key={i}>{seg.value}</strong>
+    if (seg.type === 'italic') return <em key={i}>{seg.value}</em>
+    return <span key={i}>{seg.value}</span>
   })
 }
 
 /**
- * Renderiza conteúdo com suporte básico a markdown inline:
- * **negrito**, _itálico_, listas com `-`/`*`/`+` (com sub-nível) e quebras de linha.
- *
- * Markers de lista: `-`/`*` = nível 0 (`•`); `+` = sub-item (`◦` indentado).
- * O Groq emite `*` para categorias e `+` para itens aninhados.
+ * Render do conteúdo com markdown leve (**negrito**, _itálico_, listas `-`/`*`/`+`, quebras).
+ * Markers: `-`/`*` = nível 0 (`•`); `+` = sub-item (`◦` indentado). Parse no core.
  */
 function renderMessageContent(content) {
-  return content.split('\n').map((line, lineIdx) => {
-    const bullet = line.match(/^(\s*)([-*+])\s+(.*)$/)
-    return (
-      <span key={lineIdx}>
-        {lineIdx > 0 && <br />}
-        {bullet ? (
-          <span style={{ paddingLeft: bullet[2] === '+' ? '1.25em' : 0 }}>
-            {bullet[2] === '+' ? '◦ ' : '• '}
-            {renderInline(bullet[3])}
-          </span>
-        ) : (
-          renderInline(line)
-        )}
-      </span>
-    )
-  })
+  return parseMessageMarkdown(content).map((line, lineIdx) => (
+    <span key={lineIdx}>
+      {lineIdx > 0 && <br />}
+      {line.bullet !== 'none' ? (
+        <span style={{ paddingLeft: line.bullet === 'subitem' ? '1.25em' : 0 }}>
+          {line.bullet === 'subitem' ? '◦ ' : '• '}
+          {renderSegments(line.segments)}
+        </span>
+      ) : (
+        renderSegments(line.segments)
+      )}
+    </span>
+  ))
 }
 
 export default function ChatMessageList({ messages, isLoading, messagesEndRef, shouldShowDateSeparator, formatDaySeparator, formatMessageTime, styles }) {

--- a/apps/web/src/features/chatbot/config/chatbotConfig.js
+++ b/apps/web/src/features/chatbot/config/chatbotConfig.js
@@ -15,10 +15,12 @@
 
 /**
  * Máximo de tokens na resposta do LLM.
- * 512 (era 300) — 300 truncava listas úteis (doses pendentes/atrasadas) e modelos
- * com reasoning (ex.: gpt-oss) consomem tokens de raciocínio dentro deste teto.
+ * 1024 (era 512, era 300) — modelos com reasoning (ex.: gpt-oss-120b) gastam tokens
+ * de raciocínio DENTRO deste teto, então 512 ainda truncava respostas com listas
+ * (ex.: explicar todas as doses do paciente cortava no último item). 1024 dá folga
+ * p/ raciocínio + resposta completa; custo Groq desprezível no free/dev tier.
  */
-export const CHATBOT_MAX_TOKENS = 512
+export const CHATBOT_MAX_TOKENS = 1024
 
 /**
  * Temperature conservadora para respostas factuais (médico/farmácia).
@@ -115,6 +117,8 @@ export function buildStaticSystemRules() {
   return [
     'Você é o assistente de saúde do app Dosiq, focado em ajudar o paciente a seguir seus tratamentos e melhorar a adesão.',
     'Missão: responder com clareza "o que o paciente precisa fazer agora" — doses de hoje, adesão e estoque — com tom acolhedor e sem alarmismo, adequado a pessoas com condições crônicas e a idosos.',
+    'O que é o Dosiq: um app que ORGANIZA o tratamento — cadastro de medicamentos, lembretes de doses, controle de adesão e de estoque, e relatórios. O Dosiq NÃO vende, NÃO entrega e NÃO compra medicamentos; NÃO faz consultas, exames nem teleatendimento. NUNCA afirme que o app tem uma funcionalidade que não foi listada aqui — se não souber, diga que não sabe; não invente recursos do app.',
+    'Contexto regional: o Dosiq é um app exclusivo do Brasil. Use sempre o português do Brasil e o contexto farmacêutico brasileiro — nomes comerciais, apresentações e bulas conforme a ANVISA. Não use nomes ou apresentações de outros países.',
     '',
     'O QUE VOCÊ PODE FAZER:',
     '- Informar as doses de hoje (próximas e atrasadas), a adesão e a situação de estoque a partir dos DADOS DO PACIENTE.',

--- a/packages/core/src/chatbot/__tests__/buildPatientContext.test.js
+++ b/packages/core/src/chatbot/__tests__/buildPatientContext.test.js
@@ -66,7 +66,7 @@ describe('buildPatientContext', () => {
       stockSummary: mockStockSummary,
       stats: null,
     })
-    expect(result).toContain('20 un.')
+    expect(result).toContain('20 unidades')
   })
 
   it('inclui adesao 7d quando disponivel', () => {
@@ -137,7 +137,7 @@ describe('buildPatientContext', () => {
       stockSummary: mockStockSummary,
       stats: null,
     })
-    expect(result).toContain('consumo ~1/dia')
+    expect(result).toContain('consumo ~1 un./dia')
     expect(result).toContain('40 dias restantes')
   })
 
@@ -235,7 +235,7 @@ describe('buildPatientContext', () => {
       stockSummary: [],
       stats: null,
     })
-    expect(result).toContain('estoque 20 un.')
+    expect(result).toContain('estoque 20 unidades')
   })
 })
 
@@ -326,5 +326,84 @@ describe('buildPatientContext — agrupamento por plano (onda 1b)', () => {
     expect(result).not.toContain('Plano "')
     expect(result).toContain('- Atorvastatina')
     expect(result).toContain('- Sinvastatina')
+  })
+})
+
+// -- Fixes multi-superfície (líquidos, semanais, perfil, resolução de nome) --
+describe('buildPatientContext — unidades líquidas / semanais / perfil', () => {
+  const lantus = {
+    id: 'liq-1', name: 'Lantus', active_ingredient: 'Insulina Glargina', therapeutic_class: 'Antidiabeticos',
+    dosage_per_pill: 100, dosage_unit: 'ui/ml', units_per_ml: 100, stock: [{ quantity: 5.2 }],
+  }
+  const lantusProto = {
+    medicine_id: 'liq-1', active: true, frequency: 'diario', time_schedule: ['15:00'],
+    intake_unit: 'UI', dosage_per_intake: 10,
+  }
+  const lantusStock = [{ medicine: { id: 'liq-1' }, total: 5.2, daysRemaining: 52, dailyIntake: 0.1, isZero: false, isLow: false }]
+
+  it('líquido: estoque em ml, dose em UI com ≈ml, consumo em ml/dia (não "un.")', () => {
+    const result = buildPatientContext({
+      medicines: [lantus], protocols: [lantusProto], logs: [], stockSummary: lantusStock, stats: null,
+    })
+    expect(result).toContain('estoque 5,2 ml')
+    expect(result).toContain('dose 10 UI (≈ 0,1 ml)')
+    expect(result).toContain('consumo ~0,1 ml/dia')
+    expect(result).not.toContain('5,2 un.')
+  })
+
+  it('semanal: inclui o(s) dia(s) da semana agendado(s)', () => {
+    const ozempic = { id: 'liq-2', name: 'Ozempic', dosage_per_pill: 1.34, dosage_unit: 'mg/ml', stock: [{ quantity: 1.5 }] }
+    const result = buildPatientContext({
+      medicines: [ozempic],
+      protocols: [{ medicine_id: 'liq-2', active: true, frequency: 'semanal', weekdays: ['sábado'], time_schedule: ['15:00'] }],
+      logs: [], stockSummary: [{ medicine: { id: 'liq-2' }, total: 1.5, daysRemaining: 14, dailyIntake: 0.1, isZero: false, isLow: false }], stats: null,
+    })
+    expect(result).toContain('semanal (sábado)')
+  })
+
+  it('semanal entra no contexto MESMO quando a dose não cai hoje (filtro por período, não por frequência)', () => {
+    // start no passado, sem end_date → vigente; weekdays vazio não exclui da listagem
+    const result = buildPatientContext({
+      medicines: [{ id: 'w1', name: 'Mounjaro', dosage_per_pill: 5, dosage_unit: 'mg/ml', stock: [{ quantity: 1.5 }] }],
+      protocols: [{ medicine_id: 'w1', active: true, frequency: 'semanal', weekdays: ['quinta'], start_date: '2026-01-01', time_schedule: ['22:00'] }],
+      logs: [], stockSummary: [{ medicine: { id: 'w1' }, total: 1.5, daysRemaining: 21, dailyIntake: 0.07, isZero: false, isLow: false }], stats: null,
+    })
+    expect(result).toContain('Mounjaro')
+    expect(result).toContain('Tratamentos ativos: 1')
+  })
+
+  it('doses pendentes resolvem o NOME do medicamento (não "Desconhecido")', () => {
+    // Protocolo COM id casando a dose; medicine anexado pelo builder (medicine_id → medicines[]).
+    const proto = { ...lantusProto, id: 'p-liq-1' }
+    const result = buildPatientContext({
+      medicines: [lantus], protocols: [proto], logs: [], stockSummary: lantusStock, stats: null,
+      doseInstances: [{ id: 'di-1', protocol_id: 'p-liq-1', medicine_id: 'liq-1', scheduled_for: new Date().toISOString(), status: 'pending' }],
+    })
+    expect(result).toContain('Próximas doses pendentes hoje')
+    expect(result).toContain('Lantus')
+    expect(result).not.toContain('Desconhecido')
+  })
+
+  it('perfil preenchido → linha "Paciente: <nome>, <idade> anos"', () => {
+    const result = buildPatientContext({
+      medicines: [lantus], protocols: [lantusProto], logs: [], stockSummary: lantusStock, stats: null,
+      profile: { display_name: 'Maria Silva', birth_date: '1950-06-01' },
+    })
+    expect(result).toMatch(/Paciente: Maria Silva, \d+ anos/)
+  })
+
+  it('perfil vazio → sem linha Paciente', () => {
+    const result = buildPatientContext({
+      medicines: [lantus], protocols: [lantusProto], logs: [], stockSummary: lantusStock, stats: null,
+      profile: { display_name: null, birth_date: null },
+    })
+    expect(result).not.toContain('Paciente:')
+  })
+
+  it('data inclui o dia da semana nomeado', () => {
+    const result = buildPatientContext({
+      medicines: [lantus], protocols: [lantusProto], logs: [], stockSummary: lantusStock, stats: null,
+    })
+    expect(result).toMatch(/Data: (domingo|segunda-feira|terça-feira|quarta-feira|quinta-feira|sexta-feira|sábado),/)
   })
 })

--- a/packages/core/src/chatbot/buildPatientContext.js
+++ b/packages/core/src/chatbot/buildPatientContext.js
@@ -14,15 +14,55 @@
 // - Manter o contexto compacto (<2000 tokens) p/ não estourar o free tier do LLM.
 // - dateUtils SEMPRE do core (R-020); zero `new Date()` direto.
 
-import { getTodayLocal, getSaoPauloTime, parseISO, getNow } from '../utils/dateUtils.js'
+import { getTodayLocal, getSaoPauloTime, parseISO, getNow, parseLocalDate, isProtocolActiveOnDate as isProtocolInPeriod } from '../utils/dateUtils.js'
 import { splitDayTimeline } from '../utils/doseZones.js'
-import { formatDoseItem } from '../utils/doseUnit.js'
-import { isProtocolActiveOnDate } from '../utils/adherenceLogic.js'
+import { formatDoseItem, formatStockCount, formatIntakeDose, stockUnitLabel, formatNumberPtBR } from '../utils/doseUnit.js'
+import { getProtocolDays } from '../utils/adherenceLogic.js'
+import { calculateAge } from '../utils/profile.js'
+
+/** Nomes dos dias da semana em PT (índice = Date.getDay(): 0=domingo). */
+const WEEKDAYS_PT = ['domingo', 'segunda-feira', 'terça-feira', 'quarta-feira', 'quinta-feira', 'sexta-feira', 'sábado']
 
 /** Formata dias restantes (relativo) — Infinity/sem consumo → null (omitido). */
 function _formatDaysRemaining(daysRemaining) {
   if (daysRemaining == null || !Number.isFinite(daysRemaining)) return null
   return `${Math.floor(daysRemaining)} dia${Math.floor(daysRemaining) === 1 ? '' : 's'}`
+}
+
+/** Campos derivados do PROTOCOLO (extraído p/ baixar complexidade de _toMedContext). */
+function _protocolFields(protocol) {
+  return {
+    frequencia: protocol?.frequency ?? 'sem protocolo',
+    horarios: protocol?.time_schedule ?? [],
+    // Dias da semana agendados (semanal) — sem isso o LLM só via o horário (dose
+    // semanal sem dia parece diária). getProtocolDays cobre weekdays[]/days[].
+    weekdays: getProtocolDays(protocol),
+    // Dose por tomada na unidade de tomada (gotas/UI/ml) p/ exibir certo em líquidos.
+    dosePerIntake: protocol?.dosage_per_intake ?? null,
+    intakeUnit: protocol?.intake_unit ?? null,
+    // Plano terapêutico nomeado (onda 1b). Vazio/nulo/só-espaços → sem plano (flat, sem header).
+    planName: protocol?.treatment_plan?.name?.trim() || null,
+  }
+}
+
+/**
+ * Identificação leve do paciente (se preenchida no perfil): personaliza o tom e dá
+ * contexto etário (idoso → linguagem mais simples). Nome/idade não são PII sensível
+ * (nada de IDs, CPF, contato). Retorna '' (omitido) quando vazio.
+ */
+function _formatPatientLine(profile) {
+  const name = profile?.display_name?.trim() || null
+  const age = calculateAge(profile?.birth_date)
+  if (!name && age == null) return ''
+  return `Paciente: ${[name, age != null ? `${age} anos` : null].filter(Boolean).join(', ')}`
+}
+
+/** Saldo de estoque: stockSummary.total, ou soma dos lotes embedded (fallback). */
+function _resolveStock(med, stockEntry) {
+  return (
+    stockEntry?.total ??
+    (med.stock || []).filter((s) => s.quantity > 0).reduce((sum, s) => sum + s.quantity, 0)
+  )
 }
 
 /**
@@ -34,33 +74,52 @@ function _formatDaysRemaining(daysRemaining) {
 function _toMedContext(med, validProtocols, stockByMedId) {
   const protocol = validProtocols.find((p) => p.medicine_id === med.id)
   const stockEntry = stockByMedId.get(med.id)
-  const totalStock =
-    stockEntry?.total ??
-    (med.stock || []).filter((s) => s.quantity > 0).reduce((sum, s) => sum + s.quantity, 0)
+  const totalStock = _resolveStock(med, stockEntry)
 
   return {
     nome: med.name,
     principioAtivo: med.active_ingredient,
     classeTerapeutica: med.therapeutic_class,
     dosagem: `${med.dosage_per_pill ?? ''}${med.dosage_unit ?? ''}`.trim(),
-    frequencia: protocol?.frequency ?? 'sem protocolo',
-    horarios: protocol?.time_schedule ?? [],
     estoque: totalStock,
     consumoDiario: stockEntry?.dailyIntake ?? null,
     diasRestantes: _formatDaysRemaining(stockEntry?.daysRemaining),
     semEstoque: stockEntry?.isZero ?? totalStock === 0,
-    // Plano terapêutico nomeado (onda 1b). Vazio/nulo/só-espaços → sem plano (flat, sem header).
-    planName: protocol?.treatment_plan?.name?.trim() || null,
+    // Objeto medicine-like p/ os formatadores unit-aware (líquidos vs sólidos) do doseUnit.
+    medLike: {
+      dosage_unit: med.dosage_unit ?? null,
+      dosage_per_pill: med.dosage_per_pill ?? null,
+      units_per_ml: med.units_per_ml ?? null,
+    },
+    ..._protocolFields(protocol),
   }
 }
 
-/** Linha flat de um medicamento (formato legado, reusado dentro e fora de grupos). */
+/** Cronograma: frequência + (dias da semana p/ semanal) + horários. */
+function _formatSchedule(mc) {
+  const horarios = mc.horarios.join(', ') || 'nao definidos'
+  const freq = (mc.frequencia || '').toLowerCase()
+  if ((freq === 'semanal' || freq === 'weekly') && mc.weekdays?.length) {
+    return `semanal (${mc.weekdays.join(', ')}), horarios ${horarios}`
+  }
+  return `${mc.frequencia}, horarios ${horarios}`
+}
+
+/**
+ * Linha de um medicamento. Unidades unit-aware (R-022/líquidos 022): estoque, consumo e
+ * dose por tomada usam a unidade real do medicamento (ml/UI/gotas p/ líquidos; un./mg p/
+ * sólidos) — NUNCA "un." cego (ex.: "5,2 ml" de Lantus, não "5,2 un.").
+ */
 function _formatMedLine(mc) {
   const infos = [mc.principioAtivo, mc.classeTerapeutica].filter(Boolean).join(', ')
   const detalhe = infos ? ` [${infos}]` : ''
-  const consumo = mc.consumoDiario ? `, consumo ~${mc.consumoDiario}/dia` : ''
+  const dose = mc.dosePerIntake ? `, dose ${formatIntakeDose(mc.dosePerIntake, mc.intakeUnit, mc.medLike)}` : ''
+  const estoque = formatStockCount(mc.estoque, mc.medLike)
+  const consumo = mc.consumoDiario
+    ? `, consumo ~${formatNumberPtBR(Math.round(mc.consumoDiario * 100) / 100)} ${stockUnitLabel(mc.medLike)}/dia`
+    : ''
   const dias = mc.diasRestantes ? `, ~${mc.diasRestantes} restantes` : ''
-  return `- ${mc.nome}${detalhe} (${mc.dosagem}): ${mc.frequencia}, horarios ${mc.horarios.join(', ') || 'nao definidos'}, estoque ${mc.estoque} un.${consumo}${dias}`
+  return `- ${mc.nome}${detalhe} (${mc.dosagem}): ${_formatSchedule(mc)}${dose}, estoque ${estoque}${consumo}${dias}`
 }
 
 /**
@@ -88,50 +147,16 @@ function _buildMedLines(medsContext) {
   return lines
 }
 
-/**
- * Monta contexto compacto do paciente para enviar ao LLM.
- *
- * ESCOPO (decisão de produto, R-278): considera SOMENTE tratamentos ATIVOS com prescrição
- * válida na data da interação (`p.active && isProtocolActiveOnDate(p, hoje)`). Finalizados,
- * pausados e não-iniciados NÃO entram — evita o bot sugerir repor estoque de cursos encerrados.
- *
- * @param {Object} data - Saída do fetcher canônico (ver chatbotContextSchema / CON-028)
- * @param {Array} data.medicines - Medicamentos (incluem .stock[] embedded)
- * @param {Array} data.protocols - Protocolos (todos; filtrados por ativo+válido aqui)
- * @param {Array} data.logs - Logs recentes (filtrados p/ hoje internamente)
- * @param {Array} data.stockSummary - Resumo de estoque rich ({medicine,total,daysRemaining,dailyIntake,isZero,isLow})
- * @param {Object} data.stats - Stats de adesão ({ adherence: 0-1 })
- * @param {Array} data.doseInstances - Ocorrências de dose materializadas (próximas/atrasadas)
- * @returns {string} - Contexto formatado para o system prompt
- */
-export function buildPatientContext({ medicines, protocols, logs, stockSummary, stats, doseInstances } = {}) {
-  const today = getTodayLocal('America/Sao_Paulo') // String YYYY-MM-DD (tz explícito — Hermes/Android)
-  const [y, m, d] = today.split('-').map(Number)
-  const todayStr = `${d.toString().padStart(2, '0')}/${m.toString().padStart(2, '0')}/${y}`
-
-  // Apenas tratamentos ATIVOS com prescrição válida hoje (exclui finalizados/pausados/futuros)
-  const validProtocols = (protocols || []).filter(
-    (p) => p.active && isProtocolActiveOnDate(p, today)
-  )
-  const validMedicineIds = new Set(validProtocols.map((p) => p.medicine_id))
-  const stockByMedId = new Map((stockSummary || []).map((s) => [s.medicine?.id, s]))
-
-  const medsContext = (medicines || [])
-    .filter((med) => validMedicineIds.has(med.id))
-    .map((med) => _toMedContext(med, validProtocols, stockByMedId))
-
-  const todayLogs = (logs || []).filter((log) => {
+/** Logs registrados HOJE (no tz local) — filtragem por ano/mês/dia. */
+function _countTodayLogs(logs, y, m, d) {
+  return (logs || []).filter((log) => {
     const logDate = getSaoPauloTime(parseISO(log.taken_at))
-    return (
-      logDate.getFullYear() === y &&
-      logDate.getMonth() + 1 === m &&
-      logDate.getDate() === d
-    )
+    return logDate.getFullYear() === y && logDate.getMonth() + 1 === m && logDate.getDate() === d
   })
+}
 
-  const adherence7d = stats?.adherence != null ? Math.round(stats.adherence * 100) : null
-
-  // Próximas doses pendentes (hoje) e atrasadas (dias anteriores ainda actionáveis)
+/** Filas de doses: pendentes de hoje (ordenadas) + atrasadas actionáveis (carry-over). */
+function _resolveDoseQueues(doseInstances, validProtocols) {
   const { carryOver = [], today: todayDoses = [] } = splitDayTimeline(
     doseInstances || [],
     validProtocols,
@@ -141,6 +166,58 @@ export function buildPatientContext({ medicines, protocols, logs, stockSummary, 
     .filter((dose) => dose.status === 'pending')
     .sort((a, b) => a.scheduledTime.localeCompare(b.scheduledTime))
   const overdue = carryOver.filter((dose) => dose.status === 'pending')
+  return { pendingToday, overdue }
+}
+
+/**
+ * Monta contexto compacto do paciente para enviar ao LLM.
+ *
+ * ESCOPO (decisão de produto, R-278): considera SOMENTE tratamentos ATIVOS com prescrição
+ * vigente no PERÍODO da data da interação (`p.active && isProtocolInPeriod(p, hoje)`).
+ * Finalizados, pausados e não-iniciados NÃO entram — evita o bot sugerir repor estoque de
+ * cursos encerrados. NÃO filtra por frequência cair hoje (senão tratamentos semanais/PRN/
+ * personalizados sumiriam do contexto fora do dia exato da dose); doses pendentes de HOJE
+ * seguem por caminho próprio (splitDayTimeline sobre doseInstances).
+ *
+ * @param {Object} data - Saída do fetcher canônico (ver chatbotContextSchema / CON-028)
+ * @param {Array} data.medicines - Medicamentos (incluem .stock[] embedded)
+ * @param {Array} data.protocols - Protocolos (todos; filtrados por ativo+válido aqui)
+ * @param {Array} data.logs - Logs recentes (filtrados p/ hoje internamente)
+ * @param {Array} data.stockSummary - Resumo de estoque rich ({medicine,total,daysRemaining,dailyIntake,isZero,isLow})
+ * @param {Object} data.stats - Stats de adesão ({ adherence: 0-1 })
+ * @param {Array} data.doseInstances - Ocorrências de dose materializadas (próximas/atrasadas)
+ * @param {Object} [data.profile] - Perfil leve do paciente ({ display_name, birth_date }) — sem PII sensível
+ * @returns {string} - Contexto formatado para o system prompt
+ */
+export function buildPatientContext({ medicines, protocols, logs, stockSummary, stats, doseInstances, profile } = {}) {
+  const today = getTodayLocal('America/Sao_Paulo') // String YYYY-MM-DD (tz explícito — Hermes/Android)
+  const [y, m, d] = today.split('-').map(Number)
+  // Dia da semana nomeado: permite ao LLM raciocinar sobre semanais/personalizados quando
+  // a pergunta é geral (ex.: "o que tomo às quintas?"), já que todo tratamento ativo entra
+  // no contexto independente de a frequência cair hoje.
+  const weekday = WEEKDAYS_PT[parseLocalDate(today).getDay()]
+  const todayStr = `${weekday}, ${d.toString().padStart(2, '0')}/${m.toString().padStart(2, '0')}/${y}`
+
+  // Apenas tratamentos ATIVOS com prescrição vigente no período hoje (exclui finalizados/
+  // pausados/futuros). NÃO exige que a frequência caia hoje — semanais/PRN/personalizados
+  // são tratamentos válidos mesmo sem dose no dia da interação.
+  // Anexa o medicamento (do array `medicines`) a cada protocolo: o fetcher seleciona
+  // protocols só com o join de treatment_plan, sem medicine — sem isto, splitDayTimeline
+  // não resolve o nome/unidade da dose ("Desconhecido", "un." cego).
+  const medsById = new Map((medicines || []).map((m) => [m.id, m]))
+  const validProtocols = (protocols || [])
+    .filter((p) => p.active && isProtocolInPeriod(p, today))
+    .map((p) => ({ ...p, medicine: p.medicine ?? medsById.get(p.medicine_id) ?? null }))
+  const validMedicineIds = new Set(validProtocols.map((p) => p.medicine_id))
+  const stockByMedId = new Map((stockSummary || []).map((s) => [s.medicine?.id, s]))
+
+  const medsContext = (medicines || [])
+    .filter((med) => validMedicineIds.has(med.id))
+    .map((med) => _toMedContext(med, validProtocols, stockByMedId))
+
+  const todayLogs = _countTodayLogs(logs, y, m, d)
+  const adherence7d = stats?.adherence != null ? Math.round(stats.adherence * 100) : null
+  const { pendingToday, overdue } = _resolveDoseQueues(doseInstances, validProtocols)
 
   // Alertas de estoque (somente tratamentos válidos) — sem estoque ou baixo
   const stockAlerts = medsContext
@@ -152,6 +229,7 @@ export function buildPatientContext({ medicines, protocols, logs, stockSummary, 
     )
 
   return [
+    _formatPatientLine(profile),
     `Data: ${todayStr}`,
     `Tratamentos ativos: ${medsContext.length}`,
     ..._buildMedLines(medsContext),

--- a/packages/core/src/chatbot/chatbotContextSchema.js
+++ b/packages/core/src/chatbot/chatbotContextSchema.js
@@ -41,6 +41,9 @@ export const chatbotContextDataSchema = z.object({
   stats: statsSchema.nullable().default(null),
   doseInstances: z.array(looseRow).default([]),
   treatmentPlans: z.array(looseRow).default([]),
+  // Perfil leve do paciente (nome/idade). Secundário — pode ser null. passthrough tolera
+  // colunas extras de user_settings sem enrijecer o shape.
+  profile: looseRow.nullable().default(null),
 })
 
 /**

--- a/packages/core/src/chatbot/fetchChatbotContextData.js
+++ b/packages/core/src/chatbot/fetchChatbotContextData.js
@@ -92,7 +92,7 @@ export async function fetchChatbotContextData({ supabase, getUserId }) {
   const doseRepo = createDoseInstanceRepository({ client: supabase })
 
   // Selects canônicos — uma definição, paralelos.
-  const [medicinesRes, protocolsRes, logsRes, plansRes, doseInstances, stats] = await Promise.all([
+  const [medicinesRes, protocolsRes, logsRes, plansRes, profileRes, doseInstances, stats] = await Promise.all([
     supabase.from('medicines').select('*, stock(*)').eq('user_id', userId),
     supabase
       .from('protocols')
@@ -100,11 +100,14 @@ export async function fetchChatbotContextData({ supabase, getUserId }) {
       .eq('user_id', userId),
     supabase.from('medicine_logs').select('protocol_id, taken_at').eq('user_id', userId).gte('taken_at', yesterdayIso),
     supabase.from('treatment_plans').select('id, name').eq('user_id', userId),
+    // Perfil leve (nome/idade) p/ personalizar tom — DADO SECUNDÁRIO: degrada gracioso
+    // (não derruba o contexto se falhar). Perfil vive em user_settings (1 linha/user).
+    supabase.from('user_settings').select('display_name, birth_date').eq('user_id', userId).maybeSingle(),
     doseRepo.getWindow(userId, windowFrom, windowTo),
     computeInstancesAdherence(doseRepo, userId),
   ])
 
-  // Falha alto: erro de select não pode gerar contexto silenciosamente parcial (FR-010).
+  // Falha alto: erro de select PRIMÁRIO não pode gerar contexto silenciosamente parcial (FR-010).
   for (const res of [medicinesRes, protocolsRes, logsRes, plansRes]) {
     if (res.error) throw res.error
   }
@@ -119,6 +122,8 @@ export async function fetchChatbotContextData({ supabase, getUserId }) {
     stats,
     doseInstances: doseInstances || [],
     treatmentPlans: plansRes.data || [],
+    // Secundário: erro → null (não bloqueia o contexto).
+    profile: profileRes.error ? null : profileRes.data || null,
   }
 
   // Seam Zod (CON-028) — valida o shape antes do builder (FR-010 mecanismo 3).

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -28,5 +28,8 @@ export * from './services/index.js'
 // Re-exporte de chatbot (spec 015 — fetcher + builder canônico de contexto, CON-028)
 export * from './chatbot/index.js'
 
+// Re-exporte de markdown (spec 015 onda 2 — parser leve do chat, paridade web↔mobile)
+export * from './markdown/index.js'
+
 // Re-exporte de protocols-utils (opcional, auditado em 2.4)
 // export * from './protocols-utils/index.js'

--- a/packages/core/src/markdown/__tests__/parseMessageMarkdown.test.js
+++ b/packages/core/src/markdown/__tests__/parseMessageMarkdown.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { parseMessageMarkdown, parseInlineSegments } from '../parseMessageMarkdown.js'
+
+describe('parseInlineSegments', () => {
+  it('texto cru → 1 segmento text', () => {
+    expect(parseInlineSegments('oi mundo')).toEqual([{ type: 'text', value: 'oi mundo' }])
+  })
+  it('**negrito**', () => {
+    expect(parseInlineSegments('a **b** c')).toEqual([
+      { type: 'text', value: 'a ' },
+      { type: 'bold', value: 'b' },
+      { type: 'text', value: ' c' },
+    ])
+  })
+  it('_itálico_', () => {
+    expect(parseInlineSegments('x _y_ z')).toEqual([
+      { type: 'text', value: 'x ' },
+      { type: 'italic', value: 'y' },
+      { type: 'text', value: ' z' },
+    ])
+  })
+  it('** solto (malformado) → texto cru, sem crash', () => {
+    expect(parseInlineSegments('a ** b')).toEqual([{ type: 'text', value: 'a ** b' }])
+  })
+  it('vazio/null → []', () => {
+    expect(parseInlineSegments('')).toEqual([])
+    expect(parseInlineSegments(null)).toEqual([])
+  })
+})
+
+describe('parseMessageMarkdown', () => {
+  it('linha simples → bullet none', () => {
+    const r = parseMessageMarkdown('olá')
+    expect(r).toHaveLength(1)
+    expect(r[0].bullet).toBe('none')
+    expect(r[0].segments).toEqual([{ type: 'text', value: 'olá' }])
+  })
+  it('item `-`/`*` → bullet item', () => {
+    expect(parseMessageMarkdown('- um')[0].bullet).toBe('item')
+    expect(parseMessageMarkdown('* dois')[0].bullet).toBe('item')
+  })
+  it('sub-item `+` → bullet subitem', () => {
+    expect(parseMessageMarkdown('+ filho')[0].bullet).toBe('subitem')
+  })
+  it('multi-linha preserva ordem + segmentos inline por linha', () => {
+    const r = parseMessageMarkdown('intro\n- **A**\n+ b')
+    expect(r.map((l) => l.bullet)).toEqual(['none', 'item', 'subitem'])
+    expect(r[1].segments).toEqual([{ type: 'bold', value: 'A' }])
+  })
+  it('null/vazio não lança', () => {
+    expect(() => parseMessageMarkdown(null)).not.toThrow()
+    expect(parseMessageMarkdown('')).toEqual([{ bullet: 'none', segments: [] }])
+  })
+})

--- a/packages/core/src/markdown/index.js
+++ b/packages/core/src/markdown/index.js
@@ -1,0 +1,2 @@
+// @dosiq/core/markdown — parse leve de markdown do chatbot (paridade web↔mobile, spec 015).
+export { parseMessageMarkdown, parseInlineSegments } from './parseMessageMarkdown.js'

--- a/packages/core/src/markdown/parseMessageMarkdown.js
+++ b/packages/core/src/markdown/parseMessageMarkdown.js
@@ -1,0 +1,52 @@
+// parseMessageMarkdown.js — Tokenizer PURO de markdown leve do chatbot (spec 015 onda 2).
+//
+// Fonte ÚNICA da lógica de parse compartilhada web↔mobile (antes só no web #681,
+// `ChatMessageList.jsx`). Cada superfície tem seu render adapter (web→JSX HTML,
+// mobile→RN Text) consumindo esta estrutura — paridade de formatação por construção.
+//
+// Suporta: **negrito**, _itálico_, listas `-`/`*` (item nível 0) e `+` (sub-item),
+// quebras de linha. (O Groq emite `*` p/ categorias e `+` p/ itens aninhados.)
+
+/**
+ * @typedef {{ type: 'text'|'bold'|'italic', value: string }} InlineSegment
+ * @typedef {{ bullet: 'none'|'item'|'subitem', segments: InlineSegment[] }} MarkdownLine
+ */
+
+/**
+ * Quebra uma linha em segmentos inline (**bold** / _italic_ / texto cru).
+ * @param {string} text
+ * @returns {InlineSegment[]}
+ */
+export function parseInlineSegments(text) {
+  const parts = (text ?? '').split(/(\*\*[^*]+\*\*|_[^_]+_)/g)
+  return parts
+    .filter(Boolean)
+    .map((part) => {
+      if (part.startsWith('**') && part.endsWith('**') && part.length > 4) {
+        return { type: 'bold', value: part.slice(2, -2) }
+      }
+      if (part.startsWith('_') && part.endsWith('_') && part.length > 2) {
+        return { type: 'italic', value: part.slice(1, -1) }
+      }
+      return { type: 'text', value: part }
+    })
+}
+
+/**
+ * Parseia uma mensagem em linhas estruturadas (bullet + segmentos inline).
+ * Markdown malformado degrada para texto cru (nunca lança).
+ * @param {string} content
+ * @returns {MarkdownLine[]}
+ */
+export function parseMessageMarkdown(content) {
+  return (content ?? '').split('\n').map((line) => {
+    const bullet = line.match(/^(\s*)([-*+])\s+(.*)$/)
+    if (bullet) {
+      return {
+        bullet: bullet[2] === '+' ? 'subitem' : 'item',
+        segments: parseInlineSegments(bullet[3]),
+      }
+    }
+    return { bullet: 'none', segments: parseInlineSegments(line) }
+  })
+}


### PR DESCRIPTION
## Resumo

Onda 2 da spec 015 (Tier 2): traz o **Assistente IA para dentro do app nativo** e, de quebra, enriquece o payload do chatbot em **todas as superfícies** (web + Telegram + mobile) via `@dosiq/core`.

## Onda 2 — mobile (greenfield)

- **`ChatScreen`** full-screen: bolhas assimétricas, markdown (negrito/itálico/listas), histórico local (AsyncStorage, FR-007), banner offline, chips de sugestão, "digitando…" animado, botão limpar conversa (Trash2 + re-fetch do contexto), branding no header (`BotMessageSquare` + título).
- **Entry-point** (`BotMessageSquare`) no header das abas Hoje/Tratamentos/Estoque (afordância de header, não FAB — evita AP-W24/colisão com speed-dial). Perfil não tem chat.
- **`DevBadge`** no título da aba Perfil (substitui o `<DEV>` que ficava no header de Hoje).
- **`@dosiq/core/markdown`**: parser puro compartilhado web↔mobile (tokenizer único).

## Correções de payload do chatbot (core — vale web + Telegram + mobile)

- **Tratamentos semanais/PRN/personalizados** voltam ao contexto: filtro por período de vigência (não mais "frequência cai hoje"), com o **dia da semana** agendado na linha do medicamento.
- **Unidades unit-aware** p/ líquidos/injetáveis: estoque/dose/consumo em mL/UI/gotas (ex.: Lantus "5,2 mL", dose "10 UI (≈ 0,1 mL)") — fim do "un." cego (erro factual).
- **Doses pendentes** resolvem o nome do medicamento (anexa `medicine` ao protocolo p/ `splitDayTimeline`) — fim do "Desconhecido".
- **Consumo** arredondado; **perfil** (nome/idade) + **dia da semana** no payload.

## System prompt

- Guardrail de **escopo do app** (não inventa features inexistentes, ex.: "entrega de medicamentos").
- Contexto **regional Brasil/ANVISA**.
- `max_tokens` **512 → 1024** (reasoning do gpt-oss-120b truncava respostas longas).

## SQP (R-221)

- mobile `0.20.1 → 0.21.0` (minor — nova feature)
- web `4.13.0 → 4.14.0` (minor — contexto enriquecido)
- CHANGELOG + release notes pt-BR (App Store / Play Store)

## Guard / Proof Obligations

- ✅ `validate:agent` **1447/1447**
- ✅ core chatbot vitest **32/32** (7 novos: líquidos/semanais/perfil/resolução de nome)
- ✅ lint **0 errors** · complexidade CLEAN
- ✅ `expo export` iOS EXIT 0
- ✅ **smoke PO iOS + Android OK** (gate respeitado: zero push até aprovação)

## Próximo (Onda 3)

Portar os refinos de UI do mobile para o PWA (bolhas, header com ícone, disclaimer móvel) + extrair textos iniciais p/ reuso cross-superfície.

🤖 Generated with [Claude Code](https://claude.com/claude-code)