### PR TITLE
chore(040): F6 lote 6.4 — mobile dose/onboarding: queima B/A hooks + prog tests

### DIFF
--- a/apps/mobile/src/platform/alarms/AlarmSchedulerBridge.tsx
+++ b/apps/mobile/src/platform/alarms/AlarmSchedulerBridge.tsx
@@ -11,7 +11,12 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { AppState, Platform } from 'react-native'
 import notifee, { EventType, AuthorizationStatus } from '@notifee/react-native'
-import { getTodayLocal, getRawNow, createCriticalAuditService } from '@dosiq/core'
+import {
+  getTodayLocal,
+  getRawNow,
+  createCriticalAuditService,
+  type CriticalAuditEvent,
+} from '@dosiq/core'
 import { supabase } from '@platform/supabase/nativeSupabaseClient'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { createCriticalAuditQueue } from '@platform/audit/criticalAuditQueue'
@@ -91,7 +96,7 @@ async function flushCriticalAudit(userId) {
       }
     }
     // Drena a fila: insere cada evento via o helper único (CON-031). Item só sai após insert OK.
-    await auditQueue.flush((evt) => auditEmitter.emit(evt))
+    await auditQueue.flush((evt) => auditEmitter.emit(evt as unknown as CriticalAuditEvent))
   } catch (err) {
     if (__DEV__) console.warn('[AlarmSchedulerBridge] flush audit falhou', err?.message)
   }

--- a/apps/mobile/src/platform/alarms/__tests__/alarmEnabledStore.test.ts
+++ b/apps/mobile/src/platform/alarms/__tests__/alarmEnabledStore.test.ts
@@ -8,23 +8,25 @@ import {
   ALARM_NUDGE_SEEN_KEY,
 } from '../alarmEnabledStore'
 
+const mockedGetItem = AsyncStorage.getItem as jest.Mock
+
 afterEach(() => {
   jest.clearAllMocks()
 })
 
 describe('alarmEnabledStore', () => {
   it('default OFF quando não há valor persistido', async () => {
-    AsyncStorage.getItem.mockResolvedValueOnce(null)
+    mockedGetItem.mockResolvedValueOnce(null)
     expect(await isAlarmEnabled()).toBe(false)
   })
 
   it('lê true quando persistido', async () => {
-    AsyncStorage.getItem.mockResolvedValueOnce('true')
+    mockedGetItem.mockResolvedValueOnce('true')
     expect(await isAlarmEnabled()).toBe(true)
   })
 
   it('default OFF em erro de storage (fail-safe)', async () => {
-    AsyncStorage.getItem.mockRejectedValueOnce(new Error('boom'))
+    mockedGetItem.mockRejectedValueOnce(new Error('boom'))
     expect(await isAlarmEnabled()).toBe(false)
   })
 
@@ -36,14 +38,14 @@ describe('alarmEnabledStore', () => {
   })
 
   it('nudge: não visto por padrão, marca visto', async () => {
-    AsyncStorage.getItem.mockResolvedValueOnce(null)
+    mockedGetItem.mockResolvedValueOnce(null)
     expect(await hasSeenAlarmNudge()).toBe(false)
     await markAlarmNudgeSeen()
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(ALARM_NUDGE_SEEN_KEY, 'true')
   })
 
   it('nudge: erro de leitura → não insistir (true)', async () => {
-    AsyncStorage.getItem.mockRejectedValueOnce(new Error('x'))
+    mockedGetItem.mockRejectedValueOnce(new Error('x'))
     expect(await hasSeenAlarmNudge()).toBe(true)
   })
 })

--- a/apps/mobile/src/platform/alarms/__tests__/alarmService.test.ts
+++ b/apps/mobile/src/platform/alarms/__tests__/alarmService.test.ts
@@ -1,6 +1,8 @@
 import notifee, { TriggerType } from '@notifee/react-native'
 import { scheduleAlarm, cancelAlarm, scheduleNag, cancelAll } from '../alarmService'
 
+const mockedCreateTriggerNotification = notifee.createTriggerNotification as jest.Mock
+
 afterEach(() => {
   jest.clearAllMocks()
 })
@@ -11,7 +13,7 @@ describe('scheduleAlarm', () => {
   it('agenda trigger TIMESTAMP com allowWhileIdle e id = doseInstanceId (idempotência)', async () => {
     await scheduleAlarm({ doseInstanceId: 'inst-1', medicineName: 'Losartana', scheduledFor: FUTURE() })
     expect(notifee.createTriggerNotification).toHaveBeenCalledTimes(1)
-    const [notification, trigger] = notifee.createTriggerNotification.mock.calls[0]
+    const [notification, trigger] = mockedCreateTriggerNotification.mock.calls[0]
     expect(notification.id).toBe('inst-1')
     expect(trigger.type).toBe(TriggerType.TIMESTAMP)
     expect(trigger.alarmManager).toEqual({ allowWhileIdle: true })
@@ -64,7 +66,7 @@ describe('scheduleNag', () => {
       currentNagAttempt: 0,
     })
     expect(notifee.createTriggerNotification).toHaveBeenCalledTimes(1)
-    const [notification] = notifee.createTriggerNotification.mock.calls[0]
+    const [notification] = mockedCreateTriggerNotification.mock.calls[0]
     expect(notification.id).toBe('inst-1:nag:1')
     expect(notification.data.nagAttempt).toBe('1')
   })

--- a/apps/mobile/src/platform/alarms/__tests__/quickDoseRegistration.test.ts
+++ b/apps/mobile/src/platform/alarms/__tests__/quickDoseRegistration.test.ts
@@ -1,7 +1,12 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import notifee from '@notifee/react-native'
 
-type LogData = Record<string, unknown>
+interface LogData {
+  protocol_id?: string | null
+  medicine_id?: string
+  taken_at?: string
+  quantity_taken?: number
+}
 type RegisterDoseOpts = { instanceId?: string | null }
 
 const mockRegisterDose = jest.fn((_logData: LogData, _opts?: RegisterDoseOpts) =>

--- a/apps/mobile/src/platform/alarms/__tests__/quickDoseRegistration.test.ts
+++ b/apps/mobile/src/platform/alarms/__tests__/quickDoseRegistration.test.ts
@@ -1,28 +1,36 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import notifee from '@notifee/react-native'
 
-const mockRegisterDose = jest.fn(() => Promise.resolve({ success: true, data: { id: 'log-1' } }))
+type LogData = Record<string, unknown>
+type RegisterDoseOpts = { instanceId?: string | null }
+
+const mockRegisterDose = jest.fn((_logData: LogData, _opts?: RegisterDoseOpts) =>
+  Promise.resolve({ success: true, data: { id: 'log-1' } }),
+)
 jest.mock('@dose/services/doseService', () => ({
-  registerDose: (...args) => mockRegisterDose(...args),
+  registerDose: (logData: LogData, opts?: RegisterDoseOpts) => mockRegisterDose(logData, opts),
 }))
 
 const mockEq = jest.fn(() => Promise.resolve({ error: null }))
 const mockUpdate = jest.fn(() => ({ eq: mockEq }))
-const mockFrom = jest.fn(() => ({ update: mockUpdate }))
+const mockFrom = jest.fn((_table?: string) => ({ update: mockUpdate }))
 jest.mock('@platform/supabase/nativeSupabaseClient', () => ({
-  supabase: { from: (...a) => mockFrom(...a) },
+  supabase: { from: (table?: string) => mockFrom(table) },
 }))
 
 const mockNavigate = jest.fn()
 jest.mock('@navigation/navigationRef', () => ({
-  navigationRef: { isReady: () => true, navigate: (...a) => mockNavigate(...a) },
+  navigationRef: {
+    isReady: () => true,
+    navigate: (screen?: unknown, params?: unknown) => mockNavigate(screen, params),
+  },
 }))
 jest.mock('@navigation/routes', () => ({ ROUTES: { TODAY: 'Hoje' } }))
 
 import { handleAlarmAction, registerTaken, registerSkip } from '../quickDoseRegistration'
 import { SURFACE_ACTION } from '@platform/doseActivity/doseActivitySurfaceService'
 
-function evt(pressActionId, data) {
+function evt(pressActionId: string | undefined, data: Record<string, unknown>) {
   return { detail: { pressAction: { id: pressActionId }, notification: { data } } }
 }
 
@@ -71,7 +79,7 @@ describe('handleAlarmAction — Pular', () => {
     expect(mockFrom).toHaveBeenCalledWith('dose_instances')
     expect(mockUpdate).toHaveBeenCalledWith({ status: 'skipped_user' })
     expect(mockEq).toHaveBeenCalledWith('id', 'inst-1')
-    expect(res.action).toBe('dose-skip')
+    expect((res as { action: string }).action).toBe('dose-skip')
   })
 
   it('invalida today + treatments (sem stock, não consome)', async () => {
@@ -87,7 +95,7 @@ describe('handleAlarmAction — ignorado', () => {
   it('agenda nag reativo', async () => {
     const res = await handleAlarmAction(evt(undefined, { ...BASE, nagAttempt: '0', scheduledFor: new Date(Date.now() - 1000).toISOString() }))
     expect(notifee.createTriggerNotification).toHaveBeenCalled()
-    expect(res.action).toBe('nag')
+    expect((res as { action: string }).action).toBe('nag')
   })
 
   it('sem doseInstanceId → não trata', async () => {
@@ -102,7 +110,7 @@ describe('handleAlarmAction — Soneca', () => {
     const res = await handleAlarmAction(evt('dose-snooze', { ...BASE, snoozeAttempt: '0' }))
     expect(notifee.createTriggerNotification).toHaveBeenCalled()
     expect(mockRegisterDose).not.toHaveBeenCalled()
-    expect(res.action).toBe('dose-snooze')
+    expect((res as { action: string }).action).toBe('dose-snooze')
   })
 
   it('estourou o teto (3) → não re-agenda', async () => {

--- a/apps/mobile/src/platform/alarms/__tests__/useAlarmScheduler.snooze.test.ts
+++ b/apps/mobile/src/platform/alarms/__tests__/useAlarmScheduler.snooze.test.ts
@@ -4,14 +4,16 @@
 import { syncAlarms } from '../useAlarmScheduler'
 import { alarmService } from '../alarmService'
 
+const mockedScheduleAlarm = alarmService.scheduleAlarm as jest.Mock
+
 const NOW = new Date('2026-03-05T12:00:00.000Z')
 
 jest.mock('@platform/supabase/nativeSupabaseClient', () => ({ supabase: {} }))
 
 jest.mock('../alarmService', () => ({
   alarmService: {
-    cancelAll: jest.fn().mockResolvedValue(),
-    scheduleAlarm: jest.fn().mockResolvedValue(),
+    cancelAll: jest.fn().mockResolvedValue(undefined),
+    scheduleAlarm: jest.fn().mockResolvedValue(undefined),
   },
 }))
 
@@ -20,7 +22,7 @@ jest.mock('@dosiq/core', () => ({
   createDoseInstanceRepository: () => ({ getWindow: jest.fn().mockResolvedValue([]) }),
   createCriticalAuditService: () => ({ emit: jest.fn().mockResolvedValue({ ok: true }) }),
   buildDoseItemsFromInstances: () => mockItems,
-  ensureInstancesUpTo: jest.fn().mockResolvedValue(),
+  ensureInstancesUpTo: jest.fn().mockResolvedValue(undefined),
   getRawNow: () => new Date('2026-03-05T12:00:00.000Z'),
   addDays: (d, n) => new Date(d.getTime() + n * 86400000),
   parseISO: (s) => new Date(s),
@@ -46,7 +48,7 @@ describe('syncAlarms — soneca re-armada no resync', () => {
 
     expect(alarmService.cancelAll).toHaveBeenCalled()
     expect(alarmService.scheduleAlarm).toHaveBeenCalledTimes(1)
-    const arg = alarmService.scheduleAlarm.mock.calls[0][0]
+    const arg = mockedScheduleAlarm.mock.calls[0][0]
     expect(arg.doseInstanceId).toBe('inst-1')
     expect(arg.fireAt).toBe(snoozedTs)
     expect(arg.scheduledFor).toBe('2026-03-05T11:00:00.000Z') // original preservado
@@ -55,7 +57,7 @@ describe('syncAlarms — soneca re-armada no resync', () => {
   it('snoozed_until no passado → NÃO trata como soneca (agenda normal, sem fireAt)', async () => {
     mockItems = [baseItem({ snoozedUntil: NOW.getTime() - 60000, scheduledFor: '2026-03-05T13:00:00.000Z' })]
     await syncAlarms({ userId: 'u1', protocols: [], tz: 'America/Sao_Paulo' })
-    const arg = alarmService.scheduleAlarm.mock.calls[0][0]
+    const arg = mockedScheduleAlarm.mock.calls[0][0]
     expect(arg.fireAt).toBeUndefined()
   })
 })

--- a/apps/mobile/src/platform/alarms/alarmService.ts
+++ b/apps/mobile/src/platform/alarms/alarmService.ts
@@ -318,6 +318,16 @@ function buildNotification({ doseInstanceId, medicineName, data, notificationId,
  * @param {{ doseInstanceId: string, medicineName?: string, scheduledFor: string|number|Date,
  *           toleranceMinutes?: number|null, isCritical?: boolean, data?: object, fireAt?: number|null }} params
  */
+interface ScheduleAlarmParams {
+  doseInstanceId: string
+  medicineName?: string
+  scheduledFor?: string | number
+  toleranceMinutes?: number | null
+  isCritical?: boolean
+  data?: Record<string, unknown>
+  fireAt?: number | null
+}
+
 export async function scheduleAlarm({
   doseInstanceId,
   medicineName,
@@ -326,7 +336,7 @@ export async function scheduleAlarm({
   isCritical = false,
   data = {},
   fireAt = null,
-}) {
+}: ScheduleAlarmParams) {
   await ensureAlarmSetup()
   // F: instante absoluto (timestamptz) → epoch direto via parseISO (não date-string parse).
   // fireAt (epoch ms) tem precedência: re-arma a MESMA dose num horário deslocado (soneca).
@@ -375,6 +385,16 @@ export async function cancelAlarm(doseInstanceId) {
  * @param {{ doseInstanceId: string, medicineName?: string, scheduledFor?: string|number|Date,
  *           toleranceMinutes?: number|null, currentNagAttempt?: number, isCritical?: boolean, data?: object }} params
  */
+interface ScheduleNagParams {
+  doseInstanceId: string
+  medicineName?: string
+  scheduledFor?: string | number
+  toleranceMinutes?: number | null
+  currentNagAttempt?: number
+  isCritical?: boolean
+  data?: Record<string, unknown>
+}
+
 export async function scheduleNag({
   doseInstanceId,
   medicineName,
@@ -383,7 +403,7 @@ export async function scheduleNag({
   currentNagAttempt = 0,
   isCritical = false,
   data = {},
-}) {
+}: ScheduleNagParams) {
   const next = currentNagAttempt + 1
   if (next > MAX_NAG_ATTEMPTS) return
 

--- a/apps/mobile/src/platform/alarms/alarmService.ts
+++ b/apps/mobile/src/platform/alarms/alarmService.ts
@@ -321,7 +321,7 @@ function buildNotification({ doseInstanceId, medicineName, data, notificationId,
 interface ScheduleAlarmParams {
   doseInstanceId: string
   medicineName?: string
-  scheduledFor?: string | number
+  scheduledFor: string | number | Date
   toleranceMinutes?: number | null
   isCritical?: boolean
   data?: Record<string, unknown>
@@ -388,7 +388,7 @@ export async function cancelAlarm(doseInstanceId) {
 interface ScheduleNagParams {
   doseInstanceId: string
   medicineName?: string
-  scheduledFor?: string | number
+  scheduledFor?: string | number | Date
   toleranceMinutes?: number | null
   currentNagAttempt?: number
   isCritical?: boolean

--- a/apps/mobile/src/platform/audit/criticalAuditQueue.ts
+++ b/apps/mobile/src/platform/audit/criticalAuditQueue.ts
@@ -3,6 +3,33 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 export const AUDIT_QUEUE_KEY = '@dosiq/audit/queue'
 export const AUDIT_QUEUE_CAP = 200
 
+export type AuditQueueItem = Record<string, unknown>
+
+interface AuditQueueState {
+  items: AuditQueueItem[]
+  overflowDropped: number
+}
+
+interface AuditQueueStorage {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+  removeItem(key: string): Promise<void>
+}
+
+interface CreateCriticalAuditQueueOptions {
+  storage?: AuditQueueStorage
+  key?: string
+  cap?: number
+}
+
+export type FlushInsertOne = (item: AuditQueueItem) => Promise<boolean | { ok: boolean }>
+
+export interface FlushResult {
+  inserted: number
+  remaining: number
+  skipped?: boolean
+}
+
 // Fila offline de eventos de auditoria de dose crítica (spec 042 Slice B, CON-031).
 // Persistência via AsyncStorage; drenada no foreground. NÃO importa supabase —
 // o inserter é injetado no flush() para manter o cold-start do background handler
@@ -11,15 +38,15 @@ export function createCriticalAuditQueue({
   storage = AsyncStorage,
   key = AUDIT_QUEUE_KEY,
   cap = AUDIT_QUEUE_CAP,
-} = {}) {
+}: CreateCriticalAuditQueueOptions = {}) {
   // Flag em memória para pular flush concorrente (reentrância — retorna skipped).
   let flushInFlight = false
 
   // Mutex: serializa TODA operação de read-modify-write no AsyncStorage. Sem isto, um enqueue(B)
   // que roda enquanto o flush(A) está entre o read e o write-back grava [A,B]; o flush então grava
   // os "remaining" (calculados sobre [A]) e clobbera B → perda de evento (race crítica, review #700).
-  let lockChain = Promise.resolve()
-  function withLock(op) {
+  let lockChain: Promise<unknown> = Promise.resolve()
+  function withLock<T>(op: () => Promise<T>): Promise<T> {
     const run = lockChain.then(op, op) // encadeia mesmo se o anterior rejeitou (não deve — ops são fail-open)
     // Mantém a corrente viva sem propagar rejeição/valor pro próximo elo.
     lockChain = run.then(
@@ -29,7 +56,7 @@ export function createCriticalAuditQueue({
     return run
   }
 
-  async function readState() {
+  async function readState(): Promise<AuditQueueState> {
     try {
       const raw = await storage.getItem(key)
       if (!raw) return { items: [], overflowDropped: 0 }
@@ -47,7 +74,7 @@ export function createCriticalAuditQueue({
     }
   }
 
-  async function writeState(state) {
+  async function writeState(state: AuditQueueState): Promise<void> {
     try {
       await storage.setItem(key, JSON.stringify(state))
     } catch {
@@ -55,7 +82,7 @@ export function createCriticalAuditQueue({
     }
   }
 
-  function enqueue(payload) {
+  function enqueue(payload: AuditQueueItem): Promise<void> {
     return withLock(async () => {
       try {
         const state = await readState()
@@ -71,7 +98,7 @@ export function createCriticalAuditQueue({
     })
   }
 
-  async function flush(insertOne) {
+  async function flush(insertOne: FlushInsertOne): Promise<FlushResult> {
     // Skip imediato (sem tomar o lock) se um flush já roda — evita empilhar drenagens.
     if (flushInFlight) {
       const state = await readState()
@@ -81,13 +108,13 @@ export function createCriticalAuditQueue({
     try {
       // O read→process→write inteiro roda sob o lock: um enqueue concorrente espera e anexa
       // ao estado JÁ drenado (não é clobberado).
-      return await withLock(async () => {
+      return await withLock(async (): Promise<FlushResult> => {
         const state = await readState()
         if (state.items.length === 0) {
           return { inserted: 0, remaining: 0 }
         }
 
-        const remainingItems = []
+        const remainingItems: AuditQueueItem[] = []
         let inserted = 0
 
         // Loop sequencial (não Promise.all): a ordem importa para retry.
@@ -124,14 +151,14 @@ export function createCriticalAuditQueue({
     }
   }
 
-  function peek() {
+  function peek(): Promise<AuditQueueState> {
     return withLock(async () => {
       const state = await readState()
       return { items: [...state.items], overflowDropped: state.overflowDropped }
     })
   }
 
-  function clear() {
+  function clear(): Promise<void> {
     return withLock(async () => {
       try {
         await storage.removeItem(key)

--- a/apps/mobile/src/platform/auth/__tests__/authService.test.ts
+++ b/apps/mobile/src/platform/auth/__tests__/authService.test.ts
@@ -12,8 +12,16 @@ jest.mock('@platform/supabase/nativeSupabaseClient', () => ({
   },
 }))
 
+import type {
+  AuthError,
+  User,
+  AuthTokenResponsePassword,
+  AuthResponse,
+} from '@supabase/supabase-js'
 import { supabase } from '@platform/supabase/nativeSupabaseClient'
 import { signInWithEmail, signUpWithEmail, sendPasswordReset, signOut } from '../authService'
+
+const mockedAuth = supabase.auth as jest.Mocked<typeof supabase.auth>
 
 describe('authService', () => {
   afterEach(() => {
@@ -34,19 +42,20 @@ describe('authService', () => {
     })
 
     it('retorna erro traduzido para credenciais inválidas', async () => {
-      supabase.auth.signInWithPassword.mockResolvedValue({
-        error: { message: 'Invalid login credentials' },
-      })
+      mockedAuth.signInWithPassword.mockResolvedValue({
+        data: { user: null, session: null },
+        error: { message: 'Invalid login credentials' } as AuthError,
+      } as AuthTokenResponsePassword)
       const result = await signInWithEmail('test@example.com', 'senhaerrada')
       expect(result.success).toBe(false)
       expect(result.error).toBe('Email ou senha inválidos')
     })
 
     it('retorna success em login bem-sucedido', async () => {
-      supabase.auth.signInWithPassword.mockResolvedValue({
-        data: { user: { id: 'user-123' } },
+      mockedAuth.signInWithPassword.mockResolvedValue({
+        data: { user: { id: 'user-123' } as User, session: {} },
         error: null,
-      })
+      } as AuthTokenResponsePassword)
       const result = await signInWithEmail('test@example.com', 'Senha123!')
       expect(result.success).toBe(true)
       expect(supabase.auth.signInWithPassword).toHaveBeenCalledWith({
@@ -56,7 +65,7 @@ describe('authService', () => {
     })
 
     it('trata erro de rede inesperado com fallback', async () => {
-      supabase.auth.signInWithPassword.mockRejectedValue(new Error('Network error'))
+      mockedAuth.signInWithPassword.mockRejectedValue(new Error('Network error'))
       const result = await signInWithEmail('test@example.com', 'Senha123!')
       expect(result.success).toBe(false)
       expect(result.error).toBe('Erro inesperado ao fazer login')
@@ -89,22 +98,23 @@ describe('authService', () => {
     })
 
     it('retorna erro PT-BR quando email já está cadastrado', async () => {
-      supabase.auth.signUp.mockResolvedValue({
-        error: { message: 'User already registered' },
-      })
+      mockedAuth.signUp.mockResolvedValue({
+        data: { user: null, session: null },
+        error: { message: 'User already registered' } as AuthError,
+      } as AuthResponse)
       const result = await signUpWithEmail('test@example.com', 'Senha123!', 'Senha123!')
       expect(result.success).toBe(false)
       expect(result.error).toBe('Email já cadastrado. Faça login.')
     })
 
     it('em produção usa emailRedirectTo https (Universal Link)', async () => {
-      const prevDev = global.__DEV__
-      global.__DEV__ = false
+      const prevDev = (global as unknown as { __DEV__: boolean }).__DEV__;
+      (global as unknown as { __DEV__: boolean }).__DEV__ = false
       try {
-        supabase.auth.signUp.mockResolvedValue({
-          data: { user: { id: 'user-456', email: 'novo@example.com' } },
+        mockedAuth.signUp.mockResolvedValue({
+          data: { user: { id: 'user-456', email: 'novo@example.com' } as User, session: {} },
           error: null,
-        })
+        } as AuthResponse)
         const result = await signUpWithEmail('novo@example.com', 'Senha123!', 'Senha123!')
         expect(result.success).toBe(true)
         expect(supabase.auth.signUp).toHaveBeenCalledWith({
@@ -113,18 +123,18 @@ describe('authService', () => {
           options: { emailRedirectTo: 'https://dosiq.app/auth/callback' },
         })
       } finally {
-        global.__DEV__ = prevDev
+        (global as unknown as { __DEV__: boolean }).__DEV__ = prevDev
       }
     })
 
     it('em dev usa o scheme dosiq:// (abre build de dev direto)', async () => {
-      const prevDev = global.__DEV__
-      global.__DEV__ = true
+      const prevDev = (global as unknown as { __DEV__: boolean }).__DEV__;
+      (global as unknown as { __DEV__: boolean }).__DEV__ = true
       try {
-        supabase.auth.signUp.mockResolvedValue({
-          data: { user: { id: 'user-789', email: 'dev@example.com' } },
+        mockedAuth.signUp.mockResolvedValue({
+          data: { user: { id: 'user-789', email: 'dev@example.com' } as User, session: {} },
           error: null,
-        })
+        } as AuthResponse)
         await signUpWithEmail('dev@example.com', 'Senha123!', 'Senha123!')
         expect(supabase.auth.signUp).toHaveBeenCalledWith({
           email: 'dev@example.com',
@@ -132,12 +142,12 @@ describe('authService', () => {
           options: { emailRedirectTo: 'dosiq://auth/callback' },
         })
       } finally {
-        global.__DEV__ = prevDev
+        (global as unknown as { __DEV__: boolean }).__DEV__ = prevDev
       }
     })
 
     it('trata erro de rede inesperado com fallback', async () => {
-      supabase.auth.signUp.mockRejectedValue(new Error('Network error'))
+      mockedAuth.signUp.mockRejectedValue(new Error('Network error'))
       const result = await signUpWithEmail('test@example.com', 'Senha123!', 'Senha123!')
       expect(result.success).toBe(false)
       expect(result.error).toBe('Erro inesperado ao criar conta')
@@ -152,7 +162,7 @@ describe('authService', () => {
     })
 
     it('retorna success após envio de reset (Supabase não revela se email existe)', async () => {
-      supabase.auth.resetPasswordForEmail.mockResolvedValue({
+      mockedAuth.resetPasswordForEmail.mockResolvedValue({
         data: {},
         error: null,
       })
@@ -165,8 +175,9 @@ describe('authService', () => {
     })
 
     it('retorna erro traduzido para rate limit', async () => {
-      supabase.auth.resetPasswordForEmail.mockResolvedValue({
-        error: { message: 'rate limit exceeded' },
+      mockedAuth.resetPasswordForEmail.mockResolvedValue({
+        data: null,
+        error: { message: 'rate limit exceeded' } as AuthError,
       })
       const result = await sendPasswordReset('test@example.com')
       expect(result.success).toBe(false)
@@ -174,7 +185,7 @@ describe('authService', () => {
     })
 
     it('trata erro de rede inesperado com fallback', async () => {
-      supabase.auth.resetPasswordForEmail.mockRejectedValue(new Error('Network error'))
+      mockedAuth.resetPasswordForEmail.mockRejectedValue(new Error('Network error'))
       const result = await sendPasswordReset('test@example.com')
       expect(result.success).toBe(false)
       expect(result.error).toBe('Erro inesperado ao enviar email de recuperação')
@@ -183,21 +194,21 @@ describe('authService', () => {
 
   describe('signOut', () => {
     it('retorna success em logout bem-sucedido', async () => {
-      supabase.auth.signOut.mockResolvedValue({ error: null })
+      mockedAuth.signOut.mockResolvedValue({ error: null })
       const result = await signOut()
       expect(result.success).toBe(true)
     })
 
     it('retorna failure quando Supabase retorna erro', async () => {
-      supabase.auth.signOut.mockResolvedValue({
-        error: { message: 'Logout failed' },
+      mockedAuth.signOut.mockResolvedValue({
+        error: { message: 'Logout failed' } as AuthError,
       })
       const result = await signOut()
       expect(result.success).toBe(false)
     })
 
     it('trata exceção inesperada', async () => {
-      supabase.auth.signOut.mockRejectedValue(new Error('Network error'))
+      mockedAuth.signOut.mockRejectedValue(new Error('Network error'))
       const result = await signOut()
       expect(result.success).toBe(false)
     })

--- a/apps/mobile/src/platform/auth/secureStoreAuthStorage.ts
+++ b/apps/mobile/src/platform/auth/secureStoreAuthStorage.ts
@@ -18,7 +18,7 @@ const CHUNK_SIZE = 1800 // margem segura abaixo dos 2048 bytes
 // migram no próximo refresh/login. No-op no Android (usa Keystore). Spec 001 A2.
 const KEYCHAIN_OPTS = { keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK }
 
-async function getChunked(key) {
+async function getChunked(key: string) {
   const countStr = await SecureStore.getItemAsync(`${key}_chunks`)
   if (countStr === null) {
     // fallback: valor armazenado directamente (sessões antigas ou valores pequenos)
@@ -32,7 +32,7 @@ async function getChunked(key) {
   return parts.join('')
 }
 
-async function setChunked(key, value) {
+async function setChunked(key: string, value: string) {
   if (value.length <= CHUNK_SIZE) {
     // valor pequeno — armazenar directamente, limpar chunks antigos se existirem
     await SecureStore.setItemAsync(key, value, KEYCHAIN_OPTS)
@@ -50,12 +50,12 @@ async function setChunked(key, value) {
   await SecureStore.deleteItemAsync(key).catch(() => {})
 }
 
-async function removeChunked(key) {
+async function removeChunked(key: string) {
   await cleanChunks(key)
   await SecureStore.deleteItemAsync(key).catch(() => {})
 }
 
-async function cleanChunks(key) {
+async function cleanChunks(key: string) {
   const countStr = await SecureStore.getItemAsync(`${key}_chunks`)
   if (countStr === null) return
   const count = parseInt(countStr, 10)
@@ -68,13 +68,13 @@ async function cleanChunks(key) {
 }
 
 export const secureStoreAuthStorage = {
-  async getItem(key) {
+  async getItem(key: string) {
     return getChunked(key)
   },
-  async setItem(key, value) {
+  async setItem(key: string, value: string) {
     return setChunked(key, value)
   },
-  async removeItem(key) {
+  async removeItem(key: string) {
     return removeChunked(key)
   },
 }

--- a/apps/mobile/src/platform/doseActivity/__tests__/doseActivityScheduler.test.ts
+++ b/apps/mobile/src/platform/doseActivity/__tests__/doseActivityScheduler.test.ts
@@ -27,8 +27,10 @@ const doseItem = (over = {}) => ({
   ...over,
 })
 
+const mockedCreateTriggerNotification = notifee.createTriggerNotification as jest.Mock
+
 function lastTrigger() {
-  return notifee.createTriggerNotification.mock.calls.at(-1)
+  return mockedCreateTriggerNotification.mock.calls.at(-1)
 }
 
 describe('armDoseActivity — exibe atual + agenda próximo boundary', () => {

--- a/apps/mobile/src/platform/doseActivity/__tests__/doseActivitySurfaceService.test.ts
+++ b/apps/mobile/src/platform/doseActivity/__tests__/doseActivitySurfaceService.test.ts
@@ -46,8 +46,11 @@ const doseItem = {
   scheduledTime: '17:00',
 }
 
+const mockedDisplayNotification = notifee.displayNotification as jest.Mock
+const mockedGetDisplayedNotifications = notifee.getDisplayedNotifications as jest.Mock
+
 function lastDisplay() {
-  return notifee.displayNotification.mock.calls.at(-1)[0]
+  return mockedDisplayNotification.mock.calls.at(-1)[0]
 }
 
 describe('showDoseActivity — canal + estados', () => {
@@ -200,19 +203,19 @@ describe('showDoseActivity — modo discreto (PO-SEC-1) + payload', () => {
 
 describe('readSurfaceLabel — auto-gate do card done', () => {
   it('superfície 039 ativa (__surface) → retorna medicineName', async () => {
-    notifee.getDisplayedNotifications.mockResolvedValueOnce([
+    mockedGetDisplayedNotifications.mockResolvedValueOnce([
       { id: 'inst-1:surface', notification: { id: 'inst-1:surface', data: { __surface: 'true', medicineName: 'Lantus' } } },
     ])
     expect(await readSurfaceLabel('inst-1')).toBe('Lantus')
   })
 
   it('nenhuma notif com o id → null', async () => {
-    notifee.getDisplayedNotifications.mockResolvedValueOnce([])
+    mockedGetDisplayedNotifications.mockResolvedValueOnce([])
     expect(await readSurfaceLabel('inst-1')).toBeNull()
   })
 
   it('notif do alarme (sem __surface) → null (não confunde com a superfície)', async () => {
-    notifee.getDisplayedNotifications.mockResolvedValueOnce([
+    mockedGetDisplayedNotifications.mockResolvedValueOnce([
       { id: 'inst-1:surface', notification: { id: 'inst-1:surface', data: { medicineName: 'Lantus' } } },
     ])
     expect(await readSurfaceLabel('inst-1')).toBeNull()

--- a/apps/mobile/src/platform/notifications/__tests__/usePushNotifications.test.ts
+++ b/apps/mobile/src/platform/notifications/__tests__/usePushNotifications.test.ts
@@ -64,7 +64,7 @@ const { usePushNotifications } = require('../usePushNotifications')
 
 const makeSession = () => ({ user: { id: 'user-abc' } })
 
-function makeResponse(screen, params = { at: '08:00' }) {
+function makeResponse(screen: string, params: Record<string, unknown> = { at: '08:00' }) {
   return {
     notification: {
       request: {

--- a/apps/mobile/src/shared/hooks/__tests__/useMedicineDatabase.test.ts
+++ b/apps/mobile/src/shared/hooks/__tests__/useMedicineDatabase.test.ts
@@ -45,7 +45,7 @@ const mockData = [
   { name: 'Aparat', activeIngredient: 'Aparat', therapeuticClass: 'Misc', laboratory: 'Lab F' },
 ]
 
-function mockFetchOk(body) {
+function mockFetchOk(body: unknown) {
   return Promise.resolve({ ok: true, json: () => Promise.resolve(body) })
 }
 
@@ -90,8 +90,8 @@ describe('cold start — rede OK', () => {
     expect(AsyncStorage.multiSet).toHaveBeenCalledTimes(1)
 
     // Ambas as chaves devem ter sido salvas
-    const [[pairs]] = AsyncStorage.multiSet.mock.calls
-    const keys = pairs.map(([k]) => k)
+    const [[pairs]] = (AsyncStorage.multiSet as jest.Mock).mock.calls
+    const keys = pairs.map(([k]: [string, string]) => k)
     expect(keys).toContain('@dosiq/anvisa-manifest')
     expect(keys).toContain('@dosiq/anvisa-data')
   })
@@ -142,8 +142,8 @@ describe('warm start — versão remota diferente', () => {
 
     expect(AsyncStorage.multiSet).toHaveBeenCalledTimes(1)
     // Manifest persistido deve ter versão 2.0.0
-    const [[pairs]] = AsyncStorage.multiSet.mock.calls
-    const manifestEntry = pairs.find(([k]) => k === '@dosiq/anvisa-manifest')
+    const [[pairs]] = (AsyncStorage.multiSet as jest.Mock).mock.calls
+    const manifestEntry = pairs.find(([k]: [string, string]) => k === '@dosiq/anvisa-manifest')
     expect(JSON.parse(manifestEntry[1]).version).toBe('2.0.0')
   })
 })
@@ -317,21 +317,21 @@ describe('getByName()', () => {
     const result = await getReadyHook()
     const med = result.current.getByName('paracetamol')
     expect(med).not.toBeNull()
-    expect(med.name).toBe('Paracetamol')
+    expect(med?.name).toBe('Paracetamol')
   })
 
   it('retorna match exato com acento normalizado', async () => {
     const result = await getReadyHook()
     const med = result.current.getByName('acido acetilsalicilico')
     expect(med).not.toBeNull()
-    expect(med.name).toBe('Ácido Acetilsalicílico')
+    expect(med?.name).toBe('Ácido Acetilsalicílico')
   })
 
   it('prefere match exato sobre parcial', async () => {
     // Dipirona corresponde a exact; não deve retornar Dipirona Sódica (activeIngredient)
     const result = await getReadyHook()
     const med = result.current.getByName('Dipirona')
-    expect(med.name).toBe('Dipirona')
+    expect(med?.name).toBe('Dipirona')
   })
 
   it('retorna null quando não encontrado', async () => {

--- a/apps/mobile/src/shared/hooks/__tests__/useMutation.test.ts
+++ b/apps/mobile/src/shared/hooks/__tests__/useMutation.test.ts
@@ -62,8 +62,8 @@ test('erro: onError chamado, error state definido, retorna undefined', async () 
 test('double-submit: segunda chamada retorna undefined, fn executada uma vez', async () => {
   const { result } = renderHook(() => useMutation())
 
-  let resolveFn
-  const slowFn = jest.fn(() => new Promise((r) => { resolveFn = r }))
+  let resolveFn: (value: string) => void
+  const slowFn = jest.fn(() => new Promise<string>((r) => { resolveFn = r }))
 
   let firstReturn
   let secondReturn

--- a/apps/mobile/src/shared/hooks/useMedicineDatabase.ts
+++ b/apps/mobile/src/shared/hooks/useMedicineDatabase.ts
@@ -170,7 +170,7 @@ export function useMedicineDatabase({
   // Ranking: matches no name vêm antes dos só-em-activeIngredient.
   // Early break: para de iterar assim que atinge o limite total.
   const search = useCallback(
-    (query: string, limit = 10): Medicine[] => {
+    (query: string | null | undefined, limit = 10): Medicine[] => {
       if (!normalizedDatabase || !query || query.trim().length < 3) return []
       const q = normalizeText(query)
       const nameMatches: Medicine[] = []
@@ -192,7 +192,7 @@ export function useMedicineDatabase({
   )
 
   const getByName = useCallback(
-    (name: string): Medicine | null => {
+    (name: string | null | undefined): Medicine | null => {
       if (!normalizedDatabase || !name) return null
       const n = normalizeText(name)
       const exact = normalizedDatabase.find((entry) => entry.nName === n)

--- a/apps/mobile/src/shared/services/_asyncStorageAdapter.ts
+++ b/apps/mobile/src/shared/services/_asyncStorageAdapter.ts
@@ -33,7 +33,7 @@ export function createAsyncStorageAdapter() {
     },
 
     // write(fileKey, { manifest, data }) → void. Persiste ambas as chaves.
-    async write(_fileKey, { manifest, data }) {
+    async write(_fileKey: string, { manifest, data }: { manifest: unknown; data: unknown }) {
       await AsyncStorage.multiSet([
         [STORAGE_KEYS.manifest, JSON.stringify(manifest)],
         [STORAGE_KEYS.data, JSON.stringify(data)],

--- a/apps/mobile/src/shared/utils/debugLog.ts
+++ b/apps/mobile/src/shared/utils/debugLog.ts
@@ -3,7 +3,7 @@
  * 
  * Evita violações de no-console e garante que logs não vazem em produção.
  */
-export const debugLog = (message, ...args) => {
+export const debugLog = (message: unknown, ...args: unknown[]) => {
   if (__DEV__) {
     // Usamos um objeto para evitar que o linter detecte o console.log diretamente
     // se a regra for muito estrita, mas geralmente console.log dentro de um 
@@ -13,7 +13,7 @@ export const debugLog = (message, ...args) => {
   }
 }
 
-export const errorLog = (message, ...args) => {
+export const errorLog = (message: unknown, ...args: unknown[]) => {
   if (__DEV__) {
     console.error(message, ...args)
   }

--- a/apps/mobile/src/shared/utils/haptics.ts
+++ b/apps/mobile/src/shared/utils/haptics.ts
@@ -4,8 +4,8 @@ import * as Haptics from 'expo-haptics'
 // e evita boilerplate de catch em cada call site. Erros silenciados (haptic
 // é UX-only — falha não deve quebrar fluxo do usuário).
 
-function safe(fn) {
-  return (...args) => {
+function safe(fn: (...args: unknown[]) => Promise<unknown>) {
+  return (...args: unknown[]) => {
     try {
       fn(...args).catch(() => {})
     } catch {

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -35,3 +35,4 @@ export {
 
 // Serviço de auditoria de dose crítica (spec 042 — CON-031, fail-open)
 export { createCriticalAuditService } from './criticalAuditService'
+export type { CriticalAuditEvent } from './criticalAuditService'

--- a/scripts/strict-island.sh
+++ b/scripts/strict-island.sh
@@ -20,15 +20,15 @@ cd "$(dirname "$0")/.."
 # ── Tetos por bucket (baseline 2026-07-06, F6 Bloco 0; lotes 6.x abaixam) ──
 MAX_B_PACKAGES=444        # packages/* nível-B transitivo (core 381 + shared-data 44 + storage 15 + config 4)
 MAX_B_WEB=37              # apps/web nível-B transitivo
-MAX_B_MOBILE=18           # apps/mobile nível-B transitivo
+MAX_B_MOBILE=0            # apps/mobile nível-B transitivo (zerado no lote 6.4 — secureStore/asyncStorageAdapter/debugLog/haptics tipados)
 MAX_B_SERVER=36           # server/* nível-B transitivo (utils 25 + bot 10 + services 1)
 MAX_A_TESTS_CORE=85       # testes dos domínios A do core (lote 6.3: 350→85, repos tipados; alvo ≤120 batido)
 MAX_A_TESTS_SERVER=0      # testes de server/notifications (zerado no lote 6.2)
 MAX_A_TESTS_WEB=0         # testes hooks web (já zerado — trava)
-MAX_A_TESTS_MOBILE=11     # testes hooks mobile (lote 6.4 → 0)
+MAX_A_TESTS_MOBILE=0      # testes hooks mobile (zerado no lote 6.4 — useMedicineDatabase/useMutation tipados)
 MAX_TESTS_PROG_API=0      # programa api/ (testes)
 MAX_TESTS_PROG_SERVER=0   # programa server/ (testes; zerado no lote 6.2)
-MAX_TESTS_PROG_MOBILE=86  # programa mobile (testes; lote 6.4 → ≤30)
+MAX_TESTS_PROG_MOBILE=0   # programa mobile (testes; zerado no lote 6.4 — criticalAuditQueue tipado + 8 mocks/globals corrigidos)
 
 A_SRC='^(packages/core/src/(types|repositories|services|schemas)|server/notifications|apps/web/src/shared/hooks|apps/mobile/src/shared/hooks)/'
 TESTS='__tests__|\.test\.'


### PR DESCRIPTION
## Escopo (lote 6.4)

Classe de erro alvo: mobile (implicit-any B, hooks A, testes de programa) — sem lucide/onboarding
(nenhum erro tipagem residual encontrado nesses subdomínios; ver Triagem pendente).

## Contadores (catraca strict-island.sh)

| Bucket | Antes | Alvo | Depois |
|---|---|---|---|
| MAX_TESTS_PROG_MOBILE | 86 | ≤30 | **0** |
| MAX_A_TESTS_MOBILE | 11 | 0 | **0** |
| MAX_B_MOBILE | 18 | ≤10 | **0** |

Todos os 3 buckets fecharam melhor que o alvo da tabela §F6 (zerados, não só reduzidos).

## Triagem de testes (rubrica MATA/TIPA)

Nenhum teste MATA neste lote — os 27 erros residuais (9 arquivos) eram TODOS
sintoma de tipagem faltando em módulo fonte ou mock stale sem contrato, não
lógica frágil/mock-contra-mock. Classificados TIPA DE VERDADE e corrigidos:

- criticalAuditQueue.test.ts (29 erros, maior bucket): raiz era o módulo fonte
  criticalAuditQueue.ts sem nenhum tipo (params storage/payload/insertOne/state
  implicit-any) — isso cascateava em inferência errada no teste (peek() inferido
  como void). Tipado o módulo inteiro; export CriticalAuditEvent adicionado ao
  barrel do core (faltava, usado no cast de AlarmSchedulerBridge.tsx).
- authService.test.ts (19): supabase mockado via jest.mock perdia o tipo de
  Mock no client tipado — jest.Mocked<typeof supabase.auth> resolve. Fixtures
  de erro/user tipadas como AuthError/User/AuthResponse (mocks parciais reais).
  __DEV__ via global.X precisou de cast (ambient const __DEV__ do RN não
  aparece em globalThis — só bare identifier).
- quickDoseRegistration.test.ts (11): jest.fn sem params tipados quebra spread
  (TS2556) e o destructure de .mock.calls[0]; retorno de handleAlarmAction
  é union discriminada ({handled,action}|{handled}) — cast pontual as {action}
  nos branches onde o teste já sabe que action existe.
- alarmService.test.ts (7) + alarmEnabledStore.test.ts (5) +
  useAlarmScheduler.snooze.test.ts (5) + doseActivity*.test.ts (5) +
  usePushNotifications.test.ts (5): mesmo padrão — notifee/AsyncStorage
  mockados perdem .mock/mockResolvedValueOnce porque o auto-mock preserva a
  assinatura real (não jest.Mock); cast local as jest.Mock no ponto de uso.
  alarmService.ts ganhou interfaces ScheduleAlarmParams/ScheduleNagParams
  (medicineName/scheduledFor já eram opcionais no JSDoc, só faltava o tipo).
- useMedicineDatabase.test.ts (11, bucket A) + useMutation.test.ts: mocks/binding
  elements tipados; search/getByName no hook alargados pra aceitar
  string | null | undefined (já tratavam isso no corpo — teste exercita esse
  caminho defensivo real).

## Dívida B mobile (implicit-any) zerada

secureStoreAuthStorage.ts, _asyncStorageAdapter.ts, debugLog.ts, haptics.ts
— parâmetros implicit-any tipados (string/unknown), sem mudança de comportamento.

## Triagem pendente

Nenhuma. Não encontrado nenhum resíduo de tipagem nos subdomínios
mobile dose/stock/treatments/onboarding nem aliases lucide deprecated
(import * as LucideIcons / as any) citados na linha 6.4 da tabela §F6 —
aparentemente já resolvidos em lotes F5 anteriores (review #725). Se o PO
quiser confirmar: `rtk grep -rn "import \* as LucideIcons\|CheckCircle2\|Edit3" apps/mobile/src`
não retornou nada no momento deste lote.

## Testes

npm test --workspace @dosiq/mobile -- --changedSince=main: 290 passed, 3 skipped,
0 failed. rtk lint: 0 erros (114 warnings pré-existentes, não tocados).

## APs/regras novas

Nenhuma nova — padrão de fix (cast jest.Mock local em vez de jest.mocked(),
tipar módulo fonte quando erro de teste é cascata de tipo ausente) segue o já
documentado no playbook §Erros comuns pós-rename.

## AI Review Response

| Suggestion | Priority | Decision | Reason |
|---|---|---|---|
| scheduledFor obrigatório + Date em ScheduleAlarmParams | Medium | Applied | commit dab4d726 — todos call sites reais sempre passam |
| Date em ScheduleNagParams.scheduledFor | Medium | Applied | commit dab4d726 — alinha com JSDoc |
| declare global var __DEV__ (authService.test.ts:24) | Medium | Declined | testado empiricamente — conflita com `const __DEV__` ambient do RN, `global.__DEV__` continua TS2339 mesmo com o d.ts extra |
| idem, ocorrência linha 112 | Medium | Declined | mesma razão (thread linkada) |
| LogData como interface explícita | Medium | Applied | commit dab4d726 — reflete payload real de registerDose |
| AuditQueueItem = CriticalAuditEvent | Medium | Declined | quebraria criticalAuditQueue.test.ts (payloads genéricos sem platform/actor, com campo dose_id fora da interface) — queue é testada desacoplada do shape de auditoria de propósito |
| remover cast em AlarmSchedulerBridge.tsx:99 | Medium | Declined | depende da sugestão anterior, declinada |
