### PR TITLE
feat(015): paridade do chat PWA↔mobile + textos no core (Onda 3)

### DIFF
--- a/.agent/state.json
+++ b/.agent/state.json
@@ -2,7 +2,7 @@
   "project": "dosiq",
   "sprint": "2026-W25",
   "session": {
-    "mode": "planning",
+    "mode": "coding",
     "ceremony_type": "design-review",
     "ceremony_spec": "plans/specs/015-ai-chatbot-mobile/spec.md",
     "ceremonies_run": ["eng-review", "design-review"],
@@ -12,8 +12,9 @@
       "015 chat = full-screen + bolhas assimétricas (não cards iguais); chips + disclaimer fixo",
       "015 RC3: fetcher+builder core, descope CRUD repos full, paridade bloqueante"
     ],
-    "status": "planned",
+    "status": "coding",
     "goal": "015 onda 3 — paridade de UI (mobile→PWA): alinhar bolhas L/R no web (FR-014) + header branding (FR-015) + banner de disclaimer nos dois (FR-016) + extrair textos UI p/ @dosiq/core/chatbot (FR-013, mobile=canônico) + carry-forward robustez #686 (key estável/isError/getSession/typing) + polish (FR-017). Decisões PO: web MANTÉM drawer (não full-screen); banner separado; mobile=canônico. Tier 2 slice.",
+    "branch_onda3": "feature/015/onda-3-pwa-parity",
     "goal_type": "feature",
     "tier": 2,
     "spec_dir": "plans/specs/015-ai-chatbot-mobile",
@@ -24,8 +25,8 @@
     "linked_contracts": ["CON-028"],
     "last_pr": 686,
     "branch": "main",
-    "mobile_version": "0.21.0",
-    "web_version": "4.14.0"
+    "mobile_version": "0.21.1",
+    "web_version": "4.15.0"
   },
   "memory": {
     "last_distillation": "2026-06-23T04:30:00.000Z",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ---
 
+## Web v4.15.0 + App v0.21.1 (mobile) — 2026-06-24 — Paridade do chat PWA↔mobile + textos no core (spec 015, Onda 3)
+
+> **Bump:** web `4.14.0 → 4.15.0` (minor — paridade de UX no chat) · mobile `0.21.0 → 0.21.1`
+> (patch — welcome deixa de embutir o disclaimer; passa a vir do banner). Textos de UI do chat
+> centralizados em `@dosiq/core/chatbot` (fonte única web↔mobile).
+
+### ✨ Melhorias (PWA — paridade com o app nativo)
+
+- **Bolhas alinhadas:** mensagens do usuário à direita, do assistente à esquerda (antes corriam
+  centralizadas — o alinhamento era anulado pelo wrapper da lista).
+- **Header com identidade:** ícone do assistente + título "Assistente Dosiq IA".
+- **Disclaimer em banner** próprio, com fundo amarelo claro (não se confunde com as bolhas ao rolar).
+- **"Digitando" animado** (pontos pulsando) no lugar do texto estático.
+- **Chips de sugestão** disparam a mensagem direto ao toque (antes só preenchiam o campo).
+- **Foco mantido** no campo de texto após enviar (não precisa reclicar a cada pergunta).
+
+### 🐛 Correções
+
+- **Adesão no payload (web):** o chat passava a adesão no shape do Dashboard (`rates.adherence`),
+  não no contrato do core (`stats.adherence`) — a linha sumia e o assistente respondia "não tenho
+  informações". Normalizado no adapter web.
+- Mensagens de erro transitórias (falha de conexão, limite atingido) deixam de poluir o histórico
+  persistido — exibidas na tela, não salvas.
+- Acesso defensivo à sessão (evita erro raro de inicialização).
+- Chave de renderização de mensagem estável (corrige warning de chave duplicada do `AnimatePresence`).
+
+### ⚡ Performance — Groq Prompt Caching
+
+- Reordenação das `messages` enviadas ao Groq (web/mobile + Telegram) p/ maximizar cache hit por
+  prefixo: `system` estático (cache global entre usuários) → dados do paciente (estáveis na sessão)
+  → histórico → pergunta. Antes o contexto do paciente era embutido no `system`, tornando o bloco
+  inteiro por-usuário e quase nunca cacheável.
+
+### 🛠️ Dev
+
+- Proxy do Vite dev (`/api` → `EXPO_PUBLIC_API_BASE_URL`) p/ smoke do chat IA em `vite dev` sem
+  rodar o serverless localmente (server-side, sem CORS). Dev-only; build de prod inalterado.
+
+### 🧹 Interno
+
+- Textos de UI do chat (boas-vindas, disclaimer, sugestões) numa fonte única em `@dosiq/core`,
+  consumida por web e mobile (fim da duplicação). Guardrails de segurança permanecem server-side.
+
+---
+
 ## App v0.21.0 (mobile) + Web v4.14.0 — 2026-06-24 — Assistente IA no mobile + payload cross-superfície enriquecido (spec 015, Onda 2)
 
 > **Bump:** mobile `0.20.1 → 0.21.0` (minor — nova feature: chat IA nativo) · web `4.13.0 → 4.14.0`

--- a/api/chatbot.js
+++ b/api/chatbot.js
@@ -12,7 +12,7 @@ import {
   CHATBOT_RATE_LIMIT_MAX,
   CHATBOT_RATE_LIMIT_WINDOW,
   CHATBOT_BLOCKED_PATTERNS,
-  buildSystemPrompt,
+  buildStaticSystemRules,
 } from '../apps/web/src/features/chatbot/config/chatbotConfig.js'
 import { getServerTimestamp } from '@dosiq/core/utils'
 
@@ -46,6 +46,50 @@ function rateLimited(key) {
 // direto ignoraria o safetyGuard do front). Bloqueia intenções clínicas perigosas.
 function isBlockedMessage(message) {
   return CHATBOT_BLOCKED_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+// Monta as messages do Groq na ordem otimizada p/ Prompt Caching (prefix-match exato):
+//   1. system ESTÁTICO  → idêntico p/ TODOS os usuários → cache GLOBAL entre conversas.
+//   2. DADOS DO PACIENTE → estáveis na sessão (mudam 2-3x/dia, raramente mid-chat) →
+//      cacheados por usuário/conversa logo após o system.
+//   3. histórico         → cresce por turno, cacheado em cima do prefixo estável acima.
+//   4. pergunta          → 100% dinâmica, único trecho sempre não-cacheado.
+// Pôr o paciente ANTES do histórico maximiza o prefixo estável (ele não muda a cada
+// turno); só perde cache se o paciente mudar no meio da conversa (raro). Regras
+// compostas NO SERVIDOR (AP-237). Extraído do handler p/ baixar complexidade.
+function buildChatMessages({ staticRules, history, patientContext, message }) {
+  return [
+    { role: 'system', content: staticRules },
+    ...(patientContext
+      ? [{ role: 'system', content: `DADOS DO PACIENTE:\n${patientContext}` }]
+      : []),
+    ...history.slice(-CHATBOT_MAX_HISTORY).map((h) => ({
+      role: h.role === 'user' ? 'user' : 'assistant',
+      content: h.content,
+    })),
+    { role: 'user', content: message },
+  ]
+}
+
+// Loga métricas do Groq Prompt Caching (hit rate + economia estimada). Extraído do
+// handler p/ baixar complexidade. cached_prompt_tokens tem 50% de desconto.
+function logGroqUsage(completion) {
+  const promptTokens = completion.usage?.prompt_tokens || 0
+  const cachedTokens = completion.usage?.cached_prompt_tokens || 0
+  const cacheHitRate = promptTokens > 0 ? Math.round((cachedTokens / promptTokens) * 100) : 0
+  console.log(JSON.stringify({
+    timestamp: getServerTimestamp(),
+    service: 'chatbot-api',
+    level: 'info',
+    message: 'Groq response received',
+    model: MODEL,
+    promptTokens,
+    cachedTokens,
+    cacheHitRate: `${cacheHitRate}%`,
+    estimatedTokenSavings: Math.round(cachedTokens * 0.5),
+    completionTokens: completion.usage?.completion_tokens,
+    totalTokens: completion.usage?.total_tokens,
+  }))
 }
 
 function extractToken(req) {
@@ -138,17 +182,20 @@ export default async function handler(req, res) {
       })
     }
 
-    // 5. System prompt composto NO SERVIDOR (regras autoritativas + contexto do cliente)
-    const systemPrompt = buildSystemPrompt(patientContext)
-
-    const messages = [
-      { role: 'system', content: systemPrompt },
-      ...history.slice(-CHATBOT_MAX_HISTORY).map((h) => ({
-        role: h.role === 'user' ? 'user' : 'assistant',
-        content: h.content,
-      })),
-      { role: 'user', content: message },
-    ]
+    // 5. Composição das messages otimizada p/ Groq Prompt Caching (prefix-match exato):
+    //    - system ESTÁTICO primeiro → idêntico p/ TODOS os usuários/conversas → cache
+    //      GLOBAL (maior pool de hits possível). Regras autoritativas, compostas NO
+    //      SERVIDOR (AP-237: nunca recebidas do cliente).
+    //    - histórico em seguida → prefixo estável por conversa (cresce a cada turno).
+    //    - DADOS DO PACIENTE (dinâmico) o MAIS TARDE possível, logo antes da pergunta:
+    //      assim ele só quebra o cache a partir dali, sem invalidar o system global nem
+    //      o histórico. (Antes era embutido no system → tornava o bloco inteiro por-usuário.)
+    const messages = buildChatMessages({
+      staticRules: buildStaticSystemRules(),
+      history,
+      patientContext,
+      message,
+    })
 
     const completion = await groq.chat.completions.create({
       model: MODEL,
@@ -161,25 +208,7 @@ export default async function handler(req, res) {
     const response =
       completion.choices[0]?.message?.content || 'Desculpe, não consegui responder.'
 
-    // Log cache hit metrics (Groq Prompt Caching)
-    const promptTokens = completion.usage?.prompt_tokens || 0
-    const cachedTokens = completion.usage?.cached_prompt_tokens || 0
-    const cacheHitRate = promptTokens > 0 ? Math.round((cachedTokens / promptTokens) * 100) : 0
-    const estimatedSavings = Math.round(cachedTokens * 0.5) // 50% desconto em cached_tokens
-
-    console.log(JSON.stringify({
-      timestamp: getServerTimestamp(),
-      service: 'chatbot-api',
-      level: 'info',
-      message: 'Groq response received',
-      model: MODEL,
-      promptTokens,
-      cachedTokens,
-      cacheHitRate: `${cacheHitRate}%`,
-      estimatedTokenSavings: estimatedSavings,
-      completionTokens: completion.usage?.completion_tokens,
-      totalTokens: completion.usage?.total_tokens,
-    }))
+    logGroqUsage(completion)
 
     return res.status(200).json({
       response,

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -5,7 +5,7 @@
 
 const BUILD_PROFILE = process.env.EAS_BUILD_PROFILE || 'production'
 
-const APP_VERSION = '0.21.0' // R-182: versão semântica (sem prefixo 'v')
+const APP_VERSION = '0.21.1' // R-182: versão semântica (sem prefixo 'v')
 const [major, minor, patch] = APP_VERSION.split('.').map(Number)
 // buildNumber/versionCode derivado da versão semântica: major*10000 + minor*100 + patch
 // 0.2.4 → 204 | 0.3.0 → 300 | 1.0.0 → 10000

--- a/apps/mobile/src/features/chatbot/config/chatbotConfig.js
+++ b/apps/mobile/src/features/chatbot/config/chatbotConfig.js
@@ -1,36 +1,18 @@
-// chatbotConfig.js (mobile) — constantes de UI do chat nativo (spec 015 onda 2).
+// chatbotConfig.js (mobile) — constantes de UI do chat nativo (spec 015).
 //
-// APENAS constantes client de apresentação (disclaimer exibido, teto de histórico,
-// chips de sugestão, welcome). A segurança REAL (systemPrompt + safetyGuard) é
-// composta SERVER-SIDE em api/chatbot.js (AP-237) — o cliente nunca a envia.
-// Textos espelham o web (R-166). NÃO importar de apps/web (apps separados).
+// Textos de UI (disclaimer, chips, welcome) vêm do core (FR-013 — fonte única web↔mobile);
+// aqui ficam só os parâmetros locais do mobile (teto/chave de storage — semântica própria).
+// A segurança REAL (systemPrompt + safetyGuard) é composta SERVER-SIDE em api/chatbot.js (AP-237).
 
-/** Teto de mensagens mantidas no histórico local (AsyncStorage) — FR-007. */
+// Textos canônicos compartilhados (reexport do core — não duplicar literais aqui).
+export {
+  CHATBOT_DISCLAIMER,
+  CHATBOT_QUICK_SUGGESTIONS,
+  createWelcomeMessage,
+} from '@dosiq/core'
+
+/** Teto de mensagens mantidas no histórico local (AsyncStorage) — FR-007. Local: semântica de storage. */
 export const CHATBOT_MAX_HISTORY = 20
 
-/** Disclaimer clínico (paridade com o web). */
-export const CHATBOT_DISCLAIMER =
-  'Não substituo orientação médica. Consulte seu médico para decisões sobre o seu tratamento.'
-
-/** Chave de persistência do histórico (AsyncStorage). */
+/** Chave de persistência do histórico (AsyncStorage). Local. */
 export const CHATBOT_HISTORY_STORAGE_KEY = 'mr_chat_history'
-
-/** Chips de sugestão exibidos no estado vazio / acima do input. */
-export const CHATBOT_QUICK_SUGGESTIONS = [
-  'Qual meu próximo remédio?',
-  'Como está minha adesão?',
-  'Algum estoque baixo?',
-]
-
-/**
- * Mensagem de boas-vindas inicial (paridade com o web).
- * @param {number|null} timestamp
- * @returns {{role:string, content:string, timestamp:number|null}}
- */
-export function createWelcomeMessage(timestamp = null) {
-  return {
-    role: 'assistant',
-    content: `Olá! Sou a assistente IA do Dosiq. Como posso te ajudar hoje? `,
-    timestamp,
-  }
-}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dosiq/web",
-  "version": "4.14.0",
+  "version": "4.15.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/features/chatbot/components/ChatMessageList.jsx
+++ b/apps/web/src/features/chatbot/components/ChatMessageList.jsx
@@ -4,7 +4,18 @@
  * Parse de markdown via `@dosiq/core` (parser puro único web↔mobile, spec 015 onda 2);
  * aqui só o render adapter web (tokens → JSX HTML).
  */
+import { useState, useEffect, Fragment } from 'react'
 import { parseMessageMarkdown } from '@dosiq/core'
+
+/** "Digitando" com pontos pulsando (1→2→3→repete) — paridade com o mobile. */
+function TypingDots({ styles }) {
+  const [dots, setDots] = useState(1)
+  useEffect(() => {
+    const id = setInterval(() => setDots((n) => (n >= 3 ? 1 : n + 1)), 400)
+    return () => clearInterval(id)
+  }, [])
+  return <div className={styles.thinkingBubble}>{'.'.repeat(dots)}</div>
+}
 
 /** Render web dos segmentos inline (bold/italic/text) de uma linha. */
 function renderSegments(segments) {
@@ -39,24 +50,31 @@ export default function ChatMessageList({ messages, isLoading, messagesEndRef, s
   return (
     <div className={styles.messages}>
       {messages.map((msg, i) => (
-        <div key={i}>
+        <Fragment key={`${msg.timestamp}-${msg.role}-${i}`}>
           {shouldShowDateSeparator(messages, i) && (
             <div className={styles.dateSeparator}>{formatDaySeparator(msg.timestamp)}</div>
           )}
+          {/* Wrapper alinha a bolha L/R (user→direita, bot→esquerda); a cor fica na bolha. */}
           <div
-            className={`${styles.messageBubble} ${
-              msg.role === 'user' ? styles.messageBubbleUser : styles.messageBubbleAssistant
+            className={`${styles.messageRow} ${
+              msg.role === 'user' ? styles.messageRowUser : styles.messageRowAssistant
             }`}
           >
-            {renderMessageContent(msg.content)}
-            {msg.timestamp && (
-              <span className={styles.messageTime}>{formatMessageTime(msg.timestamp)}</span>
-            )}
+            <div
+              className={`${styles.messageBubble} ${
+                msg.role === 'user' ? styles.messageBubbleUser : styles.messageBubbleAssistant
+              }`}
+            >
+              {renderMessageContent(msg.content)}
+              {msg.timestamp && (
+                <span className={styles.messageTime}>{formatMessageTime(msg.timestamp)}</span>
+              )}
+            </div>
           </div>
-        </div>
+        </Fragment>
       ))}
 
-      {isLoading && <div className={styles.thinkingBubble}>Pensando...</div>}
+      {isLoading && <TypingDots styles={styles} />}
 
       <div ref={messagesEndRef} />
     </div>

--- a/apps/web/src/features/chatbot/components/ChatWindow.jsx
+++ b/apps/web/src/features/chatbot/components/ChatWindow.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from 'react'
+import { useState, useCallback, useRef, useEffect, Fragment } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   sendChatMessage,
@@ -6,7 +6,7 @@ import {
   savePersistedHistory,
   clearPersistedHistory,
 } from '@/features/chatbot/services/chatbotService'
-import { createWelcomeMessage } from '@/features/chatbot/config/chatbotConfig'
+import { createWelcomeMessage, CHATBOT_QUICK_SUGGESTIONS } from '@/features/chatbot/config/chatbotConfig'
 import {
   getNow,
   getTodayLocal,
@@ -45,8 +45,6 @@ const formatDaySeparator = (timestamp) => {
   return date.toLocaleDateString('pt-BR', { weekday: 'long', day: '2-digit', month: 'long', timeZone: 'America/Sao_Paulo' })
 }
 
-const QUICK_SUGGESTIONS = ['Quais doses ainda faltam hoje?', 'Como está minha adesão?', 'Preciso repor algum estoque?']
-
 /**
  * Drawer lateral de chat com o assistente IA.
  * Lazy-loaded — nao impacta main bundle.
@@ -62,8 +60,13 @@ export default function ChatWindow({ isOpen, onClose }) {
   const [isLoading, setIsLoading] = useState(false)
   const [showClearConfirm, setShowClearConfirm] = useState(false)
   const messagesEndRef = useRef(null)
+  const inputRef = useRef(null)
 
   useEffect(() => { messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' }) }, [messages])
+
+  // Refoca o input ao fim do envio: `disabled={isLoading}` faz o browser soltar o foco;
+  // sem isto o usuário precisa reclicar no campo a cada pergunta.
+  useEffect(() => { if (!isLoading && isOpen) inputRef.current?.focus() }, [isLoading, isOpen])
 
   const addMessage = useCallback((message) => {
     setMessages((prev) => {
@@ -73,45 +76,59 @@ export default function ChatWindow({ isOpen, onClose }) {
     })
   }, [])
 
-  const handleSend = useCallback(async () => {
-    if (!input.trim() || isLoading) return
-    const userMessage = input.trim()
+  const handleSend = useCallback(async (overrideMessage) => {
+    // overrideMessage: pills de sugestão disparam direto (sem passar pelo input/state async).
+    const raw = typeof overrideMessage === 'string' ? overrideMessage : input
+    if (!raw.trim() || isLoading) return
+    const userMessage = raw.trim()
     setInput('')
     addMessage({ role: 'user', content: userMessage, timestamp: getNow().getTime() })
     setIsLoading(true)
     try {
-      const result = await sendChatMessage({ message: userMessage, history: messages, patientData: { medicines, protocols, logs, stockSummary, stats, doseInstances } })
-      addMessage({ role: 'assistant', content: result.response || result.reason || '', timestamp: getNow().getTime() })
+      // CON-028: o builder lê `stats.adherence` (0-1). O Dashboard expõe a adesão em
+      // `stats.rates.adherence` (e `stats.adherenceRate`), NÃO em `stats.adherence` —
+      // sem normalizar, a linha de adesão sumia do payload (LLM "não tenho info").
+      const normalizedStats = { adherence: stats?.rates?.adherence ?? stats?.adherenceRate ?? null }
+      const result = await sendChatMessage({ message: userMessage, history: messages, patientData: { medicines, protocols, logs, stockSummary, stats: normalizedStats, doseInstances } })
+      // isError: exibe na tela mas NÃO persiste (savePersistedHistory filtra) — paridade mobile #686
+      addMessage({ role: 'assistant', content: result.response || result.reason || '', timestamp: getNow().getTime(), isError: result.error === true })
     } finally {
       setIsLoading(false)
     }
-  }, [input, isLoading, messages, addMessage, medicines, protocols, logs, stockSummary, stats])
+  }, [input, isLoading, messages, addMessage, medicines, protocols, logs, stockSummary, stats, doseInstances])
 
   const handleKeyDown = (e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSend() } }
 
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <>
-          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className={styles.overlay} onClick={onClose} />
-          <ChatWindowDrawer
-            messages={messages}
-            isLoading={isLoading}
-            input={input}
-            setInput={setInput}
-            messagesEndRef={messagesEndRef}
-            quickSuggestions={QUICK_SUGGESTIONS}
-            shouldShowDateSeparator={shouldShowDateSeparator}
-            formatDaySeparator={formatDaySeparator}
-            formatMessageTime={formatMessageTime}
-            onClose={onClose}
-            onSend={handleSend}
-            onKeyDown={handleKeyDown}
-            onClearHistory={() => setShowClearConfirm(true)}
-            styles={styles}
-          />
-        </>
-      )}
+    <>
+      {/* AnimatePresence exige key única em cada filho direto animado; o fragment keyed
+          evita o warning "two children with the same key ``" (key vazia duplicada). */}
+      <AnimatePresence>
+        {isOpen && (
+          <Fragment key="chat-drawer">
+            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className={styles.overlay} onClick={onClose} />
+            <ChatWindowDrawer
+              messages={messages}
+              isLoading={isLoading}
+              input={input}
+              setInput={setInput}
+              messagesEndRef={messagesEndRef}
+              inputRef={inputRef}
+              quickSuggestions={CHATBOT_QUICK_SUGGESTIONS}
+              shouldShowDateSeparator={shouldShowDateSeparator}
+              formatDaySeparator={formatDaySeparator}
+              formatMessageTime={formatMessageTime}
+              onClose={onClose}
+              onSend={handleSend}
+              onSelectSuggestion={(suggestion) => handleSend(suggestion)}
+              onKeyDown={handleKeyDown}
+              onClearHistory={() => setShowClearConfirm(true)}
+              styles={styles}
+            />
+          </Fragment>
+        )}
+      </AnimatePresence>
+      {/* ConfirmDialog fica fora do AnimatePresence (não é filho animado por ele). */}
       <ConfirmDialog
         isOpen={showClearConfirm}
         title="Limpar histórico"
@@ -122,6 +139,6 @@ export default function ChatWindow({ isOpen, onClose }) {
         onCancel={() => setShowClearConfirm(false)}
         variant="danger"
       />
-    </AnimatePresence>
+    </>
   )
 }

--- a/apps/web/src/features/chatbot/components/ChatWindow.jsx
+++ b/apps/web/src/features/chatbot/components/ChatWindow.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect, Fragment } from 'react'
+import { useState, useCallback, useRef, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   sendChatMessage,
@@ -88,7 +88,9 @@ export default function ChatWindow({ isOpen, onClose }) {
       // CON-028: o builder lê `stats.adherence` (0-1). O Dashboard expõe a adesão em
       // `stats.rates.adherence` (e `stats.adherenceRate`), NÃO em `stats.adherence` —
       // sem normalizar, a linha de adesão sumia do payload (LLM "não tenho info").
-      const normalizedStats = { adherence: stats?.rates?.adherence ?? stats?.adherenceRate ?? null }
+      // Preserva demais métricas (...stats) e adiciona `adherence` no shape do contrato —
+      // defensivo caso o builder passe a usar outros campos (streak, etc.).
+      const normalizedStats = { ...stats, adherence: stats?.rates?.adherence ?? stats?.adherenceRate ?? stats?.adherence ?? null }
       const result = await sendChatMessage({ message: userMessage, history: messages, patientData: { medicines, protocols, logs, stockSummary, stats: normalizedStats, doseInstances } })
       // isError: exibe na tela mas NÃO persiste (savePersistedHistory filtra) — paridade mobile #686
       addMessage({ role: 'assistant', content: result.response || result.reason || '', timestamp: getNow().getTime(), isError: result.error === true })
@@ -101,31 +103,41 @@ export default function ChatWindow({ isOpen, onClose }) {
 
   return (
     <>
-      {/* AnimatePresence exige key única em cada filho direto animado; o fragment keyed
-          evita o warning "two children with the same key ``" (key vazia duplicada). */}
+      {/* Filhos diretos do AnimatePresence DEVEM ser componentes keyed separados (não um
+          Fragment): o Fragment quebra a animação de exit (o AnimatePresence precisa rastrear
+          cada motion/component por key p/ adiar a desmontagem). Keys distintas também evitam
+          o warning de chave duplicada. */}
       <AnimatePresence>
         {isOpen && (
-          <Fragment key="chat-drawer">
-            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className={styles.overlay} onClick={onClose} />
-            <ChatWindowDrawer
-              messages={messages}
-              isLoading={isLoading}
-              input={input}
-              setInput={setInput}
-              messagesEndRef={messagesEndRef}
-              inputRef={inputRef}
-              quickSuggestions={CHATBOT_QUICK_SUGGESTIONS}
-              shouldShowDateSeparator={shouldShowDateSeparator}
-              formatDaySeparator={formatDaySeparator}
-              formatMessageTime={formatMessageTime}
-              onClose={onClose}
-              onSend={handleSend}
-              onSelectSuggestion={(suggestion) => handleSend(suggestion)}
-              onKeyDown={handleKeyDown}
-              onClearHistory={() => setShowClearConfirm(true)}
-              styles={styles}
-            />
-          </Fragment>
+          <motion.div
+            key="chat-overlay"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className={styles.overlay}
+            onClick={onClose}
+          />
+        )}
+        {isOpen && (
+          <ChatWindowDrawer
+            key="chat-drawer"
+            messages={messages}
+            isLoading={isLoading}
+            input={input}
+            setInput={setInput}
+            messagesEndRef={messagesEndRef}
+            inputRef={inputRef}
+            quickSuggestions={CHATBOT_QUICK_SUGGESTIONS}
+            shouldShowDateSeparator={shouldShowDateSeparator}
+            formatDaySeparator={formatDaySeparator}
+            formatMessageTime={formatMessageTime}
+            onClose={onClose}
+            onSend={handleSend}
+            onSelectSuggestion={(suggestion) => handleSend(suggestion)}
+            onKeyDown={handleKeyDown}
+            onClearHistory={() => setShowClearConfirm(true)}
+            styles={styles}
+          />
         )}
       </AnimatePresence>
       {/* ConfirmDialog fica fora do AnimatePresence (não é filho animado por ele). */}

--- a/apps/web/src/features/chatbot/components/ChatWindow.module.css
+++ b/apps/web/src/features/chatbot/components/ChatWindow.module.css
@@ -47,6 +47,25 @@
 .headerTitle {
   font-weight: bold;
   color: var(--color-text, #fff);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.headerIcon {
+  color: var(--color-primary, #006a5e);
+  flex-shrink: 0;
+}
+
+/* Banner de disclaimer (FR-016) — separado, estilo paridade com o mobile. */
+.disclaimerBanner {
+  padding: 8px 16px;
+  font-size: 12px;
+  line-height: 1.4;
+  /* Fundo amarelo bem claro: destaca o aviso e evita se confundir com as bolhas que sobem. */
+  color: #6b5800;
+  background: #fffae6;
+  border-bottom: 1px solid #f3e3a0;
 }
 
 /* Redesign mode: ensure dark text on light background */
@@ -102,6 +121,21 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+/* Linha que alinha a bolha em lados opostos (FR-014): user→direita, bot→esquerda.
+   O align-self da bolha sozinho não bastava — o wrapper é o flex-child de .messages. */
+.messageRow {
+  display: flex;
+  flex-direction: column;
+}
+
+.messageRowUser {
+  align-items: flex-end;
+}
+
+.messageRowAssistant {
+  align-items: flex-start;
 }
 
 .messageBubble {

--- a/apps/web/src/features/chatbot/components/ChatWindowDrawer.jsx
+++ b/apps/web/src/features/chatbot/components/ChatWindowDrawer.jsx
@@ -2,7 +2,8 @@
  * ChatWindowDrawer — Conteúdo visual do drawer de chat IA.
  */
 import { motion } from 'framer-motion'
-import { Trash2, X } from 'lucide-react'
+import { Trash2, X, BotMessageSquare } from 'lucide-react'
+import { CHATBOT_DISCLAIMER } from '@/features/chatbot/config/chatbotConfig'
 import ChatMessageList from './ChatMessageList'
 
 export default function ChatWindowDrawer({
@@ -11,7 +12,9 @@ export default function ChatWindowDrawer({
   input,
   setInput,
   messagesEndRef,
+  inputRef,
   quickSuggestions,
+  onSelectSuggestion,
   shouldShowDateSeparator,
   formatDaySeparator,
   formatMessageTime,
@@ -30,7 +33,10 @@ export default function ChatWindowDrawer({
       className={styles.drawer}
     >
       <div className={styles.header}>
-        <span className={styles.headerTitle}>Assistente IA</span>
+        <span className={styles.headerTitle}>
+          <BotMessageSquare size={18} aria-hidden="true" className={styles.headerIcon} />
+          Assistente Dosiq IA
+        </span>
         <div className={styles.headerActions}>
           <button onClick={onClearHistory} className={styles.clearButton} title="Limpar histórico" aria-label="Limpar histórico de conversa">
             <Trash2 size={16} aria-hidden="true" />
@@ -39,6 +45,10 @@ export default function ChatWindowDrawer({
             <X size={18} aria-hidden="true" />
           </button>
         </div>
+      </div>
+
+      <div className={styles.disclaimerBanner} role="note">
+        ⚠ {CHATBOT_DISCLAIMER}
       </div>
 
       <ChatMessageList
@@ -54,7 +64,7 @@ export default function ChatWindowDrawer({
       {messages.length <= 2 && (
         <div className={styles.suggestions}>
           {quickSuggestions.map((suggestion, i) => (
-            <button key={i} onClick={() => setInput(suggestion)} className={styles.suggestionButton}>
+            <button key={i} onClick={() => onSelectSuggestion(suggestion)} className={styles.suggestionButton}>
               {suggestion}
             </button>
           ))}
@@ -63,6 +73,7 @@ export default function ChatWindowDrawer({
 
       <div className={styles.inputRow}>
         <input
+          ref={inputRef}
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={onKeyDown}

--- a/apps/web/src/features/chatbot/config/chatbotConfig.js
+++ b/apps/web/src/features/chatbot/config/chatbotConfig.js
@@ -62,12 +62,15 @@ export const CHATBOT_BLOCKED_PATTERNS = [
   /efeito\s+colateral\s+grave/i,
 ]
 
-/**
- * Disclaimer médico adicionado automaticamente quando a resposta do LLM
- * contém conteúdo relacionado a saúde/medicamentos.
- */
-export const CHATBOT_DISCLAIMER =
-  'Não substituo orientação médica. Consulte seu médico para decisões sobre o seu tratamento.'
+// Textos de UI canônicos vêm do core (Onda 3, FR-013 — fonte única web↔mobile). O core é
+// PURO (sem deps de plataforma), então o reexport preserva a portabilidade browser/node deste
+// arquivo (consumido por api/chatbot.js e Telegram). createWelcomeMessage do core NÃO embute
+// disclaimer (banner cobre — FR-016); o disclaimer no Telegram é anexado lá (não via welcome).
+export {
+  CHATBOT_DISCLAIMER,
+  CHATBOT_QUICK_SUGGESTIONS,
+  createWelcomeMessage,
+} from '@dosiq/core'
 
 /** Palavras-chave que disparam o disclaimer na resposta. */
 export const CHATBOT_HEALTH_KEYWORDS = [
@@ -87,18 +90,7 @@ export const CHATBOT_HISTORY_STORAGE_KEY = 'mr_chat_history'
 /** Máximo de mensagens a manter e exibir no histórico persistido (10 turnos = 20 mensagens). */
 export const CHATBOT_HISTORY_MAX_DISPLAY = 20
 
-/**
- * Cria mensagem de boas-vindas inicial com timestamp.
- * Reutilizável em web (ChatWindow) e server (Telegram).
- * @returns {{role: string, content: string, timestamp: number}}
- */
-export function createWelcomeMessage(timestamp = null) {
-  return {
-    role: 'assistant',
-    content: `Olá! Sou seu Assistente IA de medicamentos. Como posso ajudar?\n\n_${CHATBOT_DISCLAIMER}_`,
-    timestamp: timestamp,
-  }
-}
+// createWelcomeMessage: reexportado do core (acima). NÃO redefinir aqui.
 
 // -- System Prompt (regras estáticas) --
 

--- a/apps/web/src/features/chatbot/services/chatbotService.js
+++ b/apps/web/src/features/chatbot/services/chatbotService.js
@@ -35,6 +35,7 @@ export async function sendChatMessage({ message, history = [], patientData }) {
       response: '',
       blocked: false,
       rateLimited: true,
+      error: true, // transitório — não persiste no histórico
       reason: 'Limite de mensagens atingido. Tente novamente em alguns minutos.',
     }
   }
@@ -53,13 +54,15 @@ export async function sendChatMessage({ message, history = [], patientData }) {
   const patientContext = buildPatientContext(patientData)
 
   // 4. Token de sessão — endpoint exige autenticação (sem token = 401, evita abuso anônimo da quota Groq)
-  const { data: { session } } = await supabase.auth.getSession()
-  const accessToken = session?.access_token
+  // Destructure defensivo: getSession() pode devolver data nulo sob falha de init do cliente (evita TypeError).
+  const { data } = await supabase.auth.getSession()
+  const accessToken = data?.session?.access_token
   if (!accessToken) {
     return {
       response: 'Faça login para usar o assistente.',
       blocked: false,
       rateLimited: false,
+      error: true, // transitório — não persiste no histórico
     }
   }
 
@@ -92,6 +95,7 @@ export async function sendChatMessage({ message, history = [], patientData }) {
       response: safeResponse,
       blocked: false,
       rateLimited: false,
+      error: false,
     }
   } catch (error) {
     console.error('[chatbot] Erro ao enviar mensagem:', error)
@@ -99,6 +103,7 @@ export async function sendChatMessage({ message, history = [], patientData }) {
       response: 'Desculpe, estou com dificuldades técnicas. Tente novamente em instantes.',
       blocked: false,
       rateLimited: false,
+      error: true, // transitório — não persiste no histórico
     }
   }
 }
@@ -146,7 +151,8 @@ export function loadPersistedHistory() {
     const data = JSON.parse(localStorage.getItem(CHATBOT_HISTORY_STORAGE_KEY) || '[]')
     // Validar estrutura mínima: array de objetos com role, content, timestamp
     if (!Array.isArray(data)) return []
-    return data.filter((msg) => msg.role && msg.content && typeof msg.timestamp === 'number')
+    // !isError: ignora mensagens de erro transitórias eventualmente persistidas antes (robustez)
+    return data.filter((msg) => msg.role && msg.content && typeof msg.timestamp === 'number' && !msg.isError)
   } catch {
     return []
   }
@@ -160,8 +166,10 @@ export function loadPersistedHistory() {
 export function savePersistedHistory(messages) {
   if (typeof window === 'undefined') return
   try {
-    // Filtrar mensagem de boas-vindas (primeira mensagem do assistente sem outras mensagens)
+    // Filtrar boas-vindas (1ª msg do assistente isolada) E mensagens de erro transitórias
+    // (isError) — falhas de conexão/rate-limit não devem grudar no histórico persistido.
     const filtered = messages.filter((msg) => {
+      if (msg.isError) return false
       if (msg.role === 'assistant' && messages.length === 1) return false // Mensagem inicial
       return true
     })

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -1,12 +1,23 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 import path from 'path'
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => {
+  // Carrega .env* (inclui EXPO_PUBLIC_*) só no processo do Vite — NÃO expõe ao client.
+  // Permite smoke do chat IA em dev apontando /api/* para o backend serverless de prod
+  // (api/chatbot.js inalterado; proxy server-side evita CORS de localhost→dosiq.app).
+  const env = loadEnv(mode, path.resolve(__dirname), '')
+  const apiBase = (env.EXPO_PUBLIC_API_BASE_URL || '').replace(/\/$/, '')
+
+  return {
   server: {
     host: true, // expõe na rede local (0.0.0.0) — acesse pelo IP da máquina no celular
+    // Proxy /api → backend remoto quando EXPO_PUBLIC_API_BASE_URL setado (dev-only).
+    ...(apiBase
+      ? { proxy: { '/api': { target: apiBase, changeOrigin: true, secure: true } } }
+      : {}),
   },
   resolve: {
     alias: {
@@ -97,4 +108,5 @@ export default defineConfig({
       }
     })
   ]
+  }
 })

--- a/packages/core/src/chatbot/__tests__/chatbotUiText.test.js
+++ b/packages/core/src/chatbot/__tests__/chatbotUiText.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CHATBOT_DISCLAIMER,
+  CHATBOT_QUICK_SUGGESTIONS,
+  createWelcomeMessage,
+} from '../chatbotUiText.js'
+import * as chatbotIndex from '../index.js'
+
+// FR-013/PO-7 — textos de UI centralizados no core (web+mobile consomem); guardrails NÃO descem.
+
+describe('chatbotUiText (core)', () => {
+  it('exporta disclaimer não-vazio', () => {
+    expect(typeof CHATBOT_DISCLAIMER).toBe('string')
+    expect(CHATBOT_DISCLAIMER.length).toBeGreaterThan(10)
+  })
+
+  it('chips de sugestão: array não-vazio de strings', () => {
+    expect(Array.isArray(CHATBOT_QUICK_SUGGESTIONS)).toBe(true)
+    expect(CHATBOT_QUICK_SUGGESTIONS.length).toBeGreaterThan(0)
+    expect(CHATBOT_QUICK_SUGGESTIONS.every((s) => typeof s === 'string' && s.length > 0)).toBe(true)
+  })
+
+  it('createWelcomeMessage: role assistant + content + timestamp repassado', () => {
+    const msg = createWelcomeMessage(123)
+    expect(msg.role).toBe('assistant')
+    expect(typeof msg.content).toBe('string')
+    expect(msg.content.length).toBeGreaterThan(0)
+    expect(msg.timestamp).toBe(123)
+  })
+
+  it('createWelcomeMessage: NÃO embute o disclaimer (banner cobre — FR-016)', () => {
+    expect(createWelcomeMessage().content).not.toContain(CHATBOT_DISCLAIMER)
+  })
+
+  it('reexportado por @dosiq/core/chatbot index', () => {
+    expect(chatbotIndex.CHATBOT_DISCLAIMER).toBe(CHATBOT_DISCLAIMER)
+    expect(chatbotIndex.createWelcomeMessage).toBe(createWelcomeMessage)
+    expect(chatbotIndex.CHATBOT_QUICK_SUGGESTIONS).toBe(CHATBOT_QUICK_SUGGESTIONS)
+  })
+
+  it('módulo de UI NÃO vaza guardrails (systemPrompt/safetyGuard/BLOCKED) — AP-237', () => {
+    expect(chatbotIndex.buildSystemPrompt).toBeUndefined()
+    expect(chatbotIndex.CHATBOT_BLOCKED_PATTERNS).toBeUndefined()
+    expect(chatbotIndex.safetyGuard).toBeUndefined()
+  })
+})

--- a/packages/core/src/chatbot/chatbotUiText.js
+++ b/packages/core/src/chatbot/chatbotUiText.js
@@ -1,0 +1,38 @@
+// chatbotUiText.js — textos de UI do chat, fonte ÚNICA web↔mobile (spec 015 Onda 3, FR-013).
+//
+// APENAS apresentação (welcome, disclaimer, chips). PURO, sem dependências de plataforma.
+// Texto canônico = mobile (Onda 2). Web e mobile consomem daqui (elimina a duplicação que
+// existia entre apps/web/.../chatbotConfig.js e apps/mobile/.../chatbotConfig.js).
+//
+// SEGURANÇA (AP-237/FR-008): systemPrompt, safetyGuard e CHATBOT_BLOCKED_PATTERNS NÃO vivem
+// aqui — permanecem server-side (compostos em api/chatbot.js). Aqui é só texto de UI.
+//
+// NÃO centralizar CHATBOT_MAX_HISTORY nem CHATBOT_HISTORY_STORAGE_KEY: as semânticas divergem
+// por superfície (web=10 turnos enviados ao LLM, dep de api/Telegram; mobile=20 teto de storage)
+// — centralizar acoplaria comportamentos diferentes. Ficam locais em cada config.
+
+/** Disclaimer clínico exibido (banner de UI em web e mobile; também usado server-side no Telegram). */
+export const CHATBOT_DISCLAIMER =
+  'Não substituo orientação médica. Consulte seu médico para decisões sobre o seu tratamento.'
+
+/** Chips de sugestão no estado inicial / acima do input. */
+export const CHATBOT_QUICK_SUGGESTIONS = [
+  'Qual meu próximo remédio?',
+  'Como está minha adesão?',
+  'Algum estoque baixo?',
+]
+
+/**
+ * Mensagem de boas-vindas inicial. NÃO embute o disclaimer — ele é exibido por um banner
+ * próprio em ambas as superfícies (FR-016). Mantém o disclaimer fora do corpo evita
+ * duplicação banner+welcome.
+ * @param {number|null} timestamp
+ * @returns {{role:'assistant', content:string, timestamp:number|null}}
+ */
+export function createWelcomeMessage(timestamp = null) {
+  return {
+    role: 'assistant',
+    content: 'Olá! Sou a assistente IA do Dosiq. Como posso te ajudar hoje?',
+    timestamp,
+  }
+}

--- a/packages/core/src/chatbot/index.js
+++ b/packages/core/src/chatbot/index.js
@@ -7,3 +7,5 @@
 export { fetchChatbotContextData } from './fetchChatbotContextData.js'
 export { buildPatientContext } from './buildPatientContext.js'
 export { chatbotContextDataSchema, validateChatbotContextData } from './chatbotContextSchema.js'
+// Textos de UI compartilhados web↔mobile (Onda 3, FR-013)
+export { CHATBOT_DISCLAIMER, CHATBOT_QUICK_SUGGESTIONS, createWelcomeMessage } from './chatbotUiText.js'

--- a/server/bot/services/chatbotServerService.js
+++ b/server/bot/services/chatbotServerService.js
@@ -336,19 +336,23 @@ export async function sendTelegramChatMessage({ message, userId }) {
     return { response: contextError, blocked: false, rateLimited: false }
   }
 
-  // 5. System prompt + histórico
-  const systemPrompt = buildServerSystemPrompt(context)
+  // 5. Regras estáticas + histórico (contexto do paciente entra mais tarde, ver passo 6)
+  const staticRules = buildStaticSystemRules()
   const history = getConversationHistory(userId)
   logger.debug('✅ System prompt construído', {
     userId,
     contextLen: context.length,
-    systemPromptLen: systemPrompt.length,
+    staticRulesLen: staticRules.length,
     historyLen: history.length,
   })
 
-  // 6. Chamar Groq API
+  // 6. Chamar Groq API — ordem otimizada p/ Prompt Caching (prefix-match), paridade com
+  //    api/chatbot.js: system ESTÁTICO (cache global) → DADOS DO PACIENTE (estáveis na
+  //    sessão, cacheados após o system) → histórico (cresce por turno) → pergunta.
+  //    Paciente ANTES do histórico maximiza o prefixo estável (não muda a cada turno).
   const messages = [
-    { role: 'system', content: systemPrompt },
+    { role: 'system', content: staticRules },
+    ...(context ? [{ role: 'system', content: `DADOS DO PACIENTE:\n${context}` }] : []),
     ...history,
     { role: 'user', content: message },
   ]


### PR DESCRIPTION
## Onda 3 — Paridade do chat PWA↔mobile + textos no core (spec 015)

Leva os refinos do chat IA do mobile (Onda 2) para o PWA, centraliza os textos de UI em `@dosiq/core`, e inclui correções/otimizações pegas no smoke da web.

### ✨ UX (PWA, paridade com o nativo)
- Bolhas alinhadas L/R (usuário à direita, assistente à esquerda)
- Header com ícone + título "Assistente Dosiq IA"
- Disclaimer em banner próprio (fundo amarelo claro)
- "Digitando" animado (pontos pulsando)
- Chips de sugestão disparam a mensagem direto ao toque
- Foco mantido no input após enviar

### 🐛 Correções
- **Adesão sumia do payload (web):** o adapter web passava `stats.rates.adherence` (shape do Dashboard) em vez de `stats.adherence` (contrato CON-028) → linha de adesão omitida → assistente respondia "não tenho informações". Normalizado no call-site. Mobile/Telegram usam o fetcher canônico e já estavam ok.
- Chave duplicada no `AnimatePresence` (fragment keyed + `ConfirmDialog` fora do presence).
- Carry do review #686: erro transitório não persiste, `getSession` defensivo, key estável.

### ⚡ Groq Prompt Caching
Reorder das `messages` (web/mobile via `api/chatbot.js` + Telegram): `system` estático (cache **global** entre usuários) → **dados do paciente** (estáveis na sessão) → histórico → pergunta. Antes o contexto do paciente era embutido no `system`, tornando o bloco inteiro por-usuário e quase nunca cacheável. Métrica real é pós-deploy (logs `cacheHitRate`).

### 🛠️ Dev
- Proxy do Vite dev (`/api` → `EXPO_PUBLIC_API_BASE_URL`) p/ smoke do chat em `vite dev` sem serverless local (server-side, sem CORS). Dev-only; build de prod inalterado.

### 🧹 Interno
- Textos de UI (welcome/disclaimer/chips) em fonte única `@dosiq/core/chatbot`, consumidos por web e mobile. Guardrails de segurança permanecem server-side (AP-237 — teste garante que não vazam pro core).

### SQP
- web `4.14.0 → 4.15.0` (minor) · mobile `0.21.0 → 0.21.1` (patch)

### ✅ Validação
- `validate:agent` 1453/1453 · core vitest 38/38 · web chatbot 25/25 · lint limpo nos arquivos tocados
- Smoke PO web: bolhas L/R, header, banner, digitando, chips autosend, foco, **adesão no payload** ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## AI Review Response

| Sugestão | Prioridade | Decisão | Motivo |
|----------|-----------|---------|--------|
| `Fragment` em `AnimatePresence` quebra animação de exit | High | Aplicada | Commit `cd747fdb` — overlay/drawer como filhos keyed separados |
| Preservar demais props de `stats` com spread | Medium | Aplicada | Commit `cd747fdb` — `{ ...stats, adherence }` |
