### PR TITLE
fix(039): superfícies de dose vigentes hoje + horário do picker no registro bulk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
   período de vigência. Agora as superfícies de seleção de dose só trazem tratamentos **vigentes hoje**
   (ativos **e** com hoje dentro de `[start_date, end_date]`).
 
+- **Horário do picker ignorado no registro bulk (mobile):** ao ajustar a data/hora da tomada no
+  seletor da modal bulk, o valor escolhido não era gravado — a dose ficava com o horário "agora" do
+  sistema (ex.: tomada das 23:47 de ontem registrada como 01:05 de hoje, caindo no dia errado do
+  calendário). Duas causas: (1) o seletor iOS abria como Modal aninhada e os gestos não registravam;
+  (2) o horário escolhido era resetado para "agora" quando a lista de doses re-renderizava. Agora o
+  seletor é um overlay na mesma superfície e o horário só é inicializado na abertura da modal.
+
 ### 🧱 Interno
 
 - Novo predicado canônico `isTreatmentSchedulableOn(protocol, today)` em `@dosiq/core` (combina

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ---
 
+## App v0.23.2 (mobile) / Web v4.15.2 — 2026-06-30 — Fix: superfícies de dose só mostram tratamentos vigentes hoje
+
+> **Bump:** mobile `0.23.1 → 0.23.2` (patch — correção de bug). Web `4.15.1 → 4.15.2` (patch). Core: novo predicado canônico.
+> **Plataforma:** Mobile + Web. **Server-free**, sem migração.
+
+### 🐛 Correções
+
+- **Vazamento de prescrições encerradas/futuras na seleção de dose:** ao registrar dose por um plano
+  (modal bulk via botão "Tomar" da Dynamic Island/lock screen no mobile, ou FAB global de doses na web),
+  apareciam doses de tratamentos do mesmo plano que **já terminaram** (`end_date` < hoje) ou que **ainda
+  não começaram** (`start_date` > hoje). Causa: o filtro considerava só a flag `active`, ignorando o
+  período de vigência. Agora as superfícies de seleção de dose só trazem tratamentos **vigentes hoje**
+  (ativos **e** com hoje dentro de `[start_date, end_date]`).
+
+### 🧱 Interno
+
+- Novo predicado canônico `isTreatmentSchedulableOn(protocol, today)` em `@dosiq/core` (combina
+  `isTreatmentActive` + `isProtocolActiveOnDate`), elimina o literal `=== 'ativo'` espalhado e
+  centraliza a regra de elegibilidade de dose web↔mobile.
+
+---
+
 ## App v0.23.0 (mobile) — 2026-06-29 — Dose como estado contínuo: Live Activity + Dynamic Island (iOS)
 
 > **Bump:** mobile `0.22.0 → 0.23.0` (minor — nova superfície iOS, épico 039 Dose State Machine, F3). Web sem alteração.

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -5,7 +5,7 @@
 
 const BUILD_PROFILE = process.env.EAS_BUILD_PROFILE || 'production'
 
-const APP_VERSION = '0.23.1' // R-182: versão semântica (sem prefixo 'v')
+const APP_VERSION = '0.23.2' // R-182: versão semântica (sem prefixo 'v')
 const [major, minor, patch] = APP_VERSION.split('.').map(Number)
 // buildNumber/versionCode derivado da versão semântica: major*10000 + minor*100 + patch
 // 0.2.4 → 204 | 0.3.0 → 300 | 1.0.0 → 10000

--- a/apps/mobile/src/features/dose/components/BulkDoseRegisterModal.jsx
+++ b/apps/mobile/src/features/dose/components/BulkDoseRegisterModal.jsx
@@ -348,15 +348,14 @@ function BulkDoseRetroactivePicker({ takenAtDate, handleOpenRetroactivePicker })
   )
 }
 
-function IOSDateTimePickerModal({ visible, tempDate, setTempDate, onCancel, onConfirm }) {
+// Picker iOS como OVERLAY ABSOLUTO (não Modal). Modal-sobre-Modal no iOS engole gestos: o
+// spinner aparecia mas o onChange não registrava, então o horário escolhido nunca chegava em
+// `takenAtDate` e a tomada era gravada com `agora` (bug). Renderizado DENTRO da Modal bulk,
+// na mesma superfície, os gestos funcionam.
+function IOSDateTimePickerOverlay({ visible, tempDate, setTempDate, onCancel, onConfirm }) {
   if (Platform.OS !== 'ios' || !visible) return null
   return (
-    <Modal
-      visible={visible}
-      transparent
-      animationType="slide"
-      onRequestClose={onCancel}
-    >
+    <View style={styles.pickerOverlay}>
       <TouchableOpacity style={styles.pickerBackdrop} activeOpacity={1} onPress={onCancel} />
       <View style={styles.pickerSheet}>
         <SafeAreaView edges={['bottom']}>
@@ -380,7 +379,7 @@ function IOSDateTimePickerModal({ visible, tempDate, setTempDate, onCancel, onCo
           />
         </SafeAreaView>
       </View>
-    </Modal>
+    </View>
   )
 }
 
@@ -449,11 +448,15 @@ function useBulkDoseModalState({ visible, isComplex, expandedDoseItems }) {
       setShowDatePicker(false)
       setTempDate(null)
     } else {
-      setTakenAtDate(getNow())
       setInjectionSites({})
       const initial = {}
       expandedDoseItems.forEach(item => { initial[item.id] = !isComplex })
       setSelected(initial)
+      // takenAtDate SÓ na transição de ABERTURA — nunca em itemsChanged. A lista de itens
+      // pode re-renderizar (async load, tick do pai) DEPOIS do usuário ajustar o horário no
+      // picker; resetar aqui clobberava a hora manual de volta p/ `agora` (bug: tomada de
+      // ontem à noite gravada com horário de hoje). Ver _buildConfirmLogs/isBackdated.
+      if (visibilityChanged) setTakenAtDate(getNow())
     }
   }
 
@@ -679,15 +682,16 @@ export default function BulkDoseRegisterModal({
             onConfirm={handleConfirm}
           />
         </View>
-      </View>
 
-      <IOSDateTimePickerModal
-        visible={showDatePicker}
-        tempDate={tempDate}
-        setTempDate={setTempDate}
-        onCancel={handleIOSCancel}
-        onConfirm={handleIOSConfirm}
-      />
+        {/* Overlay do picker DENTRO da Modal bulk (mesma superfície) — não Modal aninhada. */}
+        <IOSDateTimePickerOverlay
+          visible={showDatePicker}
+          tempDate={tempDate}
+          setTempDate={setTempDate}
+          onCancel={handleIOSCancel}
+          onConfirm={handleIOSConfirm}
+        />
+      </View>
     </Modal>
   )
 }
@@ -983,7 +987,13 @@ const styles = StyleSheet.create({
     color: colors.primary[700],
   },
 
-  // DateTimePicker iOS Modal
+  // DateTimePicker iOS — overlay absoluto (não Modal aninhada)
+  pickerOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'flex-end',
+    zIndex: 10,
+    elevation: 10,
+  },
   pickerBackdrop: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: colors.bg.overlay,

--- a/apps/mobile/src/features/dose/hooks/__tests__/usePlanProtocols.test.js
+++ b/apps/mobile/src/features/dose/hooks/__tests__/usePlanProtocols.test.js
@@ -87,6 +87,74 @@ describe('usePlanProtocols', () => {
     expect(result.current.protocols[0].id).toBe('t1')
   })
 
+  it('no modo plan, exclui prescrição encerrada do mesmo plano (bug prod 039)', async () => {
+    // t5: finalizado (end_date < hoje), mesmo plan-1 e mesma janela das 08:00 que t1.
+    // Sem o filtro de status, vazaria para a modal bulk junto com t1.
+    getActiveTreatments.mockResolvedValue({
+      success: true,
+      data: [
+        ...MOCK_TREATMENTS,
+        {
+          id: 't5',
+          name: 'Selozok (prescrição antiga)',
+          active: true,
+          start_date: '2026-01-01',
+          end_date: '2026-05-20', // finalizado (hoje = 2026-05-27)
+          time_schedule: ['08:00'],
+          treatment_plan: { id: 'plan-1', name: 'Plano Cardio' },
+          medicine_id: 'med-5',
+        },
+      ],
+    })
+
+    const { result } = renderHook(() =>
+      usePlanProtocols({
+        mode: 'plan',
+        planId: 'plan-1',
+        scheduledTime: '08:00',
+        userId: 'user-123',
+      })
+    )
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    // Só t1 (ativo); t5 finalizado é excluído mesmo na janela/plano.
+    expect(result.current.protocols).toHaveLength(1)
+    expect(result.current.protocols[0].id).toBe('t1')
+  })
+
+  it('no modo plan, exclui prescrição FUTURA do mesmo plano (start_date > hoje)', async () => {
+    getActiveTreatments.mockResolvedValue({
+      success: true,
+      data: [
+        ...MOCK_TREATMENTS,
+        {
+          id: 't6',
+          name: 'Novo tratamento (começa amanhã)',
+          active: true,
+          start_date: '2026-05-28', // futuro (hoje = 2026-05-27)
+          end_date: null,
+          time_schedule: ['08:00'],
+          treatment_plan: { id: 'plan-1', name: 'Plano Cardio' },
+          medicine_id: 'med-6',
+        },
+      ],
+    })
+
+    const { result } = renderHook(() =>
+      usePlanProtocols({ mode: 'plan', planId: 'plan-1', scheduledTime: '08:00', userId: 'user-123' })
+    )
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.protocols).toHaveLength(1)
+    expect(result.current.protocols[0].id).toBe('t1')
+  })
+
   it('no modo misc, filtra pelos protocolIds explícitos', async () => {
     const { result } = renderHook(() =>
       usePlanProtocols({

--- a/apps/mobile/src/features/dose/hooks/usePlanProtocols.js
+++ b/apps/mobile/src/features/dose/hooks/usePlanProtocols.js
@@ -2,7 +2,7 @@
 // Reutiliza treatmentsService.getActiveTreatments e filtra por planId ou protocolIds[]
 
 import { useState, useEffect } from 'react'
-import { resolveTreatmentStatus, getTodayLocal } from '@dosiq/core'
+import { isTreatmentSchedulableOn, getTodayLocal } from '@dosiq/core'
 import { getActiveTreatments } from '../../treatments/services/treatmentsService'
 
 /**
@@ -64,9 +64,15 @@ export function usePlanProtocols({ mode, planId, protocolIds, scheduledTime, use
         }
         const all = result.data ?? []
         if (mode === 'plan') {
+          // getActiveTreatments é alias de getAllTreatments → traz TODOS os status.
+          // Só tratamentos elegíveis HOJE (ativos + dentro do período start/end) entram
+          // na modal bulk do plano; senão prescrições encerradas/futuras do mesmo
+          // treatment_plan vazam (bug prod 039).
+          const todayStr = getTodayLocal()
           setProtocols(
             all
               .filter(p => p.treatment_plan?.id === planId)
+              .filter(p => isTreatmentSchedulableOn(p, todayStr))
               .filter(p => isInWindow(p, scheduledTime))
           )
         } else if (mode === 'misc') {
@@ -74,7 +80,7 @@ export function usePlanProtocols({ mode, planId, protocolIds, scheduledTime, use
         } else if (mode === 'active') {
           const todayStr = getTodayLocal()
           setProtocols(
-            all.filter(p => resolveTreatmentStatus(p, todayStr) === 'ativo')
+            all.filter(p => isTreatmentSchedulableOn(p, todayStr))
           )
         }
       })

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dosiq/web",
-  "version": "4.15.1",
+  "version": "4.15.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/shared/components/ui/GlobalDoseModal.jsx
+++ b/apps/web/src/shared/components/ui/GlobalDoseModal.jsx
@@ -2,6 +2,7 @@
 // Modal global de registro de dose — disponível em todas as views via App.jsx
 
 import { useState, useEffect, useCallback, useMemo } from 'react'
+import { isTreatmentSchedulableOn } from '@dosiq/core'
 import { useDashboard } from '@dashboard/hooks/useDashboardContext.jsx'
 import {
   cachedLogService as logService,
@@ -24,10 +25,14 @@ export default function GlobalDoseModal({ isOpen, onClose, initialValues = null 
   const [treatmentPlans, setTreatmentPlans] = useState([])
   const [plansError, setPlansError] = useState(null)
 
-  // Filtros para garantir que apenas tratamentos ativos apareçam no formulário
-  const activeProtocols = useMemo(() => protocols.filter((p) => p.active), [protocols])
+  // Só tratamentos elegíveis para dose HOJE (ativos + hoje dentro de [start_date, end_date]).
+  // `p.active` sozinho deixava vazar prescrições encerradas/futuras (end/start fora de hoje).
+  const activeProtocols = useMemo(
+    () => protocols.filter((p) => isTreatmentSchedulableOn(p)),
+    [protocols]
+  )
   const activeTreatmentPlans = useMemo(
-    () => treatmentPlans.filter((plan) => plan.protocols?.some((p) => p.active)),
+    () => treatmentPlans.filter((plan) => plan.protocols?.some((p) => isTreatmentSchedulableOn(p))),
     [treatmentPlans]
   )
 

--- a/apps/web/src/shared/components/ui/GlobalDoseModal.jsx
+++ b/apps/web/src/shared/components/ui/GlobalDoseModal.jsx
@@ -28,11 +28,11 @@ export default function GlobalDoseModal({ isOpen, onClose, initialValues = null 
   // Só tratamentos elegíveis para dose HOJE (ativos + hoje dentro de [start_date, end_date]).
   // `p.active` sozinho deixava vazar prescrições encerradas/futuras (end/start fora de hoje).
   const activeProtocols = useMemo(
-    () => protocols.filter((p) => isTreatmentSchedulableOn(p)),
+    () => (protocols || []).filter(Boolean).filter((p) => isTreatmentSchedulableOn(p)),
     [protocols]
   )
   const activeTreatmentPlans = useMemo(
-    () => treatmentPlans.filter((plan) => plan.protocols?.some((p) => isTreatmentSchedulableOn(p))),
+    () => (treatmentPlans || []).filter(Boolean).filter((plan) => plan.protocols?.some((p) => isTreatmentSchedulableOn(p))),
     [treatmentPlans]
   )
 

--- a/packages/core/src/chatbot/__tests__/buildPatientContext.test.js
+++ b/packages/core/src/chatbot/__tests__/buildPatientContext.test.js
@@ -373,15 +373,24 @@ describe('buildPatientContext — unidades líquidas / semanais / perfil', () =>
   })
 
   it('doses pendentes resolvem o NOME do medicamento (não "Desconhecido")', () => {
-    // Protocolo COM id casando a dose; medicine anexado pelo builder (medicine_id → medicines[]).
-    const proto = { ...lantusProto, id: 'p-liq-1' }
-    const result = buildPatientContext({
-      medicines: [lantus], protocols: [proto], logs: [], stockSummary: lantusStock, stats: null,
-      doseInstances: [{ id: 'di-1', protocol_id: 'p-liq-1', medicine_id: 'liq-1', scheduled_for: new Date().toISOString(), status: 'pending' }],
-    })
-    expect(result).toContain('Próximas doses pendentes hoje')
-    expect(result).toContain('Lantus')
-    expect(result).not.toContain('Desconhecido')
+    // Relógio fixo ao meio-dia UTC (= 09:00 SP) — mesma DATA (30/06) em UTC e America/Sao_Paulo,
+    // longe da meia-noite. Evita flakiness tz-dependente: com `new Date()` real o teste passava em
+    // BRT mas quebrava no runner UTC do CI (a dose caía em outro bucket de dia).
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-30T12:00:00Z'))
+    try {
+      // Protocolo COM id casando a dose; medicine anexado pelo builder (medicine_id → medicines[]).
+      const proto = { ...lantusProto, id: 'p-liq-1' }
+      const result = buildPatientContext({
+        medicines: [lantus], protocols: [proto], logs: [], stockSummary: lantusStock, stats: null,
+        doseInstances: [{ id: 'di-1', protocol_id: 'p-liq-1', medicine_id: 'liq-1', scheduled_for: new Date().toISOString(), status: 'pending' }],
+      })
+      expect(result).toContain('Próximas doses pendentes hoje')
+      expect(result).toContain('Lantus')
+      expect(result).not.toContain('Desconhecido')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('perfil preenchido → linha "Paciente: <nome>, <idade> anos"', () => {

--- a/packages/core/src/utils/__tests__/treatmentStatus.test.js
+++ b/packages/core/src/utils/__tests__/treatmentStatus.test.js
@@ -105,6 +105,11 @@ describe('isTreatmentActive', () => {
     expect(isTreatmentActive({ active: false, end_date: null }, '2026-05-18')).toBe(false)
     expect(isTreatmentActive({ active: true, end_date: '2026-05-17' }, '2026-05-18')).toBe(false)
   })
+
+  it('returns false for null/undefined protocol (guard defensivo)', () => {
+    expect(isTreatmentActive(null, '2026-05-18')).toBe(false)
+    expect(isTreatmentActive(undefined, '2026-05-18')).toBe(false)
+  })
 })
 
 describe('isTreatmentSchedulableOn', () => {
@@ -128,6 +133,11 @@ describe('isTreatmentSchedulableOn', () => {
 
   it('returns false for PAUSED treatment (active=false) inside period', () => {
     expect(isTreatmentSchedulableOn({ active: false, start_date: '2026-05-01', end_date: '2026-06-01' }, TODAY)).toBe(false)
+  })
+
+  it('returns false for null/undefined protocol (guard defensivo)', () => {
+    expect(isTreatmentSchedulableOn(null, TODAY)).toBe(false)
+    expect(isTreatmentSchedulableOn(undefined, TODAY)).toBe(false)
   })
 })
 

--- a/packages/core/src/utils/__tests__/treatmentStatus.test.js
+++ b/packages/core/src/utils/__tests__/treatmentStatus.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveTreatmentStatus, TREATMENT_STATUS } from '../treatmentStatus.js'
+import { resolveTreatmentStatus, isTreatmentActive, isTreatmentSchedulableOn, TREATMENT_STATUS } from '../treatmentStatus.js'
 
 describe('resolveTreatmentStatus', () => {
   // Teste 1: active: true, end_date: null → ATIVO
@@ -92,6 +92,42 @@ describe('resolveTreatmentStatus', () => {
     expect(resolveTreatmentStatus(protocol, '2026-06-02')).toBe(
       TREATMENT_STATUS.FINALIZADO
     )
+  })
+})
+
+describe('isTreatmentActive', () => {
+  it('returns true only for ATIVO', () => {
+    expect(isTreatmentActive({ active: true, end_date: null }, '2026-05-18')).toBe(true)
+    expect(isTreatmentActive({ active: true, end_date: '2026-06-18' }, '2026-05-18')).toBe(true)
+  })
+
+  it('returns false for PAUSADO and FINALIZADO', () => {
+    expect(isTreatmentActive({ active: false, end_date: null }, '2026-05-18')).toBe(false)
+    expect(isTreatmentActive({ active: true, end_date: '2026-05-17' }, '2026-05-18')).toBe(false)
+  })
+})
+
+describe('isTreatmentSchedulableOn', () => {
+  const TODAY = '2026-05-18'
+
+  it('returns true when active and today is inside [start, end]', () => {
+    expect(isTreatmentSchedulableOn({ active: true, start_date: '2026-05-01', end_date: '2026-06-01' }, TODAY)).toBe(true)
+  })
+
+  it('returns true when active with open-ended period (no end_date)', () => {
+    expect(isTreatmentSchedulableOn({ active: true, start_date: '2026-05-01', end_date: null }, TODAY)).toBe(true)
+  })
+
+  it('returns false for FUTURE treatment (start_date > today) even if active', () => {
+    expect(isTreatmentSchedulableOn({ active: true, start_date: '2026-05-19', end_date: null }, TODAY)).toBe(false)
+  })
+
+  it('returns false for ENDED treatment (end_date < today)', () => {
+    expect(isTreatmentSchedulableOn({ active: true, start_date: '2026-05-01', end_date: '2026-05-17' }, TODAY)).toBe(false)
+  })
+
+  it('returns false for PAUSED treatment (active=false) inside period', () => {
+    expect(isTreatmentSchedulableOn({ active: false, start_date: '2026-05-01', end_date: '2026-06-01' }, TODAY)).toBe(false)
   })
 })
 

--- a/packages/core/src/utils/index.js
+++ b/packages/core/src/utils/index.js
@@ -127,6 +127,8 @@ export {
 export {
   TREATMENT_STATUS,
   resolveTreatmentStatus,
+  isTreatmentActive,
+  isTreatmentSchedulableOn,
 } from './treatmentStatus.js'
 
 // Prescription vigência status resolver (038 Slice C — paridade web↔mobile)

--- a/packages/core/src/utils/treatmentStatus.js
+++ b/packages/core/src/utils/treatmentStatus.js
@@ -42,6 +42,7 @@ export function resolveTreatmentStatus(protocol, today) {
  * @returns {boolean}
  */
 export function isTreatmentActive(protocol, today) {
+  if (!protocol) return false
   return resolveTreatmentStatus(protocol, today) === TREATMENT_STATUS.ATIVO
 }
 
@@ -63,6 +64,7 @@ export function isTreatmentActive(protocol, today) {
  * @returns {boolean}
  */
 export function isTreatmentSchedulableOn(protocol, today) {
+  if (!protocol) return false
   const ref = today ?? formatLocalDate(getNow())
   return isTreatmentActive(protocol, ref) && isProtocolActiveOnDate(protocol, ref)
 }

--- a/packages/core/src/utils/treatmentStatus.js
+++ b/packages/core/src/utils/treatmentStatus.js
@@ -5,7 +5,7 @@
 // `_treatmentListUtils.resolveTabStatus`. Helper canônico permite paridade
 // web↔mobile sem drift. Web adopt como wrapper no mesmo PR (G1 implícito).
 
-import { formatLocalDate, getNow } from './dateUtils.js'
+import { formatLocalDate, getNow, isProtocolActiveOnDate } from './dateUtils.js'
 
 export const TREATMENT_STATUS = Object.freeze({
   ATIVO: 'ativo',
@@ -30,4 +30,39 @@ export function resolveTreatmentStatus(protocol, today) {
   if (protocol?.end_date && protocol.end_date < ref) return TREATMENT_STATUS.FINALIZADO
   if (protocol?.active === false) return TREATMENT_STATUS.PAUSADO
   return TREATMENT_STATUS.ATIVO
+}
+
+/**
+ * Predicado canônico "tratamento operacionalmente ativo hoje" — evita repetir o
+ * literal `=== 'ativo'` espalhado pelos callsites (modal bulk, listas, transformers).
+ * Exclui FINALIZADO (end_date < hoje) e PAUSADO (active=false).
+ *
+ * @param {{ active?: boolean|null, end_date?: string|null }} protocol
+ * @param {string} [today] — YYYY-MM-DD; default = hoje local
+ * @returns {boolean}
+ */
+export function isTreatmentActive(protocol, today) {
+  return resolveTreatmentStatus(protocol, today) === TREATMENT_STATUS.ATIVO
+}
+
+/**
+ * Predicado canônico para SUPERFÍCIES DE SELEÇÃO DE DOSE (modal bulk mobile, FAB
+ * global de doses web): tratamento elegível para registrar dose HOJE.
+ *
+ * Exige AMBOS:
+ *   1. status operacional ATIVO (active=true, não pausado, end_date >= hoje), e
+ *   2. data de hoje DENTRO do período [start_date, end_date] (end inclusivo).
+ *
+ * Diferença vs `isTreatmentActive`: este TAMBÉM exclui tratamentos FUTUROS
+ * (start_date > hoje), que `resolveTreatmentStatus` classifica como ATIVO por não
+ * olhar start_date. Sem isto, prescrições futuras/encerradas do mesmo plano vazam
+ * na modal de registro (bug prod 039).
+ *
+ * @param {{ active?: boolean|null, start_date?: string|null, end_date?: string|null }} protocol
+ * @param {string} [today] — YYYY-MM-DD; default = hoje local
+ * @returns {boolean}
+ */
+export function isTreatmentSchedulableOn(protocol, today) {
+  const ref = today ?? formatLocalDate(getNow())
+  return isTreatmentActive(protocol, ref) && isProtocolActiveOnDate(protocol, ref)
 }


### PR DESCRIPTION
# 📦 fix(039): superfícies de seleção de dose vigentes hoje + horário do picker no registro bulk

## 🎯 Resumo

Dois bugs de produção (épico 039) na seleção/registro de dose, ambos detectados em uso real:

1. **Vazamento de prescrições encerradas/futuras** nas superfícies de seleção de dose (modal bulk via "Tomar" da Dynamic Island/lock screen no mobile; FAB global de doses na web).
2. **Horário do picker ignorado** no registro bulk mobile — a tomada era gravada com o "agora" do sistema, caindo no dia errado do histórico.

---

## 📋 Tarefas Implementadas

### 🐛 Fix 1 — tratamentos vigentes hoje
- [x] Predicado canônico `isTreatmentSchedulableOn(protocol, today)` em `@dosiq/core` (`isTreatmentActive` + `isProtocolActiveOnDate`)
- [x] `usePlanProtocols` (modes `plan` + `active`) filtra por vigência (exclui encerrados, pausados e futuros)
- [x] `GlobalDoseModal` (web) filtra `activeProtocols`/`activeTreatmentPlans` pelo predicado

### 🐛 Fix 2 — horário do picker no registro bulk (mobile)
- [x] Seletor iOS deixou de ser `<Modal>` aninhado → overlay absoluto na mesma superfície (gestos voltam a registrar)
- [x] `takenAtDate` só re-inicializa na transição de abertura da modal (não em `itemsChanged`) — não clobbera mais a hora manual

### ✅ Testes e Qualidade
- [x] core: +7 casos (`isTreatmentActive` / `isTreatmentSchedulableOn`) — 20 verde
- [x] hook `usePlanProtocols`: +2 casos (encerrado/futuro) — 5 verde
- [x] bulk modal: 16 verde (sem regressão)
- [x] Lint sem erros novos

---

## 🔧 Arquivos Principais

```
packages/core/src/utils/
├── treatmentStatus.js          # + isTreatmentActive, isTreatmentSchedulableOn
└── index.js                    # exports
apps/mobile/src/features/dose/
├── hooks/usePlanProtocols.js   # filtro de vigência (plan + active)
└── components/BulkDoseRegisterModal.jsx  # picker overlay + reset só na abertura
apps/web/src/shared/components/ui/
└── GlobalDoseModal.jsx         # filtro de vigência
```

---

## ✅ Checklist de Verificação

### Código
- [x] Testes críticos passam (core/hook/bulk)
- [x] Lint sem erros novos (4 issues pré-existentes em BulkDoseRegisterModal)

### Funcionalidade
- [x] Web (FAB global): só tratamentos vigentes hoje aparecem
- [ ] Mobile (device): picker da modal bulk grava o horário escolhido — **valida no smoke**
- [ ] Mobile (device): modal bulk via "Tomar" não mostra doses encerradas/futuras — **valida no smoke**

---

## 📝 Notas para Reviewers

1. **Fix 2 (gesto do picker iOS):** Modal-sobre-Modal no iOS engole gestos — por isso o overlay absoluto na mesma superfície. Não é unit-testável; valida no device.
2. **Dados de produção:** os 7 logs já gravados com horário errado foram corrigidos manualmente no DB do usuário afetado (29/06 23:47 BRT).
3. **Escopo:** estoque (compra) ficou de fora — lista por medicamento, não por plano.

---

## 🏷️ Informações de Versionamento

**Tipo:** Patch
**Plataformas afetadas:** Mobile + Web + Shared/Core
**Versão anterior:** web 4.15.1 / mobile 0.23.1
**Versão sugerida:** web 4.15.2 / mobile 0.23.2
**Changelog:** CHANGELOG.md atualizado (entrada v0.23.2 / v4.15.2)

/cc @gemini-code-assist
