### PR TITLE
chore(040): F6 lote 6.2 — triagem testes server/notifications (119+48 → 0)

### DIFF
--- a/scripts/strict-island.sh
+++ b/scripts/strict-island.sh
@@ -23,11 +23,11 @@ MAX_B_WEB=37              # apps/web nível-B transitivo
 MAX_B_MOBILE=18           # apps/mobile nível-B transitivo
 MAX_B_SERVER=36           # server/* nível-B transitivo (utils 25 + bot 10 + services 1)
 MAX_A_TESTS_CORE=350      # testes dos domínios A do core (lote 6.3 → ≤120)
-MAX_A_TESTS_SERVER=119    # testes de server/notifications (lote 6.2 → 0)
+MAX_A_TESTS_SERVER=0      # testes de server/notifications (zerado no lote 6.2)
 MAX_A_TESTS_WEB=0         # testes hooks web (já zerado — trava)
 MAX_A_TESTS_MOBILE=11     # testes hooks mobile (lote 6.4 → 0)
 MAX_TESTS_PROG_API=0      # programa api/ (testes)
-MAX_TESTS_PROG_SERVER=48  # programa server/ (testes; lote 6.2 → 0)
+MAX_TESTS_PROG_SERVER=0   # programa server/ (testes; zerado no lote 6.2)
 MAX_TESTS_PROG_MOBILE=86  # programa mobile (testes; lote 6.4 → ≤30)
 
 A_SRC='^(packages/core/src/(types|repositories|services|schemas)|server/notifications|apps/web/src/shared/hooks|apps/mobile/src/shared/hooks)/'

--- a/server/notifications/apns/__tests__/buildLiveActivityPayload.test.ts
+++ b/server/notifications/apns/__tests__/buildLiveActivityPayload.test.ts
@@ -22,7 +22,7 @@ describe('buildLiveActivityStartPayload', () => {
   afterEach(() => vi.clearAllMocks());
 
   it('estado recomputado no disparo (upcoming) + content-state casa o struct', () => {
-    const p = buildLiveActivityStartPayload(item(), { discreet: false, now: NOW });
+    const p = buildLiveActivityStartPayload(item(), { discreet: false, now: NOW })!;
     expect(p).not.toBeNull();
     expect(p.contentState.state).toBe('upcoming');
     expect(p.contentState).toHaveProperty('scheduledAt');
@@ -32,18 +32,18 @@ describe('buildLiveActivityStartPayload', () => {
   });
 
   it('DEFAULT explícito (decisão PO 2026-06-29): mostra o nome (iOS não redige a LA)', () => {
-    const p = buildLiveActivityStartPayload(item(), { now: NOW }); // sem discreet → default
+    const p = buildLiveActivityStartPayload(item(), { now: NOW })!; // sem discreet → default
     expect(p.attributes.medicineName).toBe('Selozok');
     expect(p.attributes.discreet).toBe(false);
   });
 
   it('fallback do nome: sem medicineLabel derivado usa doseItem.medicineName; senão "Dose"', () => {
-    const p = buildLiveActivityStartPayload(item({ medicineName: '' }), { now: NOW });
+    const p = buildLiveActivityStartPayload(item({ medicineName: '' }), { now: NOW })!;
     expect(p.attributes.medicineName).toBe('Dose');
   });
 
   it('discreto (opt-in): nome e dose NÃO saem no payload', () => {
-    const p = buildLiveActivityStartPayload(item(), { discreet: true, now: NOW });
+    const p = buildLiveActivityStartPayload(item(), { discreet: true, now: NOW })!;
     expect(p.attributes.medicineName).toBe('');
     expect(p.attributes.doseLabel).toBe('');
     expect(p.attributes.discreet).toBe(true);
@@ -54,7 +54,7 @@ describe('buildLiveActivityStartPayload', () => {
   it('staleEpochSec = boundary de LATE (pula now) — a única transição app-fechado que importa', () => {
     // dose em +30min (upcoming). staleDate deve ir p/ o boundary now→late (scheduled + 10min),
     // NÃO p/ upcoming→now (scheduled − 10min). 'now' é cosmético (push+alarme donos do T0).
-    const p = buildLiveActivityStartPayload(item(), { now: NOW });
+    const p = buildLiveActivityStartPayload(item(), { now: NOW })!;
     const lateBoundarySec = Math.floor((NOW.getTime() + 40 * 60000) / 1000);
     expect(p.staleEpochSec).toBe(lateBoundarySec);
   });

--- a/server/notifications/apns/__tests__/criticalAuditServerEmit.test.ts
+++ b/server/notifications/apns/__tests__/criticalAuditServerEmit.test.ts
@@ -18,24 +18,33 @@ const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
 // Mock supabase: builder encadeável/awaitable (mesmo padrão de dispatchLiveActivityStarts.test.js),
 // mas com `insert` dedicado p/ capturar payloads de auditoria (tabela dose_critical_events) e
 // `not` p/ suportar a query de lifecycle (.not('la_push_token', 'is', null)).
-function makeSupabase(selectQueue) {
-  const captured = [];
+type QueryResult = { data: unknown[] | null; error: { message: string } | null };
+interface AuditPayload {
+  user_id?: string
+  dose_instance_id?: string
+  event?: string
+  platform?: string
+  actor?: string
+  detail?: { from?: string | null; to?: string; phase?: string; status?: number; reason?: string } | null
+}
+function makeSupabase(selectQueue: QueryResult[]) {
+  const captured: AuditPayload[] = [];
   let i = 0;
   const builder = () => {
     const b = {
-      _update: null,
+      _update: null as Record<string, unknown> | null,
       select() { return b; },
       eq() { return b; },
       is() { return b; },
       gte() { return b; },
       lt() { return b; }, lte() { return b; },
       not() { return b; },
-      update(payload) { b._update = payload; return b; },
-      insert(payload) {
+      update(payload: Record<string, unknown>) { b._update = payload; return b; },
+      insert(payload: AuditPayload) {
         captured.push(payload);
         return Promise.resolve({ error: null });
       },
-      then(resolve) {
+      then(resolve: (value: unknown) => unknown) {
         if (b._update) return Promise.resolve({ data: [{ id: 'inst-1' }], error: null }).then(resolve);
         const res = selectQueue[i++] ?? { data: [], error: null };
         return Promise.resolve(res).then(resolve);
@@ -62,7 +71,7 @@ const lifecycleRow = (userId = USER_A, id = INST_1) => ({
 });
 
 // Guard PII (SEC-3): nenhuma chave/valor sensível pode vazar pro trail de auditoria.
-function assertNoPii(payload) {
+function assertNoPii(payload: unknown) {
   const json = JSON.stringify(payload);
   expect(json).not.toContain('Selozok');
   expect(json).not.toContain('push_token');
@@ -135,7 +144,8 @@ describe('criticalAuditService — emissão server (dispatchLiveActivityStarts/L
     const supabase = makeSupabase([
       { data: [lifecycleRow()], error: null }, // LAs ativas (la_push_token IS NOT NULL)
     ]);
-    const updateFn = vi.fn(() => Promise.resolve({ ok: true, status: 200 }));
+    const updateFn = vi.fn((_p: { pushToken: string | null | undefined; contentState: Record<string, unknown> }) =>
+      Promise.resolve({ ok: true, status: 200 }));
     const endFn = vi.fn();
     await dispatchLiveActivityLifecycle({ supabase, logger, now: NOW, updateFn, endFn });
 
@@ -150,7 +160,7 @@ describe('criticalAuditService — emissão server (dispatchLiveActivityStarts/L
     expect(payload.detail).toEqual({ from: null, to: 'later' });
     expect(updateFn).toHaveBeenCalledTimes(1);
     // O `to` emitido bate com o state realmente empurrado ao updateFn.
-    expect(updateFn.mock.calls[0][0].contentState.state).toBe(payload.detail.to);
+    expect(updateFn.mock.calls[0]![0].contentState.state).toBe(payload.detail!.to);
     assertNoPii(payload);
   });
 

--- a/server/notifications/apns/__tests__/dispatchLiveActivityLifecycle.test.ts
+++ b/server/notifications/apns/__tests__/dispatchLiveActivityLifecycle.test.ts
@@ -8,20 +8,20 @@ const NOW = new Date(Date.UTC(2026, 6, 1, 12, 0, 0));
 const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
 
 // Mock supabase: select(...).not(...) resolve a lista; update(...).eq(...) registra o patch.
-function makeSupabase(rows) {
-  const updates = [];
+function makeSupabase(rows: unknown[]) {
+  const updates: Array<Record<string, unknown>> = [];
   const from = () => {
     const b = {
-      _update: null,
+      _update: null as Record<string, unknown> | null,
       select() { return b; },
       not() { return b; },
       gte() { return b; },
-      update(p) { b._update = p; return b; },
+      update(p: Record<string, unknown>) { b._update = p; return b; },
       eq() {
         if (b._update) { updates.push(b._update); return Promise.resolve({ data: null, error: null }); }
         return b;
       },
-      then(resolve) { return Promise.resolve({ data: rows, error: null }).then(resolve); },
+      then(resolve: (value: unknown) => unknown) { return Promise.resolve({ data: rows, error: null }).then(resolve); },
     };
     return b;
   };
@@ -29,7 +29,7 @@ function makeSupabase(rows) {
 }
 
 // scheduled_for relativo a NOW p/ cair no estado desejado (SURFACE_WINDOWS: now ±10, late < -10).
-const at = (min) => new Date(NOW.getTime() + min * 60000).toISOString();
+const at = (min: number) => new Date(NOW.getTime() + min * 60000).toISOString();
 const row = (over = {}) => ({
   id: 'inst-1', user_id: 'userA', scheduled_for: at(0), critical_alarm: true,
   status: 'pending', la_push_token: 'tok-activity', la_push_state: null,
@@ -59,11 +59,11 @@ describe('dispatchLiveActivityLifecycle', () => {
 
   it('estado mudou (now) e la_push_state=null → 1 update + marca la_push_state', async () => {
     const supabase = makeSupabase([row({ scheduled_for: at(0), la_push_state: null })]); // now
-    const updateFn = vi.fn(() => Promise.resolve({ ok: true, status: 200 }));
+    const updateFn = vi.fn((_p: { pushToken: string | null | undefined; contentState: Record<string, unknown> }) => Promise.resolve({ ok: true, status: 200 }));
     const endFn = vi.fn();
     const r = await dispatchLiveActivityLifecycle({ supabase, logger, now: NOW, updateFn, endFn });
     expect(updateFn).toHaveBeenCalledTimes(1);
-    expect(updateFn.mock.calls[0][0].contentState.state).toBe('now');
+    expect(updateFn.mock.calls[0]![0].contentState.state).toBe('now');
     expect(r.updated).toBe(1);
     expect(supabase._updates).toContainEqual({ la_push_state: 'now' });
   });
@@ -78,12 +78,12 @@ describe('dispatchLiveActivityLifecycle', () => {
 
   it('dose taken → end (done) + limpa token/estado', async () => {
     const supabase = makeSupabase([row({ status: 'taken', la_push_state: 'late' })]);
-    const endFn = vi.fn(() => Promise.resolve({ ok: true, status: 200 }));
+    const endFn = vi.fn((_p: { pushToken: string | null | undefined; contentState: Record<string, unknown> }) => Promise.resolve({ ok: true, status: 200 }));
     const updateFn = vi.fn();
     const r = await dispatchLiveActivityLifecycle({ supabase, logger, now: NOW, updateFn, endFn });
     expect(updateFn).not.toHaveBeenCalled();
     expect(endFn).toHaveBeenCalledTimes(1);
-    expect(endFn.mock.calls[0][0].contentState.state).toBe('done');
+    expect(endFn.mock.calls[0]![0].contentState.state).toBe('done');
     expect(r.ended).toBe(1);
     expect(supabase._updates).toContainEqual({ la_push_token: null, la_push_state: null });
   });

--- a/server/notifications/apns/__tests__/dispatchLiveActivityStarts.test.ts
+++ b/server/notifications/apns/__tests__/dispatchLiveActivityStarts.test.ts
@@ -10,19 +10,21 @@ const inUpcoming = '2026-07-01T13:00:00.000Z'; // now + 60min (lead default)
 const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
 
 // Mock supabase: builder encadeável + awaitable. Fila de resultados por ordem de execução.
-function makeSupabase(queue) {
-  const updates = [];
+type QueryResult = { data: unknown[] | null; error: { message: string } | null };
+type Resolve = (value: unknown) => unknown;
+function makeSupabase(queue: QueryResult[]) {
+  const updates: Array<Record<string, unknown>> = [];
   let i = 0;
   const builder = () => {
     const b = {
-      _update: null,
+      _update: null as Record<string, unknown> | null,
       select() { return b; },
       eq() { return b; },
       is() { return b; },
       gte() { return b; },
       lt() { return b; }, lte() { return b; },
-      update(payload) { b._update = payload; return b; },
-      then(resolve) {
+      update(payload: Record<string, unknown>) { b._update = payload; return b; },
+      then(resolve: Resolve) {
         if (b._update) { updates.push(b._update); return Promise.resolve({ data: [{ id: 'inst-1' }], error: null }).then(resolve); }
         const res = queue[i++] ?? { data: [], error: null };
         return Promise.resolve(res).then(resolve);
@@ -102,24 +104,24 @@ describe('dispatchLiveActivityStarts', () => {
       { data: [{ id: 'dev1', user_id: 'userA', push_token: 'tok', is_active: true }], error: null },
     ]);
     // update-branch retorna 0 linhas (trava perdida)
+    const raceQueue: QueryResult[] = [
+      { data: [doseRow()], error: null },
+      { data: [{ id: 'dev1', user_id: 'userA', push_token: 'tok', is_active: true }], error: null },
+    ];
+    let raceIdx = 0;
     supabase.from = () => {
       const b = {
-        _update: null,
+        _update: null as Record<string, unknown> | null,
         select() { return b; }, eq() { return b; }, is() { return b; }, gte() { return b; }, lt() { return b; }, lte() { return b; },
-        update(p) { b._update = p; return b; },
-        then(resolve) {
+        update(p: Record<string, unknown>) { b._update = p; return b; },
+        then(resolve: Resolve) {
           if (b._update) return Promise.resolve({ data: [], error: null }).then(resolve);
-          const res = supabase.__q[supabase.__i++] ?? { data: [], error: null };
+          const res = raceQueue[raceIdx++] ?? { data: [], error: null };
           return Promise.resolve(res).then(resolve);
         },
       };
       return b;
     };
-    supabase.__q = [
-      { data: [doseRow()], error: null },
-      { data: [{ id: 'dev1', user_id: 'userA', push_token: 'tok', is_active: true }], error: null },
-    ];
-    supabase.__i = 0;
     const sendFn = vi.fn(() => Promise.resolve({ ok: true, status: 200 }));
     const r = await dispatchLiveActivityStarts({ supabase, logger, now: NOW, sendFn });
     expect(sendFn).toHaveBeenCalledTimes(1);
@@ -150,28 +152,28 @@ describe('dispatchLiveActivityStarts', () => {
   it('janela = [now, now+lead] inclusiva: dose criada p/ <lead min (não é fatia de T−60) é pega', async () => {
     // Captura os limites de scheduled_for aplicados na query de instâncias e filtra por eles —
     // prova que uma dose a 18min (dentro do horizonte, fora da antiga fatia de T−60) entra.
-    const bounds = {};
+    const bounds: { gte?: string; lte?: string } = {};
     const near = new Date(NOW.getTime() + 18 * 60000).toISOString(); // now + 18min
     const supabase = (() => {
       let i = 0;
-      const rows = [
+      const rows: QueryResult[] = [
         { data: [{ ...doseRow(), scheduled_for: near }], error: null }, // instâncias
         { data: [{ id: 'dev1', user_id: 'userA', push_token: 'tok', is_active: true }], error: null },
       ];
-      const updates = [];
+      const updates: Array<Record<string, unknown>> = [];
       const builder = () => {
         const b = {
-          _update: null,
+          _update: null as Record<string, unknown> | null,
           select() { return b; }, eq() { return b; }, is() { return b; },
-          gte(_c, v) { bounds.gte = v; return b; },
-          lte(_c, v) { bounds.lte = v; return b; },
+          gte(_c: string, v: string) { bounds.gte = v; return b; },
+          lte(_c: string, v: string) { bounds.lte = v; return b; },
           lt() { return b; },
-          update(p) { b._update = p; return b; },
-          then(resolve) {
+          update(p: Record<string, unknown>) { b._update = p; return b; },
+          then(resolve: Resolve) {
             if (b._update) { updates.push(b._update); return Promise.resolve({ data: [{ id: 'inst-1' }], error: null }).then(resolve); }
             // só devolve a dose se ela está dentro de [gte, lte] (a janela real).
             const res = rows[i++] ?? { data: [], error: null };
-            if (i === 1 && !(near >= bounds.gte && near <= bounds.lte)) return Promise.resolve({ data: [], error: null }).then(resolve);
+            if (i === 1 && !(near >= bounds.gte! && near <= bounds.lte!)) return Promise.resolve({ data: [], error: null }).then(resolve);
             return Promise.resolve(res).then(resolve);
           },
         };

--- a/server/notifications/apns/__tests__/liveActivityPush.test.ts
+++ b/server/notifications/apns/__tests__/liveActivityPush.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { generateKeyPairSync } from 'node:crypto';
+import type * as http2 from 'node:http2';
 import { getApnsConfig, sendLiveActivityStart, sendLiveActivityUpdate, sendLiveActivityEnd, _resetJwtCache } from '../liveActivityPush';
+
+// Espelha o type local do módulo (não exportado). Mock implementa a superfície mínima
+// connect→request→{on,setEncoding,end} — cast único e documentado no helper.
+type Http2Lib = Pick<typeof http2, 'connect'>;
+type Handlers = Record<string, ((arg?: unknown) => void) | undefined>;
+interface CapturedBody { aps: { event?: string; attributes?: unknown; 'content-state'?: unknown; 'dismissal-date'?: number } }
+interface Sink { body?: CapturedBody; headers?: Record<string, string> }
 
 // .p8 EC P-256 REAL gerada em runtime (não é segredo; só p/ assinar o JWT no unit).
 const { privateKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
@@ -18,17 +26,17 @@ describe('getApnsConfig', () => {
     expect(getApnsConfig({ ...ENV, APNS_AUTH_KEY: Buffer.from('lixo').toString('base64') })).toBeNull();
   });
   it('credenciais completas → config com host de produção', () => {
-    const c = getApnsConfig(ENV);
+    const c = getApnsConfig(ENV)!;
     expect(c.bundleId).toBe('com.x.dosiq');
     expect(c.host).toContain('api.push.apple.com');
   });
 });
 
 // Mock http2: simula a resposta APNs (status configurável).
-function makeHttp2(status, body = '') {
-  const handlers = {};
+function makeHttp2(status: number, body = ''): Http2Lib {
+  const handlers: Handlers = {};
   const req = {
-    on: (ev, cb) => { handlers[ev] = cb; return req; },
+    on: (ev: string, cb: (arg?: unknown) => void) => { handlers[ev] = cb; return req; },
     setEncoding: () => {},
     end: () => {
       handlers.response?.({ ':status': status });
@@ -36,7 +44,7 @@ function makeHttp2(status, body = '') {
       handlers.end?.();
     },
   };
-  return { connect: () => ({ on: () => {}, request: () => req, close: () => {} }) };
+  return { connect: () => ({ on: () => {}, request: () => req, close: () => {} }) } as unknown as Http2Lib;
 }
 
 describe('sendLiveActivityStart', () => {
@@ -81,14 +89,14 @@ describe('sendLiveActivityStart', () => {
 });
 
 // Captura headers + body do request p/ asserção de payload (event/priority/dismissal).
-function makeCapturingHttp2(status, sink) {
-  const handlers = {};
+function makeCapturingHttp2(status: number, sink: Sink): Http2Lib {
+  const handlers: Handlers = {};
   const req = {
-    on: (ev, cb) => { handlers[ev] = cb; return req; },
+    on: (ev: string, cb: (arg?: unknown) => void) => { handlers[ev] = cb; return req; },
     setEncoding: () => {},
-    end: (payload) => { sink.body = JSON.parse(payload); handlers.response?.({ ':status': status }); handlers.end?.(); },
+    end: (payload: string) => { sink.body = JSON.parse(payload); handlers.response?.({ ':status': status }); handlers.end?.(); },
   };
-  return { connect: () => ({ on: () => {}, request: (h) => { sink.headers = h; return req; }, close: () => {} }) };
+  return { connect: () => ({ on: () => {}, request: (h: Record<string, string>) => { sink.headers = h; return req; }, close: () => {} }) } as unknown as Http2Lib;
 }
 
 describe('sendLiveActivityUpdate', () => {
@@ -96,14 +104,14 @@ describe('sendLiveActivityUpdate', () => {
   const cfg = getApnsConfig(ENV);
 
   it('payload event=update, priority 5, sem attributes', async () => {
-    const sink = {};
+    const sink: Sink = {};
     const r = await sendLiveActivityUpdate({ pushToken: 'tok', contentState: { state: 'late' }, config: cfg, http2lib: makeCapturingHttp2(200, sink) });
     expect(r.ok).toBe(true);
-    expect(sink.body.aps.event).toBe('update');
-    expect(sink.body.aps['content-state']).toEqual({ state: 'late' });
-    expect(sink.body.aps.attributes).toBeUndefined();
-    expect(sink.headers['apns-priority']).toBe('5');
-    expect(sink.headers['apns-push-type']).toBe('liveactivity');
+    expect(sink.body!.aps.event).toBe('update');
+    expect(sink.body!.aps['content-state']).toEqual({ state: 'late' });
+    expect(sink.body!.aps.attributes).toBeUndefined();
+    expect(sink.headers!['apns-priority']).toBe('5');
+    expect(sink.headers!['apns-push-type']).toBe('liveactivity');
   });
 
   it('sem token → no_token; sem config → apns_not_configured', async () => {
@@ -117,12 +125,12 @@ describe('sendLiveActivityEnd', () => {
   const cfg = getApnsConfig(ENV);
 
   it('payload event=end com dismissal-date', async () => {
-    const sink = {};
+    const sink: Sink = {};
     const r = await sendLiveActivityEnd({ pushToken: 'tok', contentState: { state: 'done' }, dismissEpochSec: 1000, config: cfg, http2lib: makeCapturingHttp2(200, sink) });
     expect(r.ok).toBe(true);
-    expect(sink.body.aps.event).toBe('end');
-    expect(sink.body.aps['dismissal-date']).toBe(1000);
-    expect(sink.body.aps['content-state']).toEqual({ state: 'done' });
+    expect(sink.body!.aps.event).toBe('end');
+    expect(sink.body!.aps['dismissal-date']).toBe(1000);
+    expect(sink.body!.aps['content-state']).toEqual({ state: 'done' });
   });
 
   it('410 → deactivate', async () => {

--- a/server/notifications/channels/expoPushChannel.test.ts
+++ b/server/notifications/channels/expoPushChannel.test.ts
@@ -73,7 +73,7 @@ describe('expoPushChannel', () => {
       { push_token: 'ExponentPushToken[good]' },
     ]
     mockRepositories.devices.listActiveByUser.mockResolvedValue(devices)
-    mockRepositories.devices.deactivateByToken.mockResolvedValue()
+    mockRepositories.devices.deactivateByToken.mockResolvedValue(undefined)
     mockExpoClient.sendPushNotificationsAsync.mockResolvedValue([
       { status: 'error', message: 'DeviceNotRegistered', details: { error: 'DeviceNotRegistered' } },
       { status: 'ok' },

--- a/server/notifications/dispatcher/dispatchNotification.test.ts
+++ b/server/notifications/dispatcher/dispatchNotification.test.ts
@@ -11,7 +11,7 @@ const mockSendNotification = vi.fn()
 vi.mock('web-push', () => ({
   default: {
     setVapidDetails: vi.fn(),
-    sendNotification: (...args) => mockSendNotification(...args)
+    sendNotification: (...args: unknown[]) => mockSendNotification(...args)
   }
 }))
 
@@ -23,7 +23,7 @@ vi.mock('../repositories/notificationLogRepository.js', () => ({
 }))
 
 vi.mock('../../utils/dateUtils.js', async (importOriginal) => {
-  const actual = await importOriginal()
+  const actual = await importOriginal<typeof import('../../utils/dateUtils.js')>()
   return {
     ...actual,
     getNow: vi.fn(() => actual.parseISO('2026-05-02T12:00:00Z')),
@@ -124,15 +124,15 @@ describe('dispatchNotification', () => {
     const telegramResult = result.channels.find((c) => c.channel === 'telegram')
     const pushResult = result.channels.find((c) => c.channel === 'mobile_push')
 
-    expect(telegramResult.delivered).toBe(1)
-    expect(pushResult.success).toBe(false)
+    expect(telegramResult!.delivered).toBe(1)
+    expect(pushResult!.success).toBe(false)
     expect(result.totalDelivered).toBe(1)
   })
 
   // Caso 3: mobile_push com DeviceNotRegistered → token desativado
   it('caso 3: DeviceNotRegistered desativa o token', async () => {
     mockRepositories.devices.listActiveByUser.mockResolvedValue([{ push_token: 'ExponentPushToken[bad]' }])
-    mockRepositories.devices.deactivateByToken.mockResolvedValue()
+    mockRepositories.devices.deactivateByToken.mockResolvedValue(undefined)
     mockExpoClient.sendPushNotificationsAsync.mockResolvedValue([
       { status: 'error', message: 'DeviceNotRegistered', details: { error: 'DeviceNotRegistered' } },
     ])
@@ -221,13 +221,12 @@ describe('dispatchNotification', () => {
 
   // Caso 7: web_push com erro 410 (Gone) desativa o token
   it('caso 7: web_push com erro 410 (Gone) desativa o token', async () => {
-    const error = new Error('Subscription no longer active')
-    error.statusCode = 410
+    const error = Object.assign(new Error('Subscription no longer active'), { statusCode: 410 })
     mockSendNotification.mockRejectedValue(error)
     
     const mockToken = '{"endpoint":"https://fcm.googleapis.com","keys":{"p256dh":"bad","auth":"456"}}'
     mockRepositories.devices.listActiveByUser.mockResolvedValue([{ push_token: mockToken }])
-    mockRepositories.devices.deactivateByToken.mockResolvedValue()
+    mockRepositories.devices.deactivateByToken.mockResolvedValue(undefined)
 
     const result = await dispatchNotification({
       userId: 'user-7',

--- a/server/notifications/policies/__tests__/resolveChannelsForUser.test.ts
+++ b/server/notifications/policies/__tests__/resolveChannelsForUser.test.ts
@@ -1,14 +1,22 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { resolveChannelsForUser } from '../resolveChannelsForUser';
+import type { NotificationDevice } from '../../repositories/notificationDeviceRepository';
+import type { NotificationSettings } from '../../repositories/notificationPreferenceRepository';
 
 // Repos mock: dose crítica deve ir SÓ pelo canal de alarme (mobile_push), com fallback telegram
 // quando não há device mobile ativo. Não-crítica segue as preferências normais.
-function makeRepos({ telegram = true, expo = [], web = [], settings = null } = {}) {
+interface MakeReposOptions {
+  telegram?: boolean
+  expo?: NotificationDevice[]
+  web?: NotificationDevice[]
+  settings?: Partial<NotificationSettings> | null
+}
+function makeRepos({ telegram = true, expo = [], web = [], settings = null }: MakeReposOptions = {}) {
   return {
     preferences: {
       hasTelegramChat: vi.fn(() => Promise.resolve(telegram)),
       getSettingsByUserId: vi.fn(() => Promise.resolve(settings)),
-      getByUserId: vi.fn(() => Promise.resolve('both')),
+      getByUserId: vi.fn(() => Promise.resolve('both' as const)),
     },
     devices: {
       listActiveByUser: vi.fn((_u, kind) => Promise.resolve(kind === 'expo' ? expo : web)),
@@ -23,7 +31,7 @@ describe('resolveChannelsForUser — gate de dose crítica', () => {
   afterEach(() => { vi.clearAllMocks(); });
 
   it('crítica + device mobile ativo → SÓ mobile_push (sem telegram)', async () => {
-    const repositories = makeRepos({ telegram: true, expo: [{ id: 'd1' }], settings: WAVE_N2 });
+    const repositories = makeRepos({ telegram: true, expo: [{ id: 'd1' } as NotificationDevice], settings: WAVE_N2 });
     const channels = await resolveChannelsForUser({ userId: 'u1', repositories, isCritical: true });
     expect(channels).toEqual(['mobile_push']);
   });
@@ -41,7 +49,7 @@ describe('resolveChannelsForUser — gate de dose crítica', () => {
   });
 
   it('NÃO-crítica → segue preferências (telegram + mobile_push)', async () => {
-    const repositories = makeRepos({ telegram: true, expo: [{ id: 'd1' }], settings: WAVE_N2 });
+    const repositories = makeRepos({ telegram: true, expo: [{ id: 'd1' } as NotificationDevice], settings: WAVE_N2 });
     const channels = await resolveChannelsForUser({ userId: 'u1', repositories, isCritical: false });
     expect(channels).toContain('telegram');
     expect(channels).toContain('mobile_push');

--- a/server/notifications/policies/resolveChannelsForUser.test.ts
+++ b/server/notifications/policies/resolveChannelsForUser.test.ts
@@ -143,7 +143,7 @@ describe('resolveChannelsForUser — flags explícitas Wave N2', () => {
       channel_telegram_enabled: false,
     })
     repos.devices.listActiveByUser.mockImplementation((uid: string, type?: string) =>
-      type === 'expo' ? [{ id: 'dev-1' }] : []
+      Promise.resolve(type === 'expo' ? [{ id: 'dev-1' }] : [])
     )
 
     const result = await resolveChannelsForUser({ userId, repositories: repos })
@@ -173,7 +173,7 @@ describe('resolveChannelsForUser — flags explícitas Wave N2', () => {
       channel_telegram_enabled: false,
     })
     repos.devices.listActiveByUser.mockImplementation((uid: string, type?: string) =>
-      type === 'webpush' ? [{ id: 'web-1' }] : []
+      Promise.resolve(type === 'webpush' ? [{ id: 'web-1' }] : [])
     )
 
     const result = await resolveChannelsForUser({ userId, repositories: repos })
@@ -231,9 +231,9 @@ describe('resolveChannelsForUser — flags explícitas Wave N2', () => {
       channel_telegram_enabled: true,
     })
     repos.devices.listActiveByUser.mockImplementation((uid: string, type?: string) => {
-      if (type === 'expo') return [{ id: 'expo-1' }]
-      if (type === 'webpush') return [{ id: 'web-1' }]
-      return []
+      if (type === 'expo') return Promise.resolve([{ id: 'expo-1' }])
+      if (type === 'webpush') return Promise.resolve([{ id: 'web-1' }])
+      return Promise.resolve([])
     })
 
     const result = await resolveChannelsForUser({ userId, repositories: repos })
@@ -278,7 +278,7 @@ describe('resolveChannelsForUser — flags explícitas Wave N2', () => {
         channel_telegram_enabled: false,
       })
       repos.devices.listActiveByUser.mockImplementation((uid: string, type?: string) =>
-        type === 'expo' ? [{ id: 'dev-1' }] : []
+        Promise.resolve(type === 'expo' ? [{ id: 'dev-1' }] : [])
       )
 
       const result = await resolveChannelsForUser({ userId, repositories: repos, isCritical: true })
@@ -310,7 +310,7 @@ describe('resolveChannelsForUser — flags explícitas Wave N2', () => {
         channel_telegram_enabled: true,
       })
       repos.devices.listActiveByUser.mockImplementation((uid: string, type?: string) =>
-        type === 'expo' ? [{ id: 'dev-1' }] : []
+        Promise.resolve(type === 'expo' ? [{ id: 'dev-1' }] : [])
       )
 
       const result = await resolveChannelsForUser({ userId, repositories: repos, isCritical: true })

--- a/server/notifications/policies/resolveChannelsForUser.test.ts
+++ b/server/notifications/policies/resolveChannelsForUser.test.ts
@@ -119,7 +119,9 @@ describe('resolveChannelsForUser', () => {
 describe('resolveChannelsForUser — flags explícitas Wave N2', () => {
   const userId = 'user-n2'
 
-  const makeRepositories = (overrides = {}) => ({
+  const makeRepositories = (
+    overrides: { preferences?: Record<string, ReturnType<typeof vi.fn>>; devices?: Record<string, ReturnType<typeof vi.fn>> } = {}
+  ) => ({
     preferences: {
       getByUserId: vi.fn(),
       hasTelegramChat: vi.fn(),
@@ -140,7 +142,7 @@ describe('resolveChannelsForUser — flags explícitas Wave N2', () => {
       channel_web_push_enabled: false,
       channel_telegram_enabled: false,
     })
-    repos.devices.listActiveByUser.mockImplementation((uid, type) =>
+    repos.devices.listActiveByUser.mockImplementation((uid: string, type?: string) =>
       type === 'expo' ? [{ id: 'dev-1' }] : []
     )
 
@@ -170,7 +172,7 @@ describe('resolveChannelsForUser — flags explícitas Wave N2', () => {
       channel_web_push_enabled: true,
       channel_telegram_enabled: false,
     })
-    repos.devices.listActiveByUser.mockImplementation((uid, type) =>
+    repos.devices.listActiveByUser.mockImplementation((uid: string, type?: string) =>
       type === 'webpush' ? [{ id: 'web-1' }] : []
     )
 
@@ -228,7 +230,7 @@ describe('resolveChannelsForUser — flags explícitas Wave N2', () => {
       channel_web_push_enabled: true,
       channel_telegram_enabled: true,
     })
-    repos.devices.listActiveByUser.mockImplementation((uid, type) => {
+    repos.devices.listActiveByUser.mockImplementation((uid: string, type?: string) => {
       if (type === 'expo') return [{ id: 'expo-1' }]
       if (type === 'webpush') return [{ id: 'web-1' }]
       return []
@@ -275,7 +277,7 @@ describe('resolveChannelsForUser — flags explícitas Wave N2', () => {
         channel_web_push_enabled: false,
         channel_telegram_enabled: false,
       })
-      repos.devices.listActiveByUser.mockImplementation((uid, type) =>
+      repos.devices.listActiveByUser.mockImplementation((uid: string, type?: string) =>
         type === 'expo' ? [{ id: 'dev-1' }] : []
       )
 
@@ -307,7 +309,7 @@ describe('resolveChannelsForUser — flags explícitas Wave N2', () => {
         channel_web_push_enabled: false,
         channel_telegram_enabled: true,
       })
-      repos.devices.listActiveByUser.mockImplementation((uid, type) =>
+      repos.devices.listActiveByUser.mockImplementation((uid: string, type?: string) =>
         type === 'expo' ? [{ id: 'dev-1' }] : []
       )
 

--- a/server/notifications/policies/resolveChannelsForUser.ts
+++ b/server/notifications/policies/resolveChannelsForUser.ts
@@ -11,7 +11,8 @@ type Channel = 'telegram' | 'mobile_push' | 'web_push'
 export interface ResolveChannelsRepositories {
   preferences: {
     hasTelegramChat(userId: string): Promise<boolean>
-    getSettingsByUserId?(userId: string): Promise<NotificationSettings>
+    // Partial|null: a policy trata settings ausentes/incompletos com fallback legado (ver guard abaixo)
+    getSettingsByUserId?(userId: string): Promise<Partial<NotificationSettings> | null>
     getByUserId(userId: string): Promise<NotificationPreference>
   }
   devices: {
@@ -20,7 +21,7 @@ export interface ResolveChannelsRepositories {
 }
 
 function resolveWaveN2(
-  settings: NotificationSettings,
+  settings: Partial<NotificationSettings>,
   activeExpoDevices: NotificationDevice[],
   activeWebDevices: NotificationDevice[],
   hasTelegram: boolean


### PR DESCRIPTION
## Escopo
Lote 6.2 da tabela §F6 do playbook: triagem MATA/TIPA dos testes de `server/notifications` (buckets `MAX_A_TESTS_SERVER` e `MAX_TESTS_PROG_SERVER`).

## Contadores antes → depois (catraca no mesmo commit)
| Bucket | Antes | Depois | Teto novo |
|---|---|---|---|
| testes A server/notifications (strict island) | 119 | **0** | 0 |
| testes programa server | 48 | **0** | 0 |

`./scripts/strict-island.sh` verde com os tetos novos. Demais buckets inalterados.

## Triagem (rubrica §F6)
**9/9 arquivos classificados TIPA** — todos exercitam lógica real com entrada→saída observável (handling de status APNs 200/400/410/500, assinatura JWT com .p8 real, janela push-to-start, idempotência de lock, guard IDOR S-1, guard PII SEC-3, policy de canais crítica/legado/N2, isolamento de falha por canal). Mocks são stubs de dependência injetada, não mock-contra-mock.

**Testes MATA deletados: nenhum.** Histórico git dos 9 arquivos não mostra padrão "atualizar mock" recorrente (critério 3 não disparou).

## Mocks stale corrigidos
Nenhum mock stale de contrato encontrado. Ajuste de tipo legítimo no **source** (`policies/resolveChannelsForUser.ts`, interface de dependência da policy — não é API do core):
- `getSettingsByUserId?` alargado de `Promise<NotificationSettings>` para `Promise<Partial<NotificationSettings> | null>` + `resolveWaveN2(settings: Partial<NotificationSettings>)`. Motivo: a policy JÁ trata settings ausentes/incompletos defensivamente (`settings?.flag !== undefined` → fallback legado) e os testes exercitam exatamente esse ramo com `{}`/`null`. O repositório concreto continua retornando `NotificationSettings` completo (defaults no catch) — covariante, zero mudança de comportamento.

## Fixes de tipagem (sem mudança de comportamento)
- Helpers http2 mock tipados contra `Http2Lib = Pick<typeof http2, 'connect'>` (espelho do type local do módulo); cast único documentado por helper
- Builders supabase mock: `QueryResult`/`Resolve`/`AuditPayload` tipados; monkey-patch `__q`/`__i` substituído por closure local
- `vi.fn()` de `updateFn`/`endFn` com o param do contrato `UpdateFn` (contravariância)
- `mockResolvedValue()` → `mockResolvedValue(undefined)` (Vitest 4 typed mocks); `'both' as const` p/ `NotificationPreference`; `Object.assign(new Error(...), { statusCode: 410 })`
- Non-null assertions só após asserção runtime (`expect(p).not.toBeNull()` / captura garantida)

## Triagem pendente
Nenhuma.

## Testes
- `npx vitest run server/notifications`: 26 suites / 248 testes verdes
- `npm run test:changed`: verde
- `rtk lint`: 0 errors (warnings pré-existentes fora do escopo)

## APs/regras novas
Nenhuma — consolidação no C5 da fase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)