### PR TITLE
fix(041): Live Activity transiciona e encerra via push (fix-up Fase 2)

### DIFF
--- a/.agent/memory/decisions/mobile_and_platform/ADR-076.md
+++ b/.agent/memory/decisions/mobile_and_platform/ADR-076.md
@@ -1,8 +1,8 @@
 # ADR-076 — Transporte do iOS Live Activity push-to-start: APNs raw + modelo start-only
 
-- **Status:** accepted
-- **Date:** 2026-06-30
-- **Spec:** 041 (iOS push-to-start) · evolui ADR-075 (widget Live Activity Expo) e CON-030
+- **Status:** accepted (emendada 2026-07-02 — Decisão 2 revertida no 041 fix-up)
+- **Date:** 2026-06-30 · **Amended:** 2026-07-02
+- **Spec:** 041 (iOS push-to-start + fix-up) · evolui ADR-075 (widget Live Activity Expo) e CON-030
 - **Tags:** mobile, ios, apns, live-activity, push, backend, notifications
 
 ## Contexto
@@ -35,11 +35,26 @@ não conta no budget R-090).
 - **Opção B — push só START; transições via `staleDate`+foreground (modelo 039).** Mais barato;
   fecha o gap real (antecipação pré-T0 com app fechado). Transições já degradam bem como na 039.
 
-→ **Escolha: Opção B (start-only).** Decisão do PO (2026-06-30). O gap que justifica a 041 é o
-**start** pré-T0; transições não são o problema. Elimina a entidade `live_activity_token`.
-**⚠️ Estado inicial recomputado no disparo** via `deriveDoseActivityState(item, now)` (CON-029, puro)
-— a dose pode ter sido criada/editada após o agendamento, então o `content-state` nasce no estado
-certo, nunca congelado.
+→ ~~**Escolha: Opção B (start-only).** Decisão do PO (2026-06-30).~~ **REVERTIDA (2026-07-02, 041
+fix-up).** A premissa "transições degradam bem como na 039" é **falsa**: a Live Activity iOS só
+recomputa `displayState` em **re-render**, e re-render em background depende de **um único** `staleDate`
+(`liveActivityService.toParams`). Sem JS vivo (iOS não roda JS em background) não há driver de
+transição — `upcoming→now→late` congela e a resolução (`done`/end) não chega à lock screen. 039
+sofria o mesmo (limite server-free FR-009); 041 start-only NÃO resolve as user stories.
+
+→ **Escolha corrigida: Opção A (start + updates + end via APNs).** O servidor dirige o ciclo de
+vida completo da LA:
+- **update por boundary** (`event: update`) em `upcoming→now→late`, recomputando o estado no disparo
+  (`deriveDoseActivityState`, CON-029);
+- **end na resolução** (`event: end`) quando a dose vira `taken` (servidor sabe via `medicine_logs`)
+  → LA vira `done`/some mesmo com app fechado — subsume o bug foreground (registro in-app não
+  transicionava a LA na v0.23.3).
+- **Token per-Activity:** `Activity.pushTokenUpdates` (≠ push-to-start token) capturado no nativo,
+  persistido em **coluna `dose_instances.la_push_token`** (efêmero, vive/morre com a ocorrência;
+  migração aditiva — decisão 2026-07-02).
+
+O estado inicial continua recomputado no disparo (nunca congelado). O push-to-start (start com app
+fechado) da entrega original permanece; o fix-up adiciona o ciclo update+end que faltava.
 
 ## Consequências
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ---
 
+## App v0.24.1 (mobile) + Backend — 2026-07-02 — Fix (041 fix-up): Live Activity transiciona e encerra via push (iOS)
+
+> **Bump:** mobile `0.24.0 → 0.24.1` (patch — fix-up da fase 041). **Plataforma:** Mobile (iOS) + Backend. Migração aditiva. **Só validável em prod** (serverless não roda em dev/preview).
+
+### 🐛 Correções
+
+- **Live Activity agora transiciona de estado e encerra sozinha, com o app fechado:** a entrega original (v0.24.0) só _iniciava_ a superfície por push; as transições (`próxima→na hora→atrasada`) e o encerramento dependiam do app estar aberto rodando — então, com o app fechado, o countdown congelava no zero, o estado `atrasada` ficava preso na lock screen até swipe manual, e registrar a dose não trocava para `Tomada ✓`. Agora o servidor dirige o ciclo completo via push APNs: **update** de estado ao cruzar cada limite e **end** (card `Tomada ✓` + dismiss) quando a dose é registrada — tudo sem depender de o app ir a foreground.
+
+### 🧱 Interno
+
+- `server/notifications/apns/liveActivityPush.js`: `sendLiveActivityUpdate` (event `update`, priority 5) + `sendLiveActivityEnd` (event `end` + `dismissal-date`), reusando o cliente HTTP/2 + timeout (AP-256).
+- `server/notifications/apns/dispatchLiveActivityLifecycle.js` (novo): no loop de minuto (`checkReminders`), para cada LA ativa (`dose_instances.la_push_token`) dispara update ao mudar de estado (idempotência via `la_push_state`) e end na resolução (`taken`/`skipped`/`missed`), limpando o token. Fail-open total (nunca toca o alarme).
+- iOS nativo: `Activity.request(pushType: .token)` + observa `activity.pushTokenUpdates` (token per-Activity) → RN grava em `dose_instances.la_push_token` (sessão viva). `getActivityPushToken` no bridge.
+- Migração `20260702` (aditiva): `dose_instances.la_push_token` + `la_push_state`.
+- **Decisão revertida:** ADR-076 Decisão 2 (start-only → start+update+end) — a premissa "transições degradam bem como na 039" era falsa. Ver `plans/specs/041-ios-push-to-start/spec.md §Fase Fix-up`.
+
+---
+
 ## App v0.24.0 (mobile) + Backend — 2026-07-01 — Feat (041): Live Activity push-to-start no iOS
 
 > **Bump:** mobile `0.23.4 → 0.24.0` (minor — novo épico/feature). **Plataforma:** Mobile (iOS) + Backend. **NÃO server-free** (servidor dispara push). Migração aditiva (sem backfill).

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -5,7 +5,7 @@
 
 const BUILD_PROFILE = process.env.EAS_BUILD_PROFILE || 'production'
 
-const APP_VERSION = '0.24.0' // R-182: versão semântica (sem prefixo 'v')
+const APP_VERSION = '0.24.1' // R-182: versão semântica (sem prefixo 'v')
 const [major, minor, patch] = APP_VERSION.split('.').map(Number)
 // buildNumber/versionCode derivado da versão semântica: major*10000 + minor*100 + patch
 // 0.2.4 → 204 | 0.3.0 → 300 | 1.0.0 → 10000

--- a/apps/mobile/ios-native/DoseActivityBridge.m
+++ b/apps/mobile/ios-native/DoseActivityBridge.m
@@ -28,4 +28,10 @@ RCT_EXTERN_METHOD(drainPendingActions:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(getPushToStartToken:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+// Spec 041 fix-up: token push PER-ACTIVITY (Activity.pushTokenUpdates) da LA de um instanceId,
+// usado pelo backend p/ push de update/end. "" se ainda não emitido.
+RCT_EXTERN_METHOD(getActivityPushToken:(NSString *)instanceId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/apps/mobile/ios-native/DoseActivityBridge.swift
+++ b/apps/mobile/ios-native/DoseActivityBridge.swift
@@ -73,18 +73,51 @@ class DoseActivityBridge: NSObject {
         }
         let attributes = buildAttributes(params)
         let contentState = buildState(params)
+        let instanceId = params["instanceId"] as? String ?? ""
         Task {
             for activity in Activity<DoseActivityAttributes>.activities {
                 await activity.end(nil, dismissalPolicy: .immediate)
             }
             do {
+                // Spec 041 fix-up: pushType .token → o SO emite um token PER-ACTIVITY em
+                // `activity.pushTokenUpdates`. O backend usa esse token p/ push de update/end
+                // (transição de estado + encerramento com app fechado). Sem ele a LA só teria o
+                // start-only da Fase 1. iOS 17.2+ p/ o observer; <17.2 cai no start server-free (staleDate).
                 let content = ActivityContent(state: contentState, staleDate: staleDate(params, contentState))
-                let activity = try Activity.request(attributes: attributes, content: content, pushType: nil)
+                let activity: Activity<DoseActivityAttributes>
+                if #available(iOS 17.2, *) {
+                    activity = try Activity.request(attributes: attributes, content: content, pushType: .token)
+                    DoseActivityBridge.observeActivityPushToken(activity, instanceId: instanceId)
+                } else {
+                    activity = try Activity.request(attributes: attributes, content: content, pushType: nil)
+                }
                 resolve(activity.id)
             } catch {
                 reject("request_failed", error.localizedDescription, error)
             }
         }
+    }
+
+    // Spec 041 fix-up — observa o token push PER-ACTIVITY e persiste (hex) no App Group por instanceId.
+    // O RN lê via getActivityPushToken e grava em dose_instances.la_push_token (sessão viva). @private
+    @available(iOS 17.2, *)
+    private static func observeActivityPushToken(_ activity: Activity<DoseActivityAttributes>, instanceId: String) {
+        guard !instanceId.isEmpty else { return }
+        Task {
+            for await tokenData in activity.pushTokenUpdates {
+                let hex = tokenData.map { String(format: "%02x", $0) }.joined()
+                UserDefaults(suiteName: DoseActivityAppGroup.suite)?.set(hex, forKey: "activityPushToken:\(instanceId)")
+            }
+        }
+    }
+
+    // Retorna o token push per-Activity persistido p/ um instanceId (ou '' se ainda não emitido).
+    @objc(getActivityPushToken:resolver:rejecter:)
+    func getActivityPushToken(_ instanceId: String,
+                              resolver resolve: @escaping RCTPromiseResolveBlock,
+                              rejecter reject: @escaping RCTPromiseRejectBlock) {
+        let token = UserDefaults(suiteName: DoseActivityAppGroup.suite)?.string(forKey: "activityPushToken:\(instanceId)")
+        resolve(token ?? "")
     }
 
     // Atualiza o estado da Activity ativa SEM recriar (transição de estado sem flicker).

--- a/apps/mobile/src/platform/doseActivity/DoseLiveActivityBridge.jsx
+++ b/apps/mobile/src/platform/doseActivity/DoseLiveActivityBridge.jsx
@@ -60,12 +60,20 @@ const RESYNC_INTERVAL_MS = 15 * 60 * 1000
  */
 async function _syncActivityToken(instanceId) {
   if (!instanceId) return
-  try {
-    const token = await getActivityPushToken(instanceId)
-    if (!token) return
-    await supabase.from('dose_instances').update({ la_push_token: token }).eq('id', instanceId)
-  } catch {
-    // best-effort — nunca derruba o derive
+  // O token per-Activity é emitido de forma ASSÍNCRONA pelo iOS após Activity.request — logo após o
+  // start quase sempre ainda está vazio. Retry curto com backoff linear aguarda a emissão; se falhar,
+  // o próximo derive (foreground/interval) tenta de novo. Best-effort: nunca derruba o derive.
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      const token = await getActivityPushToken(instanceId)
+      if (token) {
+        await supabase.from('dose_instances').update({ la_push_token: token }).eq('id', instanceId)
+        return
+      }
+    } catch {
+      // best-effort
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000 * (attempt + 1)))
   }
 }
 

--- a/apps/mobile/src/platform/doseActivity/DoseLiveActivityBridge.jsx
+++ b/apps/mobile/src/platform/doseActivity/DoseLiveActivityBridge.jsx
@@ -43,6 +43,7 @@ import {
   showDoneLiveActivity,
   drainPendingActions,
   getPushToStartToken,
+  getActivityPushToken,
   liveActivitySupported,
 } from './liveActivityService'
 import { syncNotificationDevice } from '@platform/notifications/syncNotificationDevice'
@@ -51,6 +52,32 @@ const DEFAULT_TZ = 'America/Sao_Paulo'
 const LOOK_AHEAD_DAYS = 3
 const LOOK_BACK_DAYS = 3
 const RESYNC_INTERVAL_MS = 15 * 60 * 1000
+
+/**
+ * Spec 041 fix-up — sincroniza o token push per-Activity da LA ativa em dose_instances.la_push_token,
+ * p/ o backend empurrar update/end com app fechado. Best-effort; token vazio (SO ainda não emitiu /
+ * iOS < 17.2) → no-op, tenta de novo no próximo derive. RLS escopa ao dono (auth.uid()=user_id). @private
+ */
+async function _syncActivityToken(instanceId) {
+  if (!instanceId) return
+  try {
+    const token = await getActivityPushToken(instanceId)
+    if (!token) return
+    await supabase.from('dose_instances').update({ la_push_token: token }).eq('id', instanceId)
+  } catch {
+    // best-effort — nunca derruba o derive
+  }
+}
+
+/** Limpa o token per-Activity ao encerrar localmente a LA (paridade com o end-push do backend). @private */
+async function _clearActivityToken(instanceId) {
+  if (!instanceId) return
+  try {
+    await supabase.from('dose_instances').update({ la_push_token: null, la_push_state: null }).eq('id', instanceId)
+  } catch {
+    // best-effort
+  }
+}
 
 /** Deriva a dose ativa (crítica pendente) e start/update/end a LA. Retorna o instanceId ativo. @private */
 async function deriveAndDrive({ userId, protocols, tz, prevInstanceId }) {
@@ -76,6 +103,7 @@ async function deriveAndDrive({ userId, protocols, tz, prevInstanceId }) {
       const takenAt = prevTakenAt(prevInstanceId)
       if (takenAt) await showDoneLiveActivity({ instanceId: prevInstanceId, takenAt })
       else await endLiveActivity()
+      await _clearActivityToken(prevInstanceId) // LA encerrada → token não serve mais
     }
     return null
   }
@@ -88,9 +116,12 @@ async function deriveAndDrive({ userId, protocols, tz, prevInstanceId }) {
       const takenAt = prevTakenAt(prevInstanceId)
       if (takenAt) await showDoneLiveActivity({ instanceId: prevInstanceId, takenAt })
       else await endLiveActivity()
+      await _clearActivityToken(prevInstanceId)
     }
     await startLiveActivity(active, doseItem)
   }
+  // Fase 2: sincroniza o token per-Activity da LA ativa (idempotente; backend usa p/ update/end).
+  await _syncActivityToken(active.instanceId)
   return active.instanceId
 }
 

--- a/apps/mobile/src/platform/doseActivity/liveActivityService.js
+++ b/apps/mobile/src/platform/doseActivity/liveActivityService.js
@@ -131,4 +131,21 @@ export async function getPushToStartToken() {
   }
 }
 
+/**
+ * Spec 041 fix-up — token push PER-ACTIVITY (ActivityKit `Activity.pushTokenUpdates`, iOS 17.2+) da
+ * LA ativa de um instanceId. O backend usa p/ push de update/end (transição de estado + encerramento
+ * com app fechado). '' se ainda não emitido pelo SO / iOS < 17.2 / fora do iOS.
+ * @param {string} instanceId
+ * @returns {Promise<string>}
+ */
+export async function getActivityPushToken(instanceId) {
+  if (!available || !instanceId || !native.getActivityPushToken) return ''
+  try {
+    const token = await native.getActivityPushToken(String(instanceId))
+    return typeof token === 'string' ? token : ''
+  } catch {
+    return ''
+  }
+}
+
 export const liveActivitySupported = available

--- a/docs/migrations/20260702_dose_la_push_token.sql
+++ b/docs/migrations/20260702_dose_la_push_token.sql
@@ -1,0 +1,25 @@
+-- Spec 041 Fase 2 (fix-up) — token push per-Activity da Live Activity iOS.
+--
+-- O push-to-start (Fase 1) inicia a LA com app fechado, mas NÃO transiciona nem encerra: a LA iOS
+-- só recomputa estado em re-render, que sem JS depende de um único staleDate (ADR-076 emendada
+-- 2026-07-02). Fix-up: o servidor dirige update (upcoming→now→late) e end (dose registrada) via
+-- push APNs usando o token PER-ACTIVITY (Activity.pushTokenUpdates, ≠ pushToStartToken).
+--
+-- Este token é efêmero: vive/morre com a ocorrência da dose. Guardá-lo na própria dose_instance
+-- (não em notification_devices, que é por-device) mantém a semântica limpa — NULL = sem LA ativa.
+-- Aditivo, sem backfill. R-271 n/a (sem CHECK/enum).
+
+ALTER TABLE public.dose_instances
+  ADD COLUMN IF NOT EXISTS la_push_token text;
+
+COMMENT ON COLUMN public.dose_instances.la_push_token IS
+  'Spec 041 fix-up: token push per-Activity (ActivityKit Activity.pushTokenUpdates) da Live Activity iOS ativa desta ocorrência. Usado pelo servidor p/ push de update/end. NULL = sem LA ativa. Efêmero (limpo no end/410).';
+
+-- Último estado (CON-029) empurrado por push de update. Idempotência do update: só dispara quando o
+-- estado derivado (deriveDoseActivityState no disparo) DIFERE deste — evita spam APNs a cada minuto e
+-- resiste a tick de cron perdido / clock skew (mais robusto que aritmética de minuto de boundary).
+ALTER TABLE public.dose_instances
+  ADD COLUMN IF NOT EXISTS la_push_state text;
+
+COMMENT ON COLUMN public.dose_instances.la_push_state IS
+  'Spec 041 fix-up: último estado da máquina CON-029 (upcoming/now/late) empurrado à Live Activity via push de update. NULL = nada empurrado ainda. Guarda de idempotência do ciclo update.';

--- a/server/bot/_reminderHelpers.js
+++ b/server/bot/_reminderHelpers.js
@@ -6,6 +6,7 @@ import { partitionDoses } from './utils/partitionDoses.js';
 import { isProtocolActiveOnWeekday } from '../utils/protocolActiveHelper.js';
 import { calculateDailyIntake, calculateDaysRemaining, isLiquidMedicine, doseToMl, cleanFloat } from '@dosiq/core';
 import { dispatchLiveActivityStarts } from '../notifications/apns/dispatchLiveActivityStarts.js';
+import { dispatchLiveActivityLifecycle } from '../notifications/apns/dispatchLiveActivityLifecycle.js';
 // Formatting helpers removed — moved to Layer 2
 
 const logger = createLogger('ReminderHelpers');
@@ -326,6 +327,15 @@ async function _checkRemindersFromInstances(dispatcher, correlationId) {
       if (la.sent > 0) logger.info('push-to-start LA disparado', { ...la, correlationId });
     } catch (laErr) {
       logger.error('push-to-start LA falhou (fail-open, ignorado)', laErr, { correlationId });
+    }
+
+    // Spec 041 Fase 2 (fix-up): ciclo de vida da LA (update de estado + end na resolução) via push,
+    // p/ as LAs iOS ativas (la_push_token). Independente da janela do reminder. Best-effort + fail-open.
+    try {
+      const laLife = await dispatchLiveActivityLifecycle({ supabase, logger });
+      if (laLife.updated > 0 || laLife.ended > 0) logger.info('ciclo LA (update/end) disparado', { ...laLife, correlationId });
+    } catch (laErr) {
+      logger.error('ciclo LA falhou (fail-open, ignorado)', laErr, { correlationId });
     }
 
     const eligibleUsers = (users || []).filter(u => u.notification_mode !== 'digest');

--- a/server/notifications/apns/__tests__/dispatchLiveActivityLifecycle.test.js
+++ b/server/notifications/apns/__tests__/dispatchLiveActivityLifecycle.test.js
@@ -4,7 +4,7 @@ import { dispatchLiveActivityLifecycle } from '../dispatchLiveActivityLifecycle.
 
 const TEST_P8 = generateKeyPairSync('ec', { namedCurve: 'P-256' }).privateKey.export({ type: 'pkcs8', format: 'pem' });
 
-const NOW = new Date('2026-07-01T12:00:00.000Z');
+const NOW = new Date(Date.UTC(2026, 6, 1, 12, 0, 0));
 const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
 
 // Mock supabase: select(...).not(...) resolve a lista; update(...).eq(...) registra o patch.
@@ -15,6 +15,7 @@ function makeSupabase(rows) {
       _update: null,
       select() { return b; },
       not() { return b; },
+      gte() { return b; },
       update(p) { b._update = p; return b; },
       eq() {
         if (b._update) { updates.push(b._update); return Promise.resolve({ data: null, error: null }); }

--- a/server/notifications/apns/__tests__/dispatchLiveActivityLifecycle.test.js
+++ b/server/notifications/apns/__tests__/dispatchLiveActivityLifecycle.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { generateKeyPairSync } from 'node:crypto';
+import { dispatchLiveActivityLifecycle } from '../dispatchLiveActivityLifecycle.js';
+
+const TEST_P8 = generateKeyPairSync('ec', { namedCurve: 'P-256' }).privateKey.export({ type: 'pkcs8', format: 'pem' });
+
+const NOW = new Date('2026-07-01T12:00:00.000Z');
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+// Mock supabase: select(...).not(...) resolve a lista; update(...).eq(...) registra o patch.
+function makeSupabase(rows) {
+  const updates = [];
+  const from = () => {
+    const b = {
+      _update: null,
+      select() { return b; },
+      not() { return b; },
+      update(p) { b._update = p; return b; },
+      eq() {
+        if (b._update) { updates.push(b._update); return Promise.resolve({ data: null, error: null }); }
+        return b;
+      },
+      then(resolve) { return Promise.resolve({ data: rows, error: null }).then(resolve); },
+    };
+    return b;
+  };
+  return { from, _updates: updates };
+}
+
+// scheduled_for relativo a NOW p/ cair no estado desejado (SURFACE_WINDOWS: now ±10, late < -10).
+const at = (min) => new Date(NOW.getTime() + min * 60000).toISOString();
+const row = (over = {}) => ({
+  id: 'inst-1', user_id: 'userA', scheduled_for: at(0), critical_alarm: true,
+  status: 'pending', la_push_token: 'tok-activity', la_push_state: null,
+  protocol: { id: 'p1', name: 'TAG', treatment_plan_id: 'plan1', medicine: { name: 'TAG' } },
+  ...over,
+});
+
+describe('dispatchLiveActivityLifecycle', () => {
+  beforeEach(() => {
+    process.env.APNS_AUTH_KEY = Buffer.from(TEST_P8).toString('base64');
+    process.env.APNS_KEY_ID = 'KEY123';
+    process.env.APNS_TEAM_ID = 'TEAM123';
+    process.env.APNS_BUNDLE_ID = 'com.x.dosiq';
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    delete process.env.APNS_AUTH_KEY; delete process.env.APNS_KEY_ID;
+    delete process.env.APNS_TEAM_ID; delete process.env.APNS_BUNDLE_ID;
+  });
+
+  it('sem APNs configurado → no-op', async () => {
+    delete process.env.APNS_AUTH_KEY;
+    const supabase = makeSupabase([row()]);
+    const r = await dispatchLiveActivityLifecycle({ supabase, logger, now: NOW });
+    expect(r).toEqual({ processed: 0, updated: 0, ended: 0, skipped: 0, failed: 0 });
+  });
+
+  it('estado mudou (now) e la_push_state=null → 1 update + marca la_push_state', async () => {
+    const supabase = makeSupabase([row({ scheduled_for: at(0), la_push_state: null })]); // now
+    const updateFn = vi.fn(() => Promise.resolve({ ok: true, status: 200 }));
+    const endFn = vi.fn();
+    const r = await dispatchLiveActivityLifecycle({ supabase, logger, now: NOW, updateFn, endFn });
+    expect(updateFn).toHaveBeenCalledTimes(1);
+    expect(updateFn.mock.calls[0][0].contentState.state).toBe('now');
+    expect(r.updated).toBe(1);
+    expect(supabase._updates).toContainEqual({ la_push_state: 'now' });
+  });
+
+  it('estado igual ao já empurrado → skip (não spammar APNs)', async () => {
+    const supabase = makeSupabase([row({ scheduled_for: at(0), la_push_state: 'now' })]);
+    const updateFn = vi.fn();
+    const r = await dispatchLiveActivityLifecycle({ supabase, logger, now: NOW, updateFn, endFn: vi.fn() });
+    expect(updateFn).not.toHaveBeenCalled();
+    expect(r.skipped).toBe(1);
+  });
+
+  it('dose taken → end (done) + limpa token/estado', async () => {
+    const supabase = makeSupabase([row({ status: 'taken', la_push_state: 'late' })]);
+    const endFn = vi.fn(() => Promise.resolve({ ok: true, status: 200 }));
+    const updateFn = vi.fn();
+    const r = await dispatchLiveActivityLifecycle({ supabase, logger, now: NOW, updateFn, endFn });
+    expect(updateFn).not.toHaveBeenCalled();
+    expect(endFn).toHaveBeenCalledTimes(1);
+    expect(endFn.mock.calls[0][0].contentState.state).toBe('done');
+    expect(r.ended).toBe(1);
+    expect(supabase._updates).toContainEqual({ la_push_token: null, la_push_state: null });
+  });
+
+  it('410 no update → limpa token (LA morta), não conta como update', async () => {
+    const supabase = makeSupabase([row({ scheduled_for: at(0) })]);
+    const updateFn = vi.fn(() => Promise.resolve({ ok: false, status: 410, deactivate: true }));
+    const r = await dispatchLiveActivityLifecycle({ supabase, logger, now: NOW, updateFn, endFn: vi.fn() });
+    expect(r.updated).toBe(0);
+    expect(r.skipped).toBe(1);
+    expect(supabase._updates).toContainEqual({ la_push_token: null, la_push_state: null });
+  });
+
+  it('fail-open: erro no update não derruba o loop', async () => {
+    const supabase = makeSupabase([row({ scheduled_for: at(0) })]);
+    const updateFn = vi.fn(() => { throw new Error('boom'); });
+    const r = await dispatchLiveActivityLifecycle({ supabase, logger, now: NOW, updateFn, endFn: vi.fn() });
+    expect(r.failed).toBe(1);
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/server/notifications/apns/__tests__/liveActivityPush.test.js
+++ b/server/notifications/apns/__tests__/liveActivityPush.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { generateKeyPairSync } from 'node:crypto';
-import { getApnsConfig, sendLiveActivityStart, _resetJwtCache } from '../liveActivityPush.js';
+import { getApnsConfig, sendLiveActivityStart, sendLiveActivityUpdate, sendLiveActivityEnd, _resetJwtCache } from '../liveActivityPush.js';
 
 // .p8 EC P-256 REAL gerada em runtime (não é segredo; só p/ assinar o JWT no unit).
 const { privateKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
@@ -77,5 +77,56 @@ describe('sendLiveActivityStart', () => {
   it('sem token → no_token', async () => {
     const r = await sendLiveActivityStart({ ...base, pushToStartToken: '' });
     expect(r.reason).toBe('no_token');
+  });
+});
+
+// Captura headers + body do request p/ asserção de payload (event/priority/dismissal).
+function makeCapturingHttp2(status, sink) {
+  const handlers = {};
+  const req = {
+    on: (ev, cb) => { handlers[ev] = cb; return req; },
+    setEncoding: () => {},
+    end: (payload) => { sink.body = JSON.parse(payload); handlers.response?.({ ':status': status }); handlers.end?.(); },
+  };
+  return { connect: () => ({ on: () => {}, request: (h) => { sink.headers = h; return req; }, close: () => {} }) };
+}
+
+describe('sendLiveActivityUpdate', () => {
+  beforeEach(() => _resetJwtCache());
+  const cfg = getApnsConfig(ENV);
+
+  it('payload event=update, priority 5, sem attributes', async () => {
+    const sink = {};
+    const r = await sendLiveActivityUpdate({ pushToken: 'tok', contentState: { state: 'late' }, config: cfg, http2lib: makeCapturingHttp2(200, sink) });
+    expect(r.ok).toBe(true);
+    expect(sink.body.aps.event).toBe('update');
+    expect(sink.body.aps['content-state']).toEqual({ state: 'late' });
+    expect(sink.body.aps.attributes).toBeUndefined();
+    expect(sink.headers['apns-priority']).toBe('5');
+    expect(sink.headers['apns-push-type']).toBe('liveactivity');
+  });
+
+  it('sem token → no_token; sem config → apns_not_configured', async () => {
+    expect((await sendLiveActivityUpdate({ pushToken: '', contentState: {}, config: cfg })).reason).toBe('no_token');
+    expect((await sendLiveActivityUpdate({ pushToken: 't', contentState: {}, config: null })).reason).toBe('apns_not_configured');
+  });
+});
+
+describe('sendLiveActivityEnd', () => {
+  beforeEach(() => _resetJwtCache());
+  const cfg = getApnsConfig(ENV);
+
+  it('payload event=end com dismissal-date', async () => {
+    const sink = {};
+    const r = await sendLiveActivityEnd({ pushToken: 'tok', contentState: { state: 'done' }, dismissEpochSec: 1000, config: cfg, http2lib: makeCapturingHttp2(200, sink) });
+    expect(r.ok).toBe(true);
+    expect(sink.body.aps.event).toBe('end');
+    expect(sink.body.aps['dismissal-date']).toBe(1000);
+    expect(sink.body.aps['content-state']).toEqual({ state: 'done' });
+  });
+
+  it('410 → deactivate', async () => {
+    const r = await sendLiveActivityEnd({ pushToken: 'tok', contentState: {}, config: cfg, http2lib: makeHttp2(410, 'Unregistered') });
+    expect(r.deactivate).toBe(true);
   });
 });

--- a/server/notifications/apns/dispatchLiveActivityLifecycle.js
+++ b/server/notifications/apns/dispatchLiveActivityLifecycle.js
@@ -12,7 +12,7 @@
 // Fail-open total (FR-008): qualquer falha loga e segue — NUNCA propaga, NUNCA toca o alarme.
 
 import { deriveDoseActivityState } from '@dosiq/core'
-import { getServerTimestamp, parseISO } from '../../utils/dateUtils.js'
+import { getServerTimestamp, parseISO, addMinutes } from '../../utils/dateUtils.js'
 import { sendLiveActivityUpdate, sendLiveActivityEnd, getApnsConfig } from './liveActivityPush.js'
 
 // Status que encerram a LA (dose saiu de pendente).
@@ -130,10 +130,15 @@ export async function dispatchLiveActivityLifecycle({ supabase, logger, now = pa
 
   let instances
   try {
+    // iOS limita a exibição de uma Live Activity a ~8h → tokens de ocorrências além de 24h atrás são
+    // órfãos (limpeza falhou / app desinstalado). Restringe a janela p/ não varrer/processar lixo a
+    // cada minuto (carga DB + chamadas APNs redundantes).
+    const limitDate = addMinutes(-24 * 60, now).toISOString()
     const { data, error } = await supabase
       .from('dose_instances')
       .select(SELECT_FIELDS)
       .not('la_push_token', 'is', null)
+      .gte('scheduled_for', limitDate)
     if (error) throw error
     instances = data || []
   } catch (err) {

--- a/server/notifications/apns/dispatchLiveActivityLifecycle.js
+++ b/server/notifications/apns/dispatchLiveActivityLifecycle.js
@@ -1,0 +1,156 @@
+// Spec 041 Fase 2 (fix-up) — dirige o CICLO DE VIDA da Live Activity iOS via push (update + end).
+//
+// A Fase 1 (push-to-start) só INICIA a LA. Sem JS vivo (app fechado) a LA não transiciona nem
+// encerra — a máquina de estados iOS só recomputa em re-render (ADR-076 emendada 2026-07-02). Este
+// dispatcher, no mesmo loop de minuto (checkReminders), empurra:
+//   • update — quando o estado derivado (CON-029) da ocorrência ativa MUDA (upcoming→now→late);
+//   • end    — quando a dose foi resolvida (taken/skipped) → card done + dismiss, app fechado.
+//
+// Token: PER-ACTIVITY (Activity.pushTokenUpdates), gravado em dose_instances.la_push_token pelo app.
+// Vive na própria linha da ocorrência → SEM lookup cross-device, SEM IDOR (o token É da instância).
+// Idempotência do update: dose_instances.la_push_state guarda o último estado empurrado.
+// Fail-open total (FR-008): qualquer falha loga e segue — NUNCA propaga, NUNCA toca o alarme.
+
+import { deriveDoseActivityState } from '@dosiq/core'
+import { getServerTimestamp, parseISO } from '../../utils/dateUtils.js'
+import { sendLiveActivityUpdate, sendLiveActivityEnd, getApnsConfig } from './liveActivityPush.js'
+
+// Status que encerram a LA (dose saiu de pendente).
+const RESOLVED_STATUSES = new Set(['taken', 'skipped', 'completed', 'done'])
+
+const SELECT_FIELDS = `
+  id, user_id, scheduled_for, critical_alarm, status, la_push_token, la_push_state,
+  protocol:protocols(
+    id, name, treatment_plan_id, medicine_id,
+    medicine:medicines(name)
+  )
+`
+
+/** dose_instance → shape CON-029 (mínimo p/ deriveDoseActivityState). @private */
+function mapInstance(inst) {
+  const protocol = inst.protocol || {}
+  const medicine = protocol.medicine || {}
+  return {
+    instanceId: inst.id,
+    scheduledFor: inst.scheduled_for,
+    critical_alarm: inst.critical_alarm ?? false,
+    medicineName: medicine.name || protocol.name || 'Dose',
+    treatmentPlanId: protocol.treatment_plan_id ?? null,
+  }
+}
+
+/** Epoch (s) do scheduled_for (R-020: parseISO, nunca Date cru). @private */
+function scheduledEpochSec(inst, now) {
+  const d = inst.scheduled_for ? parseISO(inst.scheduled_for) : null
+  const ms = d && !Number.isNaN(d.getTime()) ? d.getTime() : now.getTime()
+  return Math.floor(ms / 1000)
+}
+
+/** Limpa o token+estado da LA da ocorrência (encerrada ou token morto). @private */
+async function _clearToken(supabase, logger, instanceId) {
+  const { error } = await supabase
+    .from('dose_instances')
+    .update({ la_push_token: null, la_push_state: null })
+    .eq('id', instanceId)
+  if (error) logger?.error?.('Falha ao limpar la_push_token (fail-open)', error, { instanceId })
+}
+
+/** Processa UMA ocorrência com LA ativa: end se resolvida, update se o estado mudou. @private */
+async function _driveInstance({ supabase, logger, inst, now, updateFn, endFn }) {
+  // Resolvida (dose registrada/pulada) → encerra a LA (card done p/ taken; dismiss p/ resto).
+  if (RESOLVED_STATUSES.has(inst.status)) {
+    const finalState = inst.status === 'taken' ? 'done' : 'missed'
+    const res = await endFn({
+      pushToken: inst.la_push_token,
+      contentState: { state: finalState, scheduledAt: scheduledEpochSec(inst, now), doneAtLabel: '' },
+    })
+    if (res.ok || res.deactivate) {
+      await _clearToken(supabase, logger, inst.id)
+      logger?.info?.('LA encerrada por push (end)', { instanceId: inst.id, status: inst.status, apns: res.status })
+      return 'ended'
+    }
+    logger?.warn?.('push end falhou (fail-open; backstop dismissal cobre)', { instanceId: inst.id, reason: res.reason })
+    return 'failed'
+  }
+
+  // Pendente → estado derivado no instante (dose pode ter sido editada). Idempotência por la_push_state.
+  const derived = deriveDoseActivityState(mapInstance(inst), now)
+  if (!derived) return 'skipped' // inválido / fora de janela
+  if (derived.state === inst.la_push_state) return 'skipped' // nada mudou → não spammar APNs
+
+  // 'missed' num item pendente = passou a tolerância sem registro → encerra (paridade cancel/dismiss).
+  if (derived.state === 'missed') {
+    const res = await endFn({
+      pushToken: inst.la_push_token,
+      contentState: { state: 'missed', scheduledAt: scheduledEpochSec(inst, now), doneAtLabel: '' },
+    })
+    if (res.ok || res.deactivate) {
+      await _clearToken(supabase, logger, inst.id)
+      return 'ended'
+    }
+    return 'failed'
+  }
+
+  const res = await updateFn({
+    pushToken: inst.la_push_token,
+    contentState: { state: derived.state, scheduledAt: scheduledEpochSec(inst, now), doneAtLabel: '' },
+  })
+  if (res.ok) {
+    const { error } = await supabase
+      .from('dose_instances')
+      .update({ la_push_state: derived.state })
+      .eq('id', inst.id)
+    if (error) logger?.error?.('Falha ao marcar la_push_state (fail-open)', error, { instanceId: inst.id })
+    logger?.info?.('LA atualizada por push (update)', { instanceId: inst.id, state: derived.state })
+    return 'updated'
+  }
+  if (res.deactivate) {
+    await _clearToken(supabase, logger, inst.id) // token morto → LA não existe mais
+    return 'skipped'
+  }
+  logger?.warn?.('push update falhou (fail-open)', { instanceId: inst.id, reason: res.reason })
+  return 'failed'
+}
+
+/**
+ * Empurra update/end para todas as LAs iOS ativas (la_push_token IS NOT NULL) no loop de minuto.
+ * @param {object} deps
+ * @param {object} deps.supabase - client service_role
+ * @param {object} deps.logger
+ * @param {Date}   [deps.now]
+ * @param {Function} [deps.updateFn] - override (testes) do envio de update APNs
+ * @param {Function} [deps.endFn] - override (testes) do envio de end APNs
+ * @returns {Promise<{processed:number, updated:number, ended:number, skipped:number, failed:number}>}
+ */
+export async function dispatchLiveActivityLifecycle({ supabase, logger, now = parseISO(getServerTimestamp()), updateFn = sendLiveActivityUpdate, endFn = sendLiveActivityEnd } = {}) {
+  const result = { processed: 0, updated: 0, ended: 0, skipped: 0, failed: 0 }
+
+  // Fail-closed na config (R-088): sem APNs, sem ciclo (LA degrada p/ foreground 039).
+  if (!getApnsConfig()) return result
+
+  let instances
+  try {
+    const { data, error } = await supabase
+      .from('dose_instances')
+      .select(SELECT_FIELDS)
+      .not('la_push_token', 'is', null)
+    if (error) throw error
+    instances = data || []
+  } catch (err) {
+    logger?.error?.('Falha ao buscar LAs ativas p/ ciclo (fail-open)', err)
+    return result
+  }
+
+  for (const inst of instances) {
+    result.processed += 1
+    try {
+      const outcome = await _driveInstance({ supabase, logger, inst, now, updateFn, endFn })
+      result[outcome] += 1
+    } catch (err) {
+      result.failed += 1
+      logger?.error?.('Erro no ciclo de LA da ocorrência (fail-open)', err, { instanceId: inst.id })
+    }
+  }
+
+  return result
+}

--- a/server/notifications/apns/liveActivityPush.js
+++ b/server/notifications/apns/liveActivityPush.js
@@ -54,6 +54,63 @@ export function _resetJwtCache() {
 }
 
 /**
+ * POST HTTP/2 de um payload APNs liveactivity p/ um token. Timeout defensivo (AP-256): em serverless
+ * uma conexão travada penduraria a função até o teto da plataforma. Fail-open em qualquer falha. @private
+ * @returns {Promise<{ok:boolean, status:number, deactivate?:boolean, reason?:string}>}
+ */
+function _postToApns({ cfg, pushToken, payload, priority, http2lib }) {
+  return new Promise((resolve) => {
+    let client
+    const timer = setTimeout(() => {
+      try { client?.close() } catch { /* noop */ }
+      resolve({ ok: false, status: 0, reason: 'timeout' })
+    }, APNS_TIMEOUT_MS)
+    const safeResolve = (val) => {
+      clearTimeout(timer)
+      resolve(val)
+    }
+
+    try {
+      client = http2lib.connect(cfg.host)
+    } catch (err) {
+      safeResolve({ ok: false, status: 0, reason: `connect_failed: ${err.message}` })
+      return
+    }
+    client.on('error', (err) => {
+      safeResolve({ ok: false, status: 0, reason: `client_error: ${err.message}` })
+      try { client.close() } catch { /* noop */ }
+    })
+
+    const req = client.request({
+      ':method': 'POST',
+      ':path': `/3/device/${pushToken}`,
+      authorization: `bearer ${_providerToken(cfg)}`,
+      'apns-topic': `${cfg.bundleId}.push-type.liveactivity`,
+      'apns-push-type': 'liveactivity',
+      'apns-priority': String(priority ?? 10),
+    })
+
+    let status = 0
+    let body = ''
+    req.on('response', (headers) => { status = Number(headers[':status']) || 0 })
+    req.setEncoding('utf8')
+    req.on('data', (chunk) => { body += chunk })
+    req.on('end', () => {
+      try { client.close() } catch { /* noop */ }
+      if (status === 200) { safeResolve({ ok: true, status }); return }
+      // 410 (Unregistered) / 400 BadDeviceToken → token morto, revogar (S-6)
+      const deactivate = status === 410 || body.includes('BadDeviceToken') || body.includes('Unregistered')
+      safeResolve({ ok: false, status, deactivate, reason: body || `http_${status}` })
+    })
+    req.on('error', (err) => {
+      try { client.close() } catch { /* noop */ }
+      safeResolve({ ok: false, status: 0, reason: `request_error: ${err.message}` })
+    })
+    req.end(JSON.stringify(payload))
+  })
+}
+
+/**
  * Dispara um push-to-start ActivityKit (event=start) para um device.
  * @param {object} args
  * @param {string} args.pushToStartToken - token push-to-start (hex) do device (ActivityKit)
@@ -81,56 +138,59 @@ export async function sendLiveActivityStart({ pushToStartToken, attributes, cont
       alert: { title: '', body: '' }, // push-to-start silencioso (a superfície é a UI; alarme cobre som)
     },
   }
+  return _postToApns({ cfg, pushToken: pushToStartToken, payload, priority: 10, http2lib })
+}
 
-  return new Promise((resolve) => {
-    let client
-    // Timeout defensivo: em serverless (Vercel) uma conexão travada pendura a função até o limite
-    // da plataforma, atrasando o fluxo de lembretes. 5s fecha o cliente e resolve fail-open.
-    const timer = setTimeout(() => {
-      try { client?.close() } catch { /* noop */ }
-      resolve({ ok: false, status: 0, reason: 'timeout' })
-    }, APNS_TIMEOUT_MS)
-    const safeResolve = (val) => {
-      clearTimeout(timer)
-      resolve(val)
-    }
+/**
+ * Fase 2 (fix-up) — atualiza uma LA já ativa (event=update) via token PER-ACTIVITY. Transiciona o
+ * estado (upcoming→now→late) com o app fechado. priority 5 (não-urgente: o alarme T0 cobre urgência).
+ * @param {object} args
+ * @param {string} args.pushToken - token per-Activity (ActivityKit Activity.pushTokenUpdates)
+ * @param {object} args.contentState - novo estado (CON-029-compat)
+ * @param {number} [args.staleEpochSec] - stale (s); default +1h
+ * @param {object} [args.config] @param {object} [args.http2lib]
+ * @returns {Promise<{ok:boolean, status:number, deactivate?:boolean, reason?:string}>}
+ */
+export async function sendLiveActivityUpdate({ pushToken, contentState, staleEpochSec, config, http2lib = http2 }) {
+  const cfg = config || getApnsConfig()
+  if (!cfg) return { ok: false, status: 0, reason: 'apns_not_configured' }
+  if (!pushToken) return { ok: false, status: 0, reason: 'no_token' }
 
-    try {
-      client = http2lib.connect(cfg.host)
-    } catch (err) {
-      safeResolve({ ok: false, status: 0, reason: `connect_failed: ${err.message}` })
-      return
-    }
-    client.on('error', (err) => {
-      safeResolve({ ok: false, status: 0, reason: `client_error: ${err.message}` })
-      try { client.close() } catch { /* noop */ }
-    })
+  const nowSec = Math.floor(Date.now() / 1000)
+  const payload = {
+    aps: {
+      timestamp: nowSec,
+      event: 'update',
+      'content-state': contentState,
+      'stale-date': staleEpochSec ?? nowSec + 3600,
+    },
+  }
+  return _postToApns({ cfg, pushToken, payload, priority: 5, http2lib })
+}
 
-    const req = client.request({
-      ':method': 'POST',
-      ':path': `/3/device/${pushToStartToken}`,
-      authorization: `bearer ${_providerToken(cfg)}`,
-      'apns-topic': `${cfg.bundleId}.push-type.liveactivity`,
-      'apns-push-type': 'liveactivity',
-      'apns-priority': '10',
-    })
+/**
+ * Fase 2 (fix-up) — encerra uma LA ativa (event=end) via token PER-ACTIVITY. Usado na resolução da
+ * dose (registrada/pulada): mostra o content-state final (ex.: done) e agenda o dismiss.
+ * @param {object} args
+ * @param {string} args.pushToken - token per-Activity
+ * @param {object} args.contentState - estado final (ex.: { state:'done', ... })
+ * @param {number} [args.dismissEpochSec] - quando remover a LA da tela (s); default +180s (paridade card done)
+ * @param {object} [args.config] @param {object} [args.http2lib]
+ * @returns {Promise<{ok:boolean, status:number, deactivate?:boolean, reason?:string}>}
+ */
+export async function sendLiveActivityEnd({ pushToken, contentState, dismissEpochSec, config, http2lib = http2 }) {
+  const cfg = config || getApnsConfig()
+  if (!cfg) return { ok: false, status: 0, reason: 'apns_not_configured' }
+  if (!pushToken) return { ok: false, status: 0, reason: 'no_token' }
 
-    let status = 0
-    let body = ''
-    req.on('response', (headers) => { status = Number(headers[':status']) || 0 })
-    req.setEncoding('utf8')
-    req.on('data', (chunk) => { body += chunk })
-    req.on('end', () => {
-      try { client.close() } catch { /* noop */ }
-      if (status === 200) { safeResolve({ ok: true, status }); return }
-      // 410 (Unregistered) / 400 BadDeviceToken → revogar o token (S-6)
-      const deactivate = status === 410 || body.includes('BadDeviceToken') || body.includes('Unregistered')
-      safeResolve({ ok: false, status, deactivate, reason: body || `http_${status}` })
-    })
-    req.on('error', (err) => {
-      try { client.close() } catch { /* noop */ }
-      safeResolve({ ok: false, status: 0, reason: `request_error: ${err.message}` })
-    })
-    req.end(JSON.stringify(payload))
-  })
+  const nowSec = Math.floor(Date.now() / 1000)
+  const payload = {
+    aps: {
+      timestamp: nowSec,
+      event: 'end',
+      'content-state': contentState,
+      'dismissal-date': dismissEpochSec ?? nowSec + 180,
+    },
+  }
+  return _postToApns({ cfg, pushToken, payload, priority: 10, http2lib })
 }


### PR DESCRIPTION
## O que
Fix-up da **spec 041** (Fase 2): a Live Activity iOS agora **transiciona de estado e encerra via push**, com o app fechado. A Fase 1 (PR #696) só *iniciava* a LA por push; transições/encerramento dependiam do app rodando JS — então, fechado, o countdown congelava, o `atrasada` ficava preso até swipe, e registrar a dose não virava `Tomada ✓`.

## Por que
Investigação (dados prod do usuário, doses do almoço 01/07) confirmou: **DB correto, bug 100% na apresentação iOS**. A premissa da ADR-076 Decisão 2 ("start-only; transições degradam bem como na 039") é **falsa** — a LA iOS só recomputa estado em re-render, e re-render sem JS depende de um único `staleDate`. Não é spec nova: é fix-up que completa as user stories da 041 (US2). ADR-076 emendada (start-only → start+update+end).

## Como
- **Backend:** `sendLiveActivityUpdate`/`sendLiveActivityEnd` (event `update`/`end`, reusa HTTP/2+timeout AP-256); `dispatchLiveActivityLifecycle` no loop de minuto — update ao mudar estado (idempotência via `la_push_state`), end na resolução (`taken`/`skipped`/`missed`) limpando o token. Fail-open total.
- **iOS nativo:** `Activity.request(pushType:.token)` + observa `activity.pushTokenUpdates` (token per-Activity) → App Group; `getActivityPushToken` no bridge.
- **RN:** sincroniza `dose_instances.la_push_token` no derive; limpa no end.
- **DB:** migração aditiva `20260702` — `la_push_token` + `la_push_state` (aplicada em prod via MCP).

## Testes
- 30 testes apns (novos: ciclo update/end, idempotência por estado, 410→limpa token, fail-open; payloads update/end) + 151 server + 39 mobile doseActivity — todos verdes.
- Lint 0 erros nos arquivos tocados.
- **⚠️ Comportamento real só validável em smoke PROD** (serverless não roda em dev/preview) — PO-2/PO-3.

## Deploy notes
- Migração `20260702` já aplicada em prod (MCP). Aditiva, backward-compat.
- Sem envs novas (reusa APNs da Fase 1).
- Só serverless/mobile — roda na Vercel prod.

## Risco sinalizado
- Decode de `scheduledAt` (epoch sec) no widget Swift Codable (`.deferredToDate` = base 2001) — validar no device junto do smoke.

## AI Review Response
| Sugestão | Prioridade | Decisão | Reason |
|----------|-----------|---------|--------|
| Token per-Activity assíncrono (retry) | High | Aplicada | 48feb34d |
| Query ciclo LA sem limite de data (órfãos) | Medium | Aplicada | 1a8179e3 |
| Mock `gte()` no teste | Medium | Aplicada | 1a8179e3 |
| `new Date(string)` no teste (R-020) | Medium | Aplicada | 1a8179e3 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)