### PR TITLE
refactor(040): F6 lote 6.5 — residual packages: B 444→0 + testes A core 85→0

### DIFF
--- a/apps/mobile/src/features/chatbot/services/chatbotService.ts
+++ b/apps/mobile/src/features/chatbot/services/chatbotService.ts
@@ -24,7 +24,12 @@ async function getUserId() {
  * @returns {Promise<string>} patientContext (string compacta p/ o LLM)
  */
 export async function buildMobilePatientContext() {
-  const data = await fetchChatbotContextData({ supabase, getUserId })
+  // TODO(040-strict): divergência nominal de generics — mobile resolve @supabase/supabase-js
+  // do node_modules próprio (Expo) e o core do root; mesmo Database, instâncias distintas.
+  const data = await fetchChatbotContextData({
+    supabase: supabase as unknown as Parameters<typeof fetchChatbotContextData>[0]['supabase'],
+    getUserId,
+  })
   return buildPatientContext(data)
 }
 

--- a/apps/mobile/src/features/profile/hooks/useNudges.ts
+++ b/apps/mobile/src/features/profile/hooks/useNudges.ts
@@ -34,11 +34,11 @@ async function saveCachedNudges(view, nudges) {
  * Carrega as chaves de dismiss salvas no AsyncStorage apenas para os nudges recebidos.
  * Evita getAllKeys() que varre todo o storage independente do tamanho.
  */
-async function loadDismissedKeys(keysToCheck) {
+async function loadDismissedKeys(keysToCheck: string[]): Promise<Set<string>> {
   if (!keysToCheck || keysToCheck.length === 0) return new Set()
   try {
     const pairs = await AsyncStorage.multiGet(keysToCheck)
-    const dismissed = new Set()
+    const dismissed = new Set<string>()
     for (const [key, value] of pairs) {
       if (value === '1') dismissed.add(key)
     }

--- a/apps/mobile/src/features/profile/screens/ProfileEditScreen.tsx
+++ b/apps/mobile/src/features/profile/screens/ProfileEditScreen.tsx
@@ -79,7 +79,7 @@ export default function ProfileEditScreen() {
 
   // birth_date é string 'YYYY-MM-DD' no form; FormDatePicker opera com Date.
   const birthDateAsDate = useMemo(
-    () => (form.values.birth_date ? parseLocalDate(form.values.birth_date) : null),
+    () => (typeof form.values.birth_date === 'string' && form.values.birth_date ? parseLocalDate(form.values.birth_date) : null),
     [form.values.birth_date],
   )
 

--- a/apps/mobile/src/features/stock/screens/PurchaseFormScreen.tsx
+++ b/apps/mobile/src/features/stock/screens/PurchaseFormScreen.tsx
@@ -254,8 +254,8 @@ function usePurchaseForm(route, navigation) {
   const { createPurchase, createLiquidPurchase, updatePurchase, isLoading } = useStockMutation()
   const { handleChange } = form
 
-  const purchaseDateObj = useMemo(() => form.values.purchase_date ? parseLocalDate(form.values.purchase_date) : null, [form.values.purchase_date])
-  const expirationDateObj = useMemo(() => form.values.expiration_date ? parseLocalDate(form.values.expiration_date) : null, [form.values.expiration_date])
+  const purchaseDateObj = useMemo(() => typeof form.values.purchase_date === 'string' && form.values.purchase_date ? parseLocalDate(form.values.purchase_date) : null, [form.values.purchase_date])
+  const expirationDateObj = useMemo(() => typeof form.values.expiration_date === 'string' && form.values.expiration_date ? parseLocalDate(form.values.expiration_date) : null, [form.values.expiration_date])
 
   const quantityHelperText = useMemo(
     () => getQuantityHelperText(isEdit, form.values.quantity, medicine),

--- a/apps/mobile/src/features/stock/services/stockService.ts
+++ b/apps/mobile/src/features/stock/services/stockService.ts
@@ -18,6 +18,7 @@ import {
   getTodayLocal,
   isProtocolActiveOnDate,
 } from '@dosiq/core'
+import type { AdherenceProtocol } from '@dosiq/core'
 import { supabase as nativeSupabaseClient } from '../../../platform/supabase/nativeSupabaseClient'
 import { debugLog, errorLog } from '@shared/utils/debugLog'
 
@@ -81,7 +82,8 @@ export async function getStockData(userId) {
 
     const today = getTodayLocal()
     const validData = (rawData || []).filter((m) =>
-      (m.protocols || []).some((p) => isProtocolActiveOnDate(p, today)),
+      // TODO(040-strict): Row Supabase traz time_schedule como Json; em runtime é string[] (CHECK no schema)
+      (m.protocols || []).some((p) => isProtocolActiveOnDate(p as AdherenceProtocol, today)),
     )
 
     return { success: true, data: validData }

--- a/apps/web/src/features/dashboard/components/__tests__/SparklineAdesao.test.tsx
+++ b/apps/web/src/features/dashboard/components/__tests__/SparklineAdesao.test.tsx
@@ -19,7 +19,8 @@ function makeData(days, adherence = 80) {
     const d = new Date(today)
     d.setDate(d.getDate() - i)
     data.push({
-      date: d.toISOString().split('T')[0],
+      // Data LOCAL (nunca toISOString): após 21h BRT o UTC vira o dia seguinte e a janela do hook não casa
+      date: `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`,
       adherence,
       taken: Math.round((adherence / 100) * 4),
       expected: 4,

--- a/apps/web/src/features/emergency/components/__tests__/EmergencyCardForm.test.tsx
+++ b/apps/web/src/features/emergency/components/__tests__/EmergencyCardForm.test.tsx
@@ -11,9 +11,9 @@ vi.mock('@features/emergency/services/emergencyCardService', () => ({
 describe('EmergencyCardForm Smoke Test', () => {
   it('renders correctly', () => {
     render(<EmergencyCardForm onSave={vi.fn()} onCancel={vi.fn()} />)
-    expect(screen.getByText('📞 Contatos de Emergência')).toBeInTheDocument()
-    expect(screen.getByText('⚠️ Alergias')).toBeInTheDocument()
-    expect(screen.getByText('🩸 Tipo Sanguíneo')).toBeInTheDocument()
-    expect(screen.getByText('📝 Observações')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Contatos de Emergência' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Alergias' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Tipo Sanguíneo' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Observações' })).toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/protocols/components/ProtocolChecklistItem.test.tsx
+++ b/apps/web/src/features/protocols/components/ProtocolChecklistItem.test.tsx
@@ -17,7 +17,7 @@ describe('ProtocolChecklistItem', () => {
     render(<ProtocolChecklistItem protocol={protocol} isSelected={false} onToggle={onToggle} />)
 
     expect(screen.getByText('💊 Manhã')).toBeInTheDocument()
-    expect(screen.getByText('1 comp.')).toBeInTheDocument()
+    expect(screen.getByText('1 un.')).toBeInTheDocument()
     expect(screen.queryByText('✓')).not.toBeInTheDocument()
   })
 
@@ -145,7 +145,7 @@ describe('ProtocolChecklistItem', () => {
 
     render(<ProtocolChecklistItem protocol={protocol} isSelected={false} onToggle={onToggle} />)
 
-    expect(screen.getByText('1 comp.')).toBeInTheDocument()
+    expect(screen.getByText('1 un.')).toBeInTheDocument()
   })
 
   it('renders correct dosage text for multiple pills', () => {
@@ -161,6 +161,6 @@ describe('ProtocolChecklistItem', () => {
 
     render(<ProtocolChecklistItem protocol={protocol} isSelected={false} onToggle={onToggle} />)
 
-    expect(screen.getByText('2 comps.')).toBeInTheDocument()
+    expect(screen.getByText('2 un.')).toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/protocols/components/ProtocolForm.test.tsx
+++ b/apps/web/src/features/protocols/components/ProtocolForm.test.tsx
@@ -147,6 +147,8 @@ describe('ProtocolForm', () => {
         active: true,
         start_date: expect.any(String),
         end_date: null,
+        intake_unit: null,
+        weekdays: [],
       })
     })
   })

--- a/apps/web/src/features/protocols/components/TitrationWizard.test.tsx
+++ b/apps/web/src/features/protocols/components/TitrationWizard.test.tsx
@@ -53,7 +53,9 @@ describe('TitrationWizard', () => {
 
     fireEvent.click(screen.getByText('✓ Gravar Etapa'))
 
-    expect(onChange).toHaveBeenCalledWith([{ duration_days: 7, dosage: 1, description: 'Introdução' }])
+    expect(onChange).toHaveBeenCalledWith([
+      { duration_days: 7, dosage: 1, description: 'Introdução', requires_new_medicine: false },
+    ])
   })
 
   it('aceita vírgula PT-BR na dose da nova etapa (R-270): "0,25" → 0.25', () => {

--- a/apps/web/src/features/protocols/hooks/protocolFormUtils.ts
+++ b/apps/web/src/features/protocols/hooks/protocolFormUtils.ts
@@ -113,8 +113,8 @@ function _validateDosagePerIntake(dosage, errors) {
   // Cap 1000 (Fase B): líquidos podem ter doses maiores em gotas/ml/UI.
   // Normaliza vírgula→ponto antes de comparar (R-270): "2,5" não pode falhar.
   const n = coerceDecimal(dosage)
-  if (dosage === '' || dosage === null || Number.isNaN(n) || n < 0 || n > 1000) {
-    errors.dosage_per_intake = 'Dosagem deve estar entre 0 e 1000'
+  if (dosage === '' || dosage === null || Number.isNaN(n) || n <= 0 || n > 1000) {
+    errors.dosage_per_intake = 'Dosagem deve ser maior que 0 e até 1000'
   }
 }
 

--- a/apps/web/src/features/stock/components/__tests__/StockForm.test.tsx
+++ b/apps/web/src/features/stock/components/__tests__/StockForm.test.tsx
@@ -66,8 +66,8 @@ describe('StockForm', () => {
       expect(screen.getByLabelText(/Medicamento/i)).toBeInTheDocument()
 
       // Check that medicines are listed with dosage info
-      expect(screen.getByText('Dipirona (500mg)')).toBeInTheDocument()
-      expect(screen.getByText('Paracetamol (750mg)')).toBeInTheDocument()
+      expect(screen.getByText('Dipirona (500 mg)')).toBeInTheDocument()
+      expect(screen.getByText('Paracetamol (750 mg)')).toBeInTheDocument()
     })
 
     it('should render quantity input', () => {
@@ -75,9 +75,8 @@ describe('StockForm', () => {
 
       const quantityInput = screen.getByLabelText(/Quantidade/i)
       expect(quantityInput).toBeInTheDocument()
-      expect(quantityInput).toHaveAttribute('type', 'number')
-      expect(quantityInput).toHaveAttribute('min', '0.1')
-      expect(quantityInput).toHaveAttribute('step', '0.1')
+      expect(quantityInput).toHaveAttribute('type', 'text')
+      expect(quantityInput).toHaveAttribute('inputMode', 'decimal')
     })
 
     it('should render unit price input', () => {
@@ -85,9 +84,8 @@ describe('StockForm', () => {
 
       const priceInput = screen.getByLabelText(/Preço Unitário/i)
       expect(priceInput).toBeInTheDocument()
-      expect(priceInput).toHaveAttribute('type', 'number')
-      expect(priceInput).toHaveAttribute('step', '0.001')
-      expect(priceInput).toHaveAttribute('min', '0')
+      expect(priceInput).toHaveAttribute('type', 'text')
+      expect(priceInput).toHaveAttribute('inputMode', 'decimal')
     })
 
     it('should render purchase date input with default to today', () => {
@@ -138,8 +136,8 @@ describe('StockForm', () => {
       )
 
       expect(screen.getByLabelText(/Medicamento/i)).toHaveValue('med-2')
-      expect(screen.getByLabelText(/Quantidade/i)).toHaveValue(30)
-      expect(screen.getByLabelText(/Preço Unitário/i)).toHaveValue(0.5)
+      expect(screen.getByLabelText(/Quantidade/i)).toHaveValue('30')
+      expect(screen.getByLabelText(/Preço Unitário/i)).toHaveValue('0.5')
       expect(screen.getByLabelText(/Data da Compra/i)).toHaveValue('2024-01-15')
       expect(screen.getByLabelText(/Data de Validade/i)).toHaveValue('2025-01-15')
     })
@@ -159,7 +157,7 @@ describe('StockForm', () => {
       )
 
       expect(screen.getByLabelText(/Medicamento/i)).toHaveValue('med-1')
-      expect(screen.getByLabelText(/Quantidade/i)).toHaveValue(null)
+      expect(screen.getByLabelText(/Quantidade/i)).toHaveValue('')
     })
   })
 
@@ -312,6 +310,7 @@ describe('StockForm', () => {
           unit_price: 0.5,
           purchase_date: '2024-01-15',
           expiration_date: '2025-01-15',
+          injection_container: null,
           pharmacy: null,
           laboratory: null,
           notes: null,
@@ -467,7 +466,7 @@ describe('StockForm', () => {
 
       const quantityInput = screen.getByLabelText(/Quantidade/i)
       fireEvent.change(quantityInput, { target: { value: '50' } })
-      expect(quantityInput).toHaveValue(50)
+      expect(quantityInput).toHaveValue('50')
     })
 
     it('should handle decimal values correctly', () => {
@@ -475,11 +474,11 @@ describe('StockForm', () => {
 
       const quantityInput = screen.getByLabelText(/Quantidade/i)
       fireEvent.change(quantityInput, { target: { value: '10.5' } })
-      expect(quantityInput).toHaveValue(10.5)
+      expect(quantityInput).toHaveValue('10.5')
 
       const priceInput = screen.getByLabelText(/Preço Unitário/i)
       fireEvent.change(priceInput, { target: { value: '0.123' } })
-      expect(priceInput).toHaveValue(0.123)
+      expect(priceInput).toHaveValue('0.123')
     })
   })
 })

--- a/apps/web/src/views/__tests__/Profile.test.tsx
+++ b/apps/web/src/views/__tests__/Profile.test.tsx
@@ -20,6 +20,19 @@ vi.mock('@shared/utils/supabase', () => ({
     from: vi.fn(() => ({
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockImplementation(() =>
+        Promise.resolve({
+          data: {
+            display_name: 'Joao Silva',
+            birth_date: '1990-01-01',
+            city: 'São Paulo',
+            state: 'SP',
+            phone: null,
+            complexity_override: null,
+          },
+          error: null,
+        })
+      ),
       single: vi.fn().mockImplementation(() =>
         Promise.resolve({
           data: {
@@ -27,13 +40,16 @@ vi.mock('@shared/utils/supabase', () => ({
             birth_date: '1990-01-01',
             city: 'São Paulo',
             state: 'SP',
+            phone: null,
+            complexity_override: null,
           },
           error: null,
         })
       ),
-      upsert: vi.fn().mockResolvedValue({ error: null }),
+      upsert: vi.fn().mockReturnThis(),
     })),
   },
+  getUserId: vi.fn(() => Promise.resolve('user-1')),
 }))
 
 vi.mock('@shared/components/ui/Loading', () => ({

--- a/apps/web/src/views/__tests__/Treatment.test.tsx
+++ b/apps/web/src/views/__tests__/Treatment.test.tsx
@@ -47,10 +47,27 @@ vi.mock('@protocols/hooks/useTreatmentList', () => ({
 vi.mock('@shared/services', () => ({
   protocolService: { update: vi.fn(), delete: vi.fn() },
   medicineService: { getAll: vi.fn(() => Promise.resolve([])) },
-  treatmentPlanService: { 
+  treatmentPlanService: {
     getAll: vi.fn(() => Promise.resolve([])),
     delete: vi.fn(() => Promise.resolve()),
     getById: vi.fn(() => Promise.resolve({}))
+  },
+  cachedMedicineService: {
+    getAll: vi.fn(() => Promise.resolve([])),
+    getById: vi.fn(() => Promise.resolve(null)),
+    create: vi.fn(() => Promise.resolve({})),
+  },
+  cachedProtocolService: {
+    getById: vi.fn(() => Promise.resolve({})),
+    update: vi.fn(() => Promise.resolve()),
+    delete: vi.fn(() => Promise.resolve()),
+  },
+  cachedTreatmentPlanService: {
+    getAll: vi.fn(() => Promise.resolve([])),
+    getById: vi.fn(() => Promise.resolve({})),
+    create: vi.fn(() => Promise.resolve()),
+    update: vi.fn(() => Promise.resolve()),
+    delete: vi.fn(() => Promise.resolve()),
   },
 }))
 

--- a/packages/config/src/contracts.ts
+++ b/packages/config/src/contracts.ts
@@ -6,11 +6,21 @@
  */
 
 /**
+ * Candidato de config pública (shape parcial, ainda não validado).
+ */
+export interface PublicAppConfigCandidate {
+  supabaseUrl?: string
+  supabaseAnonKey?: string
+  detectSessionInUrl?: boolean
+  appEnv?: string
+}
+
+/**
  * Valida que um objeto contém todos os valores obrigatórios de config pública.
- * @param {Object} config - Candidato para config pública
+ * @param config - Candidato para config pública
  * @throws {Error} Se algum campo obrigatório estiver faltando ou invalido
  */
-export function assertPublicAppConfig(config) {
+export function assertPublicAppConfig(config: PublicAppConfigCandidate | null | undefined) {
   if (!config) throw new Error('Config object is required')
 
   if (!config.supabaseUrl) {

--- a/packages/config/src/createPublicAppConfig.ts
+++ b/packages/config/src/createPublicAppConfig.ts
@@ -8,18 +8,40 @@
 import { assertPublicAppConfig } from './contracts'
 
 /**
+ * Valores de entrada aceitos pela factory (injetados por quem chama).
+ * Campos opcionais na entrada porque vêm de env vars (`process.env.X` é
+ * `string|undefined`) — `assertPublicAppConfig` abaixo falha alto se faltarem.
+ */
+export interface PublicAppConfigInput {
+  supabaseUrl?: string
+  supabaseAnonKey?: string
+  detectSessionInUrl?: boolean
+  appEnv?: string
+}
+
+/** Config pública já validada (pós `assertPublicAppConfig` — campos obrigatórios). */
+export interface PublicAppConfig {
+  supabaseUrl: string
+  supabaseAnonKey: string
+  detectSessionInUrl: boolean
+  appEnv: string
+}
+
+/**
  * Cria um objeto de config pública validado.
  * Nao lê import.meta.env, process.env, ou qualquer env var directamente.
  * Valores devem ser injetados pelo app-specific bootstrap.
  *
- * @param {Object} input - Valores de entrada (injetados por quem chama)
- * @returns {Object} Config pública validada
+ * @param input - Valores de entrada (injetados por quem chama)
+ * @returns Config pública validada
  * @throws {Error} Se algum valor obrigatório estiver faltando ou invalido
  */
-export function createPublicAppConfig(input) {
+export function createPublicAppConfig(input: PublicAppConfigInput): PublicAppConfig {
+  // Cast seguro: assertPublicAppConfig (abaixo) falha alto se supabaseUrl/supabaseAnonKey
+  // vierem ausentes — o cast só reflete o contrato JÁ garantido em runtime pelo assert.
   const config = {
-    supabaseUrl: input.supabaseUrl,
-    supabaseAnonKey: input.supabaseAnonKey,
+    supabaseUrl: input.supabaseUrl as string,
+    supabaseAnonKey: input.supabaseAnonKey as string,
     detectSessionInUrl: Boolean(input.detectSessionInUrl ?? true),
     appEnv: input.appEnv ?? 'development',
   }

--- a/packages/config/src/validateConfig.ts
+++ b/packages/config/src/validateConfig.ts
@@ -5,31 +5,32 @@
  * Util para logging e diagnostico.
  */
 
-import { assertPublicAppConfig } from './contracts'
+import { assertPublicAppConfig, type PublicAppConfigCandidate } from './contracts'
 
 /**
  * Valida config pública sem lançar erro.
  * Retorna {valid: true} ou {valid: false, error: string}
  *
- * @param {Object} config - Config a validar
- * @returns {Object} {valid: boolean, error?: string}
+ * @param config - Config a validar
+ * @returns {valid: boolean, error?: string}
  */
-export function validatePublicAppConfig(config) {
+export function validatePublicAppConfig(config: PublicAppConfigCandidate | null | undefined) {
   try {
     assertPublicAppConfig(config)
     return { valid: true }
   } catch (error) {
-    return { valid: false, error: error.message }
+    const message = error instanceof Error ? error.message : String(error)
+    return { valid: false, error: message }
   }
 }
 
 /**
  * Valida se um objeto tem os campos minimos (sem lancar erro).
  *
- * @param {Object} input - Objeto a verificar
- * @returns {Object} {hasAll: boolean, missing: string[]}
+ * @param input - Objeto a verificar
+ * @returns {hasAll: boolean, missing: string[]}
  */
-export function checkRequiredFields(input) {
+export function checkRequiredFields(input: Record<string, unknown> | null | undefined) {
   const required = ['supabaseUrl', 'supabaseAnonKey']
   const missing = required.filter((field) => !input?.[field])
 

--- a/packages/core/src/chatbot/buildPatientContext.ts
+++ b/packages/core/src/chatbot/buildPatientContext.ts
@@ -15,7 +15,7 @@
 // - dateUtils SEMPRE do core (R-020); zero `new Date()` direto.
 
 import { getTodayLocal, getSaoPauloTime, parseISO, getNow, parseLocalDate, isProtocolActiveOnDate as isProtocolInPeriod } from '../utils/dateUtils'
-import { splitDayTimeline } from '../utils/doseZones'
+import { splitDayTimeline, type DoseZoneInstance, type DoseZoneProtocol } from '../utils/doseZones'
 import { formatDoseItem, formatStockCount, formatIntakeDose, stockUnitLabel, formatNumberPtBR } from '../utils/doseUnit'
 import { getProtocolDays } from '../utils/adherenceLogic'
 import { calculateAge } from '../utils/profile'
@@ -23,14 +23,79 @@ import { calculateAge } from '../utils/profile'
 /** Nomes dos dias da semana em PT (índice = Date.getDay(): 0=domingo). */
 const WEEKDAYS_PT = ['domingo', 'segunda-feira', 'terça-feira', 'quarta-feira', 'quinta-feira', 'sexta-feira', 'sábado']
 
+/** Medicamento (shape mínimo consumido por este builder). */
+interface MedicineLike {
+  id: string
+  name: string
+  active_ingredient?: string | null
+  therapeutic_class?: string | null
+  dosage_per_pill?: number | null
+  dosage_unit?: string | null
+  units_per_ml?: number | null
+  stock?: Array<{ quantity: number }>
+}
+
+/** Protocolo (shape mínimo consumido por este builder). */
+interface ProtocolLike {
+  medicine_id: string
+  medicine?: MedicineLike | null
+  active?: boolean
+  start_date?: string | null
+  end_date?: string | null
+  frequency?: string
+  time_schedule?: string[]
+  dosage_per_intake?: number | null
+  intake_unit?: string | null
+  treatment_plan?: { name?: string | null } | null
+}
+
+/** Entrada de resumo de estoque (rich, já calculada pelo fetcher). */
+interface StockSummaryEntry {
+  medicine?: { id: string } | null
+  total?: number
+  dailyIntake?: number | null
+  daysRemaining?: number | null
+  isZero?: boolean
+}
+
+/** Perfil leve do paciente (sem PII sensível). */
+interface ProfileLike {
+  display_name?: string | null
+  birth_date?: string | null
+}
+
+/** Log de dose registrada. */
+interface LogLike {
+  taken_at: string
+}
+
+/** Contexto derivado de UM medicamento (saída de _toMedContext). */
+interface MedContext {
+  nome: string
+  principioAtivo?: string | null
+  classeTerapeutica?: string | null
+  dosagem: string
+  estoque: number
+  consumoDiario: number | null
+  diasRestantes: string | null
+  semEstoque: boolean
+  medLike: { dosage_unit: string | null; dosage_per_pill: number | null; units_per_ml: number | null }
+  frequencia: string
+  horarios: string[]
+  weekdays?: string[]
+  dosePerIntake: number | null
+  intakeUnit: string | null
+  planName: string | null
+}
+
 /** Formata dias restantes (relativo) — Infinity/sem consumo → null (omitido). */
-function _formatDaysRemaining(daysRemaining) {
+function _formatDaysRemaining(daysRemaining: number | null | undefined) {
   if (daysRemaining == null || !Number.isFinite(daysRemaining)) return null
   return `${Math.floor(daysRemaining)} dia${Math.floor(daysRemaining) === 1 ? '' : 's'}`
 }
 
 /** Campos derivados do PROTOCOLO (extraído p/ baixar complexidade de _toMedContext). */
-function _protocolFields(protocol) {
+function _protocolFields(protocol: ProtocolLike | null | undefined) {
   return {
     frequencia: protocol?.frequency ?? 'sem protocolo',
     horarios: protocol?.time_schedule ?? [],
@@ -50,7 +115,7 @@ function _protocolFields(protocol) {
  * contexto etário (idoso → linguagem mais simples). Nome/idade não são PII sensível
  * (nada de IDs, CPF, contato). Retorna '' (omitido) quando vazio.
  */
-function _formatPatientLine(profile) {
+function _formatPatientLine(profile: ProfileLike | null | undefined) {
   const name = profile?.display_name?.trim() || null
   const age = calculateAge(profile?.birth_date)
   if (!name && age == null) return ''
@@ -58,7 +123,7 @@ function _formatPatientLine(profile) {
 }
 
 /** Saldo de estoque: stockSummary.total, ou soma dos lotes embedded (fallback). */
-function _resolveStock(med, stockEntry) {
+function _resolveStock(med: MedicineLike, stockEntry: StockSummaryEntry | undefined) {
   return (
     stockEntry?.total ??
     (med.stock || []).filter((s) => s.quantity > 0).reduce((sum, s) => sum + s.quantity, 0)
@@ -67,11 +132,15 @@ function _resolveStock(med, stockEntry) {
 
 /**
  * Deriva a entrada de contexto de UM medicamento (extraído p/ baixar complexidade do map).
- * @param {Object} med
- * @param {Array} validProtocols
- * @param {Map} stockByMedId
+ * @param med
+ * @param validProtocols
+ * @param stockByMedId
  */
-function _toMedContext(med, validProtocols, stockByMedId) {
+function _toMedContext(
+  med: MedicineLike,
+  validProtocols: ProtocolLike[],
+  stockByMedId: Map<string | undefined, StockSummaryEntry>
+): MedContext {
   const protocol = validProtocols.find((p) => p.medicine_id === med.id)
   const stockEntry = stockByMedId.get(med.id)
   const totalStock = _resolveStock(med, stockEntry)
@@ -96,7 +165,7 @@ function _toMedContext(med, validProtocols, stockByMedId) {
 }
 
 /** Cronograma: frequência + (dias da semana p/ semanal) + horários. */
-function _formatSchedule(mc) {
+function _formatSchedule(mc: MedContext) {
   const horarios = mc.horarios.join(', ') || 'nao definidos'
   const freq = (mc.frequencia || '').toLowerCase()
   if ((freq === 'semanal' || freq === 'weekly') && mc.weekdays?.length) {
@@ -110,7 +179,7 @@ function _formatSchedule(mc) {
  * dose por tomada usam a unidade real do medicamento (ml/UI/gotas p/ líquidos; un./mg p/
  * sólidos) — NUNCA "un." cego (ex.: "5,2 ml" de Lantus, não "5,2 un.").
  */
-function _formatMedLine(mc) {
+function _formatMedLine(mc: MedContext) {
   const infos = [mc.principioAtivo, mc.classeTerapeutica].filter(Boolean).join(', ')
   const detalhe = infos ? ` [${infos}]` : ''
   const dose = mc.dosePerIntake ? `, dose ${formatIntakeDose(mc.dosePerIntake, mc.intakeUnit, mc.medLike)}` : ''
@@ -127,16 +196,16 @@ function _formatMedLine(mc) {
  * sem rótulo "Sem plano", evita ruído/associação falsa no LLM), DEPOIS os grupos nomeados
  * (header `Plano "<nome>":` + itens). Quando nenhum med tem plano nomeado, a saída é o
  * formato legado flat idêntico (compat PO-1).
- * @param {Array} medsContext - entradas já derivadas (com `planName: string|null`)
- * @returns {string[]} linhas prontas
+ * @param medsContext - entradas já derivadas (com `planName: string|null`)
+ * @returns linhas prontas
  */
-function _buildMedLines(medsContext) {
+function _buildMedLines(medsContext: MedContext[]): string[] {
   const ungrouped = medsContext.filter((mc) => !mc.planName)
-  const grouped = new Map() // nome do plano → mc[] (ordem de aparição)
+  const grouped = new Map<string, MedContext[]>() // nome do plano → mc[] (ordem de aparição)
   for (const mc of medsContext) {
     if (!mc.planName) continue
     if (!grouped.has(mc.planName)) grouped.set(mc.planName, [])
-    grouped.get(mc.planName).push(mc)
+    grouped.get(mc.planName)?.push(mc)
   }
 
   const lines = ungrouped.map(_formatMedLine)
@@ -148,7 +217,7 @@ function _buildMedLines(medsContext) {
 }
 
 /** Logs registrados HOJE (no tz local) — filtragem por ano/mês/dia. */
-function _countTodayLogs(logs, y, m, d) {
+function _countTodayLogs(logs: LogLike[] | null | undefined, y: number, m: number, d: number) {
   return (logs || []).filter((log) => {
     const logDate = getSaoPauloTime(parseISO(log.taken_at))
     return logDate.getFullYear() === y && logDate.getMonth() + 1 === m && logDate.getDate() === d
@@ -156,7 +225,7 @@ function _countTodayLogs(logs, y, m, d) {
 }
 
 /** Filas de doses: pendentes de hoje (ordenadas) + atrasadas actionáveis (carry-over). */
-function _resolveDoseQueues(doseInstances, validProtocols) {
+function _resolveDoseQueues(doseInstances: DoseZoneInstance[] | undefined, validProtocols: DoseZoneProtocol[]) {
   const { carryOver = [], today: todayDoses = [] } = splitDayTimeline(
     doseInstances || [],
     validProtocols,

--- a/packages/core/src/chatbot/chatbotContextSchema.ts
+++ b/packages/core/src/chatbot/chatbotContextSchema.ts
@@ -48,10 +48,16 @@ export const chatbotContextDataSchema = z.object({
 
 /**
  * Valida (e normaliza com defaults) o shape do contexto do chatbot.
- * @param {unknown} data
- * @returns {{success:true,data:object}|{success:false,errors:Array<{field:string,message:string}>}}
+ * @param data
+ * @returns {success:true,data:object}|{success:false,errors:Array<{field:string,message:string}>}
  */
-export function validateChatbotContextData(data) {
+export type ChatbotContextData = z.infer<typeof chatbotContextDataSchema>
+
+export type ValidateChatbotContextDataResult =
+  | { success: true; data: ChatbotContextData }
+  | { success: false; errors: Array<{ field: string; message: string }> }
+
+export function validateChatbotContextData(data: unknown): ValidateChatbotContextDataResult {
   const result = chatbotContextDataSchema.safeParse(data)
   if (!result.success) {
     return {

--- a/packages/core/src/chatbot/fetchChatbotContextData.ts
+++ b/packages/core/src/chatbot/fetchChatbotContextData.ts
@@ -9,8 +9,10 @@
 // (descopada por blast radius — RC3 F2). A saída é validada pelo seam Zod (CON-028) antes
 // de chegar ao builder.
 
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@dosiq/shared-data'
 import { createDoseInstanceRepository } from '../repositories/createDoseInstanceRepository'
-import { calculateDailyIntake, calculateDaysRemaining } from '../utils/adherenceLogic'
+import { calculateDailyIntake, calculateDaysRemaining, type AdherenceProtocol } from '../utils/adherenceLogic'
 import { getNow, getTodayLocal, parseLocalDate, addDays } from '../utils/dateUtils'
 import { validateChatbotContextData } from './chatbotContextSchema'
 
@@ -19,21 +21,43 @@ const DOSE_WINDOW_DAYS = 2
 /** Janela de adesão instances-based (R-248). */
 const ADHERENCE_WINDOW_DAYS = 30
 
+/** Medicamento (linha crua do Supabase, `stock(*)` embedded). */
+interface MedicineRow {
+  id: string
+  min_stock_threshold?: number | null
+  stock?: Array<{ quantity: number }> | null
+  [key: string]: unknown
+}
+
+/** Protocolo (linha crua do Supabase). */
+interface ProtocolRow {
+  medicine_id: string | null
+  active?: boolean | null
+  [key: string]: unknown
+}
+
 /**
  * Resumo de estoque rich (paridade web — `_deriveStockSummary`). Movido p/ o core para que
  * as 3 superfícies derivem igual. Lê `medicine.stock[]` embedded + protocolos ativos.
- * @param {Array} medicines
- * @param {Array} protocols
- * @returns {Array<{medicine,total,daysRemaining,isZero,isLow,dailyIntake}>}
+ * @param medicines
+ * @param protocols
+ * @returns Array<{medicine,total,daysRemaining,isZero,isLow,dailyIntake}>
  */
-function deriveStockSummary(medicines, protocols) {
+function deriveStockSummary(medicines: MedicineRow[] | null | undefined, protocols: ProtocolRow[] | null | undefined) {
   const activeMedicineIds = new Set((protocols || []).filter((p) => p.active).map((p) => p.medicine_id))
   return (medicines || [])
     .filter((m) => activeMedicineIds.has(m.id))
     .map((medicine) => {
       const activeStockEntries = (medicine.stock || []).filter((s) => s.quantity > 0)
       const totalQuantity = activeStockEntries.reduce((sum, s) => sum + s.quantity, 0)
-      const dailyIntake = calculateDailyIntake(medicine.id, protocols, medicine)
+      // Cast local: `protocols`/`medicine` aqui são linhas cruas do Supabase (shape amplo,
+      // `medicine_id` pode ser `null`); `AdherenceProtocol` (adherenceLogic.ts) não modela
+      // `null` no FK — seguro pois a comparação `p.medicine_id === medicineId` tolera null.
+      const dailyIntake = calculateDailyIntake(
+        medicine.id,
+        protocols as AdherenceProtocol[] | null | undefined,
+        medicine as AdherenceProtocol['medicine']
+      )
       const daysRemaining = calculateDaysRemaining(totalQuantity, dailyIntake)
       const threshold = medicine.min_stock_threshold || 0
       const isZero = totalQuantity === 0
@@ -50,11 +74,11 @@ function deriveStockSummary(medicines, protocols) {
  * Adesão leve instances-based (R-248): taken/(taken+missed) na janela; skipped_* neutro;
  * denom vazio → null. Substitui as duas implementações divergentes (web 30d-instances via
  * adherenceService vs Telegram 7d-logs) por uma fonte única no core.
- * @param {Object} repo - createDoseInstanceRepository
- * @param {string} userId
- * @returns {Promise<{adherence:number|null}>}
+ * @param repo - createDoseInstanceRepository
+ * @param userId
+ * @returns Promise<{adherence:number|null}>
  */
-async function computeInstancesAdherence(repo, userId) {
+async function computeInstancesAdherence(repo: ReturnType<typeof createDoseInstanceRepository>, userId: string) {
   // Adesão é dado SECUNDÁRIO (1 linha no contexto): falha transitória na consulta NÃO deve
   // derrubar todo o contexto do chatbot. Degrada gracioso (null) — diferente dos selects
   // primários (medicines/protocols), que falham alto por design (FR-010).
@@ -72,12 +96,18 @@ async function computeInstancesAdherence(repo, userId) {
 
 /**
  * Busca + deriva o contexto do paciente para o chatbot (saída == entrada do builder, CON-028).
- * @param {Object} deps
- * @param {Object} deps.supabase - Cliente Supabase do runtime
- * @param {Function} deps.getUserId - () => Promise<string> (id do usuário autenticado)
- * @returns {Promise<import('./chatbotContextSchema').chatbotContextDataSchema>} ChatbotContextData
+ * @param deps
+ * @param deps.supabase - Cliente Supabase do runtime
+ * @param deps.getUserId - () => Promise<string> (id do usuário autenticado)
+ * @returns ChatbotContextData
  */
-export async function fetchChatbotContextData({ supabase, getUserId }) {
+export async function fetchChatbotContextData({
+  supabase,
+  getUserId,
+}: {
+  supabase: SupabaseClient<Database>
+  getUserId: () => Promise<string>
+}) {
   if (!supabase) throw new Error('fetchChatbotContextData: supabase é obrigatório')
   if (typeof getUserId !== 'function') throw new Error('fetchChatbotContextData: getUserId é obrigatório')
 
@@ -128,7 +158,8 @@ export async function fetchChatbotContextData({ supabase, getUserId }) {
 
   // Seam Zod (CON-028) — valida o shape antes do builder (FR-010 mecanismo 3).
   const validation = validateChatbotContextData(data)
-  if (!validation.success) {
+  // `=== false` (não `!`): consumidores non-strict (mobile) só estreitam a união com literal
+  if (validation.success === false) {
     const detail = validation.errors.map((e) => `${e.field}: ${e.message}`).join('; ')
     throw new Error(`fetchChatbotContextData: shape inválido (CON-028) — ${detail}`)
   }

--- a/packages/core/src/markdown/parseMessageMarkdown.ts
+++ b/packages/core/src/markdown/parseMessageMarkdown.ts
@@ -8,20 +8,29 @@
 // quebras de linha. (O Groq emite `*` p/ categorias e `+` p/ itens aninhados.)
 
 /**
- * @typedef {{ type: 'text'|'bold'|'italic', value: string }} InlineSegment
- * @typedef {{ bullet: 'none'|'item'|'subitem', segments: InlineSegment[] }} MarkdownLine
+ * Segmento inline de texto (negrito/itálico/texto cru).
  */
+export interface InlineSegment {
+  type: 'text' | 'bold' | 'italic'
+  value: string
+}
+
+/** Linha estruturada (bullet + segmentos inline). */
+export interface MarkdownLine {
+  bullet: 'none' | 'item' | 'subitem'
+  segments: InlineSegment[]
+}
 
 /**
  * Quebra uma linha em segmentos inline (**bold** / _italic_ / texto cru).
- * @param {string} text
- * @returns {InlineSegment[]}
+ * @param text
+ * @returns segmentos inline
  */
-export function parseInlineSegments(text) {
+export function parseInlineSegments(text: string | null | undefined): InlineSegment[] {
   const parts = (text ?? '').split(/(\*\*[^*]+\*\*|_[^_]+_)/g)
   return parts
     .filter(Boolean)
-    .map((part) => {
+    .map((part): InlineSegment => {
       if (part.startsWith('**') && part.endsWith('**') && part.length > 4) {
         return { type: 'bold', value: part.slice(2, -2) }
       }
@@ -35,11 +44,11 @@ export function parseInlineSegments(text) {
 /**
  * Parseia uma mensagem em linhas estruturadas (bullet + segmentos inline).
  * Markdown malformado degrada para texto cru (nunca lança).
- * @param {string} content
- * @returns {MarkdownLine[]}
+ * @param content
+ * @returns linhas estruturadas
  */
-export function parseMessageMarkdown(content) {
-  return (content ?? '').split('\n').map((line) => {
+export function parseMessageMarkdown(content: string | null | undefined): MarkdownLine[] {
+  return (content ?? '').split('\n').map((line): MarkdownLine => {
     const bullet = line.match(/^(\s*)([-*+])\s+(.*)$/)
     if (bullet) {
       return {

--- a/packages/core/src/schemas/__tests__/b2GlpSchemas.test.ts
+++ b/packages/core/src/schemas/__tests__/b2GlpSchemas.test.ts
@@ -53,7 +53,7 @@ describe('injection_container — enum (FR-019)', () => {
       injection_container: 'caneta',
     })
     expect(res.success).toBe(true)
-    expect('injection_container' in res.data).toBe(false)
+    expect('injection_container' in res.data!).toBe(false)
   })
 })
 

--- a/packages/core/src/schemas/__tests__/biomarkerLogSchema.test.ts
+++ b/packages/core/src/schemas/__tests__/biomarkerLogSchema.test.ts
@@ -31,12 +31,12 @@ describe('biomarkerLogSchema — context por família (ADR-070)', () => {
   it('PA + contexto de glicemia → rejeitado', () => {
     const r = validateBiomarkerLog({ type: 'pressao_arterial', value: 120, value_secondary: 80, unit: 'mmHg', context: 'jejum' })
     expect(r.success).toBe(false)
-    expect(r.errors.some((e) => e.field === 'context')).toBe(true)
+    expect(r.errors!.some((e) => e.field === 'context')).toBe(true)
   })
   it('glicemia + contexto PA → rejeitado', () => {
     const r = validateBiomarkerLog({ type: 'glicemia', value: 110, unit: 'mg/dL', context: 'em_repouso' })
     expect(r.success).toBe(false)
-    expect(r.errors.some((e) => e.field === 'context')).toBe(true)
+    expect(r.errors!.some((e) => e.field === 'context')).toBe(true)
   })
   it('PA + contexto null → aceito (opcional)', () => {
     const r = validateBiomarkerLog({ type: 'pressao_arterial', value: 120, value_secondary: 80, unit: 'mmHg' })
@@ -48,7 +48,7 @@ describe('biomarkerLogSchema — happy path', () => {
   it('glicemia válida', () => {
     const r = validateBiomarkerLog({ type: 'glicemia', value: 110, unit: 'mg/dL', context: 'jejum' })
     expect(r.success).toBe(true)
-    expect(r.data.value).toBe(110)
+    expect(r.data!.value).toBe(110)
   })
   it('peso válido sem contexto', () => {
     const r = validateBiomarkerLog({ type: 'peso', value: 82.5, unit: BIOMARKER_TYPE_UNITS.peso })
@@ -68,7 +68,7 @@ describe('biomarkerLogSchema — failure modes', () => {
   it('vírgula PT-BR — string "110,5" coage (decimal-pad)', () => {
     const r = validateBiomarkerLog({ type: 'glicemia', value: '110.5', unit: 'mg/dL' })
     expect(r.success).toBe(true)
-    expect(r.data.value).toBeCloseTo(110.5)
+    expect(r.data!.value).toBeCloseTo(110.5)
   })
 })
 
@@ -76,7 +76,7 @@ describe('biomarkerLogSchema — PA / value_secondary (superRefine)', () => {
   it('PA exige value_secondary', () => {
     const r = validateBiomarkerLog({ type: 'pressao_arterial', value: 120, unit: 'mmHg' })
     expect(r.success).toBe(false)
-    expect(r.errors.some((e) => e.field === 'value_secondary')).toBe(true)
+    expect(r.errors!.some((e) => e.field === 'value_secondary')).toBe(true)
   })
   it('PA com sistólica+diastólica válida', () => {
     const r = validateBiomarkerLog({ type: 'pressao_arterial', value: 120, value_secondary: 80, unit: 'mmHg' })

--- a/packages/core/src/schemas/__tests__/emergencyCardSchema.test.ts
+++ b/packages/core/src/schemas/__tests__/emergencyCardSchema.test.ts
@@ -106,7 +106,7 @@ describe('emergencyCardSchema', () => {
 
       expect(result.success).toBe(false)
       expect(result.errors).toBeDefined()
-      expect(result.errors.some((e) => e.field === 'phone')).toBe(true)
+      expect(result.errors!.some((e) => e.field === 'phone')).toBe(true)
     })
 
     it('should reject name shorter than 2 characters', () => {
@@ -119,7 +119,7 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyContact(invalidContact)
 
       expect(result.success).toBe(false)
-      expect(result.errors.some((e) => e.field === 'name')).toBe(true)
+      expect(result.errors!.some((e) => e.field === 'name')).toBe(true)
     })
 
     it('should reject name longer than 200 characters', () => {
@@ -132,7 +132,7 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyContact(invalidContact)
 
       expect(result.success).toBe(false)
-      expect(result.errors.some((e) => e.field === 'name')).toBe(true)
+      expect(result.errors!.some((e) => e.field === 'name')).toBe(true)
     })
 
     it('should reject relationship shorter than 2 characters', () => {
@@ -145,7 +145,7 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyContact(invalidContact)
 
       expect(result.success).toBe(false)
-      expect(result.errors.some((e) => e.field === 'relationship')).toBe(true)
+      expect(result.errors!.some((e) => e.field === 'relationship')).toBe(true)
     })
 
     it('should reject relationship longer than 100 characters', () => {
@@ -158,7 +158,7 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyContact(invalidContact)
 
       expect(result.success).toBe(false)
-      expect(result.errors.some((e) => e.field === 'relationship')).toBe(true)
+      expect(result.errors!.some((e) => e.field === 'relationship')).toBe(true)
     })
   })
 
@@ -180,16 +180,16 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyCard(validCard)
 
       expect(result.success).toBe(true)
-      expect(result.data.emergency_contacts).toHaveLength(1)
-      expect(result.data.allergies).toHaveLength(2)
-      expect(result.data.blood_type).toBe('A+')
+      expect(result.data!.emergency_contacts).toHaveLength(1)
+      expect(result.data!.allergies).toHaveLength(2)
+      expect(result.data!.blood_type).toBe('A+')
     })
 
     it('should add default last_updated timestamp', () => {
       const result = validateEmergencyCard(validCard)
 
       expect(result.success).toBe(true)
-      expect(result.data.last_updated).toBeDefined()
+      expect(result.data!.last_updated).toBeDefined()
     })
 
     it('should accept empty allergies array', () => {
@@ -201,7 +201,7 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyCard(cardWithEmptyAllergies)
 
       expect(result.success).toBe(true)
-      expect(result.data.allergies).toEqual([])
+      expect(result.data!.allergies).toEqual([])
     })
 
     it('should accept null notes', () => {
@@ -213,7 +213,7 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyCard(cardWithNullNotes)
 
       expect(result.success).toBe(true)
-      expect(result.data.notes).toBeNull()
+      expect(result.data!.notes).toBeNull()
     })
 
     it('should accept undefined notes (converted to null)', () => {
@@ -222,7 +222,7 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyCard(cardWithoutNotes)
 
       expect(result.success).toBe(true)
-      expect(result.data.notes).toBeNull()
+      expect(result.data!.notes).toBeNull()
     })
 
     it('should reject missing emergency_contacts', () => {
@@ -243,7 +243,7 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyCard(cardWithEmptyContacts)
 
       expect(result.success).toBe(false)
-      expect(result.errors.some((e) => e.field === 'emergency_contacts')).toBe(true)
+      expect(result.errors!.some((e) => e.field === 'emergency_contacts')).toBe(true)
     })
 
     it('should reject more than 5 emergency contacts', () => {
@@ -261,7 +261,7 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyCard(cardWithTooManyContacts)
 
       expect(result.success).toBe(false)
-      expect(result.errors.some((e) => e.field === 'emergency_contacts')).toBe(true)
+      expect(result.errors!.some((e) => e.field === 'emergency_contacts')).toBe(true)
     })
 
     it('should accept exactly 5 emergency contacts', () => {
@@ -279,7 +279,7 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyCard(cardWith5Contacts)
 
       expect(result.success).toBe(true)
-      expect(result.data.emergency_contacts).toHaveLength(5)
+      expect(result.data!.emergency_contacts).toHaveLength(5)
     })
 
     it('should reject invalid blood type', () => {
@@ -291,7 +291,7 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyCard(cardWithInvalidBloodType)
 
       expect(result.success).toBe(false)
-      expect(result.errors.some((e) => e.field === 'blood_type')).toBe(true)
+      expect(result.errors!.some((e) => e.field === 'blood_type')).toBe(true)
     })
 
     it('should accept all valid blood types', () => {
@@ -304,7 +304,7 @@ describe('emergencyCardSchema', () => {
         const result = validateEmergencyCard(card)
 
         expect(result.success).toBe(true)
-        expect(result.data.blood_type).toBe(bloodType)
+        expect(result.data!.blood_type).toBe(bloodType)
       })
     })
 
@@ -317,7 +317,7 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyCard(cardWithLongNotes)
 
       expect(result.success).toBe(false)
-      expect(result.errors.some((e) => e.field === 'notes')).toBe(true)
+      expect(result.errors!.some((e) => e.field === 'notes')).toBe(true)
     })
 
     it('should reject more than 20 allergies', () => {
@@ -331,7 +331,7 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyCard(cardWithTooManyAllergies)
 
       expect(result.success).toBe(false)
-      expect(result.errors.some((e) => e.field === 'allergies')).toBe(true)
+      expect(result.errors!.some((e) => e.field === 'allergies')).toBe(true)
     })
 
     it('should reject empty allergy string', () => {
@@ -371,7 +371,7 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyCard(cardWithInvalidContact)
 
       expect(result.success).toBe(false)
-      expect(result.errors.length).toBeGreaterThan(0)
+      expect(result.errors!.length).toBeGreaterThan(0)
     })
   })
 
@@ -404,7 +404,7 @@ describe('emergencyCardSchema', () => {
       const result = validateEmergencyCardUpdate(partialData)
 
       expect(result.success).toBe(true)
-      expect(result.data.blood_type).toBe('B-')
+      expect(result.data!.blood_type).toBe('B-')
     })
 
     it('should accept empty object', () => {
@@ -435,8 +435,8 @@ describe('emergencyCardSchema', () => {
       const result = emergencyContactSchema.safeParse(contactWithWhitespace)
 
       expect(result.success).toBe(true)
-      expect(result.data.name).toBe('Maria Silva')
-      expect(result.data.relationship).toBe('Esposa')
+      expect(result.data!.name).toBe('Maria Silva')
+      expect(result.data!.relationship).toBe('Esposa')
     })
   })
 
@@ -457,7 +457,7 @@ describe('emergencyCardSchema', () => {
       const result = emergencyCardSchema.safeParse(cardWithWhitespaceAllergies)
 
       expect(result.success).toBe(true)
-      expect(result.data.allergies).toEqual(['Penicilina', 'Dipirona'])
+      expect(result.data!.allergies).toEqual(['Penicilina', 'Dipirona'])
     })
   })
 })

--- a/packages/core/src/schemas/__tests__/feedbackSchema.test.ts
+++ b/packages/core/src/schemas/__tests__/feedbackSchema.test.ts
@@ -10,7 +10,7 @@ describe('Feedback Schema Validation', () => {
       platform: 'ios'
     })
     expect(result.success).toBe(true)
-    expect(result.data.subject).toBe('Problema no login')
+    expect(result.data!.subject).toBe('Problema no login')
   })
 
   it('accepts other and android as platforms and optional fields', () => {
@@ -23,8 +23,8 @@ describe('Feedback Schema Validation', () => {
       app_version: '3.3.0'
     })
     expect(result.success).toBe(true)
-    expect(result.data.device).toBe('Samsung Galaxy S21')
-    expect(result.data.app_version).toBe('3.3.0')
+    expect(result.data!.device).toBe('Samsung Galaxy S21')
+    expect(result.data!.app_version).toBe('3.3.0')
   })
 
   it('rejects empty subject', () => {
@@ -35,7 +35,7 @@ describe('Feedback Schema Validation', () => {
       platform: 'other'
     })
     expect(result.success).toBe(false)
-    expect(result.errors.some(e => e.field === 'subject')).toBe(true)
+    expect(result.errors!.some(e => e.field === 'subject')).toBe(true)
   })
 
   it('rejects subject longer than 100 characters', () => {
@@ -46,7 +46,7 @@ describe('Feedback Schema Validation', () => {
       platform: 'other'
     })
     expect(result.success).toBe(false)
-    expect(result.errors.find(e => e.field === 'subject').message).toContain('mais de 100 caracteres')
+    expect(result.errors!.find(e => e.field === 'subject')!.message).toContain('mais de 100 caracteres')
   })
 
   it('rejects empty comment', () => {
@@ -57,7 +57,7 @@ describe('Feedback Schema Validation', () => {
       platform: 'other'
     })
     expect(result.success).toBe(false)
-    expect(result.errors.some(e => e.field === 'comment')).toBe(true)
+    expect(result.errors!.some(e => e.field === 'comment')).toBe(true)
   })
 
   it('rejects comment longer than 2000 characters', () => {
@@ -68,7 +68,7 @@ describe('Feedback Schema Validation', () => {
       platform: 'other'
     })
     expect(result.success).toBe(false)
-    expect(result.errors.find(e => e.field === 'comment').message).toContain('mais de 2000 caracteres')
+    expect(result.errors!.find(e => e.field === 'comment')!.message).toContain('mais de 2000 caracteres')
   })
 
   it('rejects invalid rating values', () => {
@@ -105,7 +105,7 @@ describe('Feedback Schema Validation', () => {
       platform: 'ios'
     })
     expect(nullRating.success).toBe(true)
-    expect(nullRating.data.rating).toBe(null)
+    expect(nullRating.data!.rating).toBe(null)
 
     const missingRating = validateFeedbackCreate({
       subject: 'Assunto',
@@ -123,6 +123,6 @@ describe('Feedback Schema Validation', () => {
       platform: 'web'
     })
     expect(result.success).toBe(false)
-    expect(result.errors.some(e => e.field === 'platform')).toBe(true)
+    expect(result.errors!.some(e => e.field === 'platform')).toBe(true)
   })
 })

--- a/packages/core/src/schemas/__tests__/geminiReviewSchema.test.ts
+++ b/packages/core/src/schemas/__tests__/geminiReviewSchema.test.ts
@@ -149,11 +149,10 @@ describe('Gemini Review Schema', () => {
     })
 
     it('deve aplicar status padrão "pending"', () => {
-      const withoutStatus = { ...validReview }
-      delete withoutStatus.status
+      const { status: _status, ...withoutStatus } = validReview
       const result = geminiReviewSchema.safeParse(withoutStatus)
       expect(result.success).toBe(true)
-      expect(result.data.status).toBe('pendente')
+      expect(result.data!.status).toBe('pendente')
     })
   })
 
@@ -336,13 +335,13 @@ describe('Gemini Review Schema', () => {
         const result = validateGeminiReview(invalidReview)
         expect(result.success).toBe(false)
         expect(result.errors).toBeDefined()
-        expect(result.errors.length).toBeGreaterThan(0)
+        expect(result.errors!.length).toBeGreaterThan(0)
       })
 
       it('deve incluir field nos erros', () => {
         const invalidReview = { ...validReview, pr_number: -1 }
         const result = validateGeminiReview(invalidReview)
-        expect(result.errors[0].field).toBe('pr_number')
+        expect(result.errors![0].field).toBe('pr_number')
       })
     })
 

--- a/packages/core/src/schemas/__tests__/medicine.smoke.test.ts
+++ b/packages/core/src/schemas/__tests__/medicine.smoke.test.ts
@@ -27,9 +27,9 @@ describe('Smoke: Medicine Schema', () => {
     it('update parcial (só therapeutic_class) não traz presentation/type', () => {
       const result = validateMedicineUpdate({ therapeutic_class: 'Análogo de GLP-1' })
       expect(result.success).toBe(true)
-      expect('presentation' in result.data).toBe(false)
-      expect('type' in result.data).toBe(false)
-      expect(result.data.therapeutic_class).toBe('Análogo de GLP-1')
+      expect('presentation' in result.data!).toBe(false)
+      expect('type' in result.data!).toBe(false)
+      expect(result.data!.therapeutic_class).toBe('Análogo de GLP-1')
     })
 
     it('create ainda aplica os defaults (comprimido/medicamento)', () => {
@@ -39,14 +39,14 @@ describe('Smoke: Medicine Schema', () => {
         dosage_unit: 'mg',
       })
       expect(result.success).toBe(true)
-      expect(result.data.presentation).toBe('comprimido')
-      expect(result.data.type).toBe('medicamento')
+      expect(result.data!.presentation).toBe('comprimido')
+      expect(result.data!.type).toBe('medicamento')
     })
 
     it('update preserva presentation quando explicitamente enviado', () => {
       const result = validateMedicineUpdate({ presentation: 'injetavel' })
       expect(result.success).toBe(true)
-      expect(result.data.presentation).toBe('injetavel')
+      expect(result.data!.presentation).toBe('injetavel')
     })
   })
 })

--- a/packages/core/src/schemas/__tests__/stockInjectionContainer.b4.test.ts
+++ b/packages/core/src/schemas/__tests__/stockInjectionContainer.b4.test.ts
@@ -13,12 +13,12 @@ describe('injection_container por lote (B4 — ADR-068)', () => {
   it('stockCreate aceita injection_container válido', () => {
     const r = validateStockCreate({ ...BASE, injection_container: 'caneta' })
     expect(r.success).toBe(true)
-    expect(r.data.injection_container).toBe('caneta')
+    expect(r.data!.injection_container).toBe('caneta')
   })
 
   it('stockCreate normaliza ausência/"" → null', () => {
-    expect(validateStockCreate(BASE).data.injection_container).toBeNull()
-    expect(validateStockCreate({ ...BASE, injection_container: null }).data.injection_container).toBeNull()
+    expect(validateStockCreate(BASE).data!.injection_container).toBeNull()
+    expect(validateStockCreate({ ...BASE, injection_container: null }).data!.injection_container).toBeNull()
   })
 
   it('stockCreate rejeita enum inválido', () => {

--- a/packages/core/src/schemas/__tests__/userSettingsSchema.test.ts
+++ b/packages/core/src/schemas/__tests__/userSettingsSchema.test.ts
@@ -46,7 +46,7 @@ describe('userSettingsSchema — timezone (ADR-053)', () => {
     for (const tz of ['Europe/London', 'America/New_York', 'Europe/Lisbon', 'America/Los_Angeles']) {
       const r = userSettingsNotificationSchema.safeParse({ timezone: tz })
       expect(r.success).toBe(true)
-      expect(r.data.timezone).toBe(tz)
+      expect(r.data!.timezone).toBe(tz)
     }
   })
 

--- a/packages/core/src/schemas/__tests__/validation.test.ts
+++ b/packages/core/src/schemas/__tests__/validation.test.ts
@@ -20,7 +20,7 @@ describe('Schemas de Validação Zod', () => {
       }
       const result = validateMedicineCreate(medicine)
       expect(result.success).toBe(true)
-      expect(result.data.name).toBe('Paracetamol')
+      expect(result.data!.name).toBe('Paracetamol')
     })
 
     it('deve rejeitar nome muito curto', () => {
@@ -31,8 +31,8 @@ describe('Schemas de Validação Zod', () => {
       }
       const result = validateMedicineCreate(medicine)
       expect(result.success).toBe(false)
-      expect(result.errors[0].field).toBe('name')
-      expect(result.errors[0].message).toContain('pelo menos 2 caracteres')
+      expect(result.errors![0].field).toBe('name')
+      expect(result.errors![0].message).toContain('pelo menos 2 caracteres')
     })
 
     it('deve rejeitar dosagem negativa', () => {
@@ -43,7 +43,7 @@ describe('Schemas de Validação Zod', () => {
       }
       const result = validateMedicineCreate(medicine)
       expect(result.success).toBe(false)
-      expect(result.errors[0].field).toBe('dosage_per_pill')
+      expect(result.errors![0].field).toBe('dosage_per_pill')
     })
 
     it('deve rejeitar unidade inválida', () => {
@@ -54,7 +54,7 @@ describe('Schemas de Validação Zod', () => {
       }
       const result = validateMedicineCreate(medicine)
       expect(result.success).toBe(false)
-      expect(result.errors[0].field).toBe('dosage_unit')
+      expect(result.errors![0].field).toBe('dosage_unit')
     })
 
     it('deve aplicar valor padrão para tipo', () => {
@@ -65,7 +65,7 @@ describe('Schemas de Validação Zod', () => {
       }
       const result = validateMedicineCreate(medicine)
       expect(result.success).toBe(true)
-      expect(result.data.type).toBe('medicamento')
+      expect(result.data!.type).toBe('medicamento')
     })
 
     it('deve mapear erros para formato de formulário', () => {
@@ -108,8 +108,8 @@ describe('Schemas de Validação Zod', () => {
       }
       const result = validateStockCreate(stock)
       expect(result.success).toBe(false)
-      expect(result.errors[0].field).toBe('medicine_id')
-      expect(result.errors[0].message).toContain('UUID')
+      expect(result.errors![0].field).toBe('medicine_id')
+      expect(result.errors![0].message).toContain('UUID')
     })
 
     it('deve rejeitar quantidade negativa', () => {
@@ -120,7 +120,7 @@ describe('Schemas de Validação Zod', () => {
       }
       const result = validateStockCreate(stock)
       expect(result.success).toBe(false)
-      expect(result.errors[0].field).toBe('quantity')
+      expect(result.errors![0].field).toBe('quantity')
     })
 
     it('deve rejeitar data de compra no futuro', () => {
@@ -131,7 +131,7 @@ describe('Schemas de Validação Zod', () => {
       }
       const result = validateStockCreate(stock)
       expect(result.success).toBe(false)
-      expect(result.errors[0].message).toContain('futuro')
+      expect(result.errors![0].message).toContain('futuro')
     })
 
     it('deve rejeitar data de validade anterior à compra', () => {
@@ -143,7 +143,7 @@ describe('Schemas de Validação Zod', () => {
       }
       const result = validateStockCreate(stock)
       expect(result.success).toBe(false)
-      expect(result.errors[0].message).toContain('posterior')
+      expect(result.errors![0].message).toContain('posterior')
     })
 
     it('deve aceitar data de validade ausente', () => {
@@ -176,7 +176,7 @@ describe('Schemas de Validação Zod', () => {
       }
       const result = validateLogCreate(log)
       expect(result.success).toBe(false)
-      expect(result.errors[0].message).toContain('futuro')
+      expect(result.errors![0].message).toContain('futuro')
     })
 
     it('deve rejeitar quantidade muito alta', () => {
@@ -188,7 +188,7 @@ describe('Schemas de Validação Zod', () => {
       }
       const result = validateLogCreate(log)
       expect(result.success).toBe(false)
-      expect(result.errors[0].message).toContain('1000')
+      expect(result.errors![0].message).toContain('1000')
     })
 
     it('deve aceitar dose líquida em gotas acima do antigo cap-100', () => {
@@ -226,7 +226,7 @@ describe('Schemas de Validação Zod', () => {
       }
       const result = validateProtocolCreate(protocol)
       expect(result.success).toBe(false)
-      expect(result.errors[0].field).toContain('time_schedule')
+      expect(result.errors![0].field).toContain('time_schedule')
     })
 
     it('deve rejeitar schedule vazio', () => {
@@ -240,7 +240,7 @@ describe('Schemas de Validação Zod', () => {
       }
       const result = validateProtocolCreate(protocol)
       expect(result.success).toBe(false)
-      expect(result.errors[0].message).toContain('pelo menos um horário')
+      expect(result.errors![0].message).toContain('pelo menos um horário')
     })
 
     describe('Validação end_date >= start_date', () => {
@@ -266,8 +266,8 @@ describe('Schemas de Validação Zod', () => {
       it('deve rejeitar end_date menor que start_date', () => {
         const result = validateProtocolCreate({ ...baseProtocol, end_date: '2024-01-01' })
         expect(result.success).toBe(false)
-        expect(result.errors.some((e) => e.field === 'end_date')).toBe(true)
-        expect(result.errors.some((e) => e.message.includes('maior ou igual'))).toBe(true)
+        expect(result.errors!.some((e) => e.field === 'end_date')).toBe(true)
+        expect(result.errors!.some((e) => e.message.includes('maior ou igual'))).toBe(true)
       })
 
       it('deve aceitar end_date ausente (protocolo sem data de término)', () => {
@@ -307,13 +307,13 @@ describe('Schemas de Validação Zod', () => {
     it('deve retornar erro para tipo inválido', () => {
       const result = validateEntity('invalid', {}, 'create')
       expect(result.success).toBe(false)
-      expect(result.error.message).toContain('desconhecido')
+      expect(result.error!.message).toContain('desconhecido')
     })
 
     it('deve retornar erro para operação inválida', () => {
       const result = validateEntity('medicine', {}, 'invalid_op')
       expect(result.success).toBe(false)
-      expect(result.error.message).toContain('não suportada')
+      expect(result.error!.message).toContain('não suportada')
     })
   })
 
@@ -341,7 +341,7 @@ describe('Schemas de Validação Zod', () => {
         _medicineIsLiquid: true,
       })
       expect(r.success).toBe(false)
-      expect(r.errors.some((e) => e.field === 'intake_unit')).toBe(true)
+      expect(r.errors!.some((e) => e.field === 'intake_unit')).toBe(true)
     })
     it('protocolo líquido COM intake_unit gotas + dose decimal → aceita', () => {
       const r = validateProtocolCreate({
@@ -366,13 +366,13 @@ describe('medicineSchema shelf_life_days', () => {
   it('aceita inteiro positivo (28)', () => {
     const r = medicineSchema.safeParse({ ...base, shelf_life_days: 28 })
     expect(r.success).toBe(true)
-    expect(r.data.shelf_life_days).toBe(28)
+    expect(r.data!.shelf_life_days).toBe(28)
   })
 
   it("campo limpo ('') vira null — não 0 (R-270)", () => {
     const r = medicineSchema.safeParse({ ...base, shelf_life_days: '' })
     expect(r.success).toBe(true)
-    expect(r.data.shelf_life_days).toBe(null)
+    expect(r.data!.shelf_life_days).toBe(null)
   })
 
   it('ausente/null aceito (eixo inativo)', () => {
@@ -389,6 +389,6 @@ describe('medicineSchema shelf_life_days', () => {
   it('coerção de string numérica do form ("28" → 28)', () => {
     const r = medicineSchema.safeParse({ ...base, shelf_life_days: '28' })
     expect(r.success).toBe(true)
-    expect(r.data.shelf_life_days).toBe(28)
+    expect(r.data!.shelf_life_days).toBe(28)
   })
 })

--- a/packages/core/src/services/__tests__/anvisaDatabase.test.ts
+++ b/packages/core/src/services/__tests__/anvisaDatabase.test.ts
@@ -20,15 +20,17 @@ const DATA = [
 ]
 
 // Response-like helper
-function ok(body) {
+function ok(body: unknown) {
   return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) })
 }
 function httpErr(status = 500) {
   return Promise.resolve({ ok: false, status, json: () => Promise.resolve(null) })
 }
 
+type CachedRecord = { manifest: Record<string, unknown>; data: unknown[] } | null
+
 // Adapter in-memory configurável (simula Cache Storage / AsyncStorage)
-function makeAdapter(initial = null, { writeFails = false } = {}) {
+function makeAdapter(initial: CachedRecord = null, { writeFails = false } = {}) {
   let store = initial
   return {
     read: vi.fn(() => Promise.resolve(store)),
@@ -88,7 +90,7 @@ describe('anvisaDatabase — createAnvisaDatabase.load()', () => {
     const data = await db.load()
     expect(data).toEqual(DATA)
     expect(adapter.write).toHaveBeenCalledTimes(1)
-    expect(adapter._get().data).toEqual(DATA)
+    expect(adapter._get()!.data).toEqual(DATA)
   })
 
   it('memoiza: 2ª chamada não refaz fetch', async () => {
@@ -159,7 +161,7 @@ describe('anvisaDatabase — createAnvisaDatabase.load()', () => {
     const data = await db.load()
     expect(data).toEqual(DATA)
     expect(adapter.write).toHaveBeenCalledTimes(1)
-    expect(adapter._get().manifest.version).toBe('1.1.2')
+    expect(adapter._get()!.manifest.version).toBe('1.1.2')
   })
 
   it('read do adapter rejeita: trata como sem cache (baixa do remoto)', async () => {

--- a/packages/core/src/utils/adherenceLogic.ts
+++ b/packages/core/src/utils/adherenceLogic.ts
@@ -19,6 +19,55 @@ import {
 } from './dateUtils'
 import { densityFor } from './doseUnit'
 
+export interface AdherenceProtocol {
+  id?: string
+  medicine_id?: string
+  time_schedule?: string[] | null
+  frequency?: string | null
+  weekdays?: string[] | null
+  days?: string[] | null
+  start_date?: string | null
+  end_date?: string | null
+  active?: boolean
+  dosage_per_intake?: number | null
+  intake_unit?: string | null
+  medicine?: {
+    dosage_unit?: string | null
+    units_per_ml?: number | null
+    dosage_per_pill?: number | null
+  } | null
+}
+
+interface AdherenceLog {
+  taken_at?: string
+  protocol_id?: string
+  quantity_taken?: number
+  [key: string]: unknown
+}
+
+interface ExpectedDoseSlot {
+  protocolId?: string
+  medicineId?: string
+  scheduledTime: string
+  expectedQuantity: number
+  protocol: AdherenceProtocol
+  medicine: AdherenceProtocol['medicine']
+}
+
+interface DoseRecord {
+  [key: string]: unknown
+  scheduledTime?: string | null
+  status?: string
+  taken_at?: string
+}
+
+interface DoseInstance {
+  status?: string
+  expected_dose?: number
+  quantity_taken?: number
+  scheduled_for?: string
+}
+
 // Invariantes de Negócio (R-022, R-129)
 const TOLERANCE_WINDOW_HOURS = 2
 const TOLERANCE_WINDOW_MS = TOLERANCE_WINDOW_HOURS * 60 * 60 * 1000
@@ -33,13 +82,13 @@ const TOLERANCE_WINDOW_MINUTES = TOLERANCE_WINDOW_HOURS * 60
  * @param {Date} endDate - Data final do período (padrão: hoje)
  * @returns {number} Total de doses esperadas
  */
-function getWeeklyRate(protocol, timesPerDay) {
+function getWeeklyRate(protocol: AdherenceProtocol, timesPerDay: number): number {
   const days = getProtocolDays(protocol)
   const numDays = days.length
   return timesPerDay * (numDays > 0 ? numDays : 1) / 7
 }
 
-const FREQUENCY_RATE_STRATEGIES = {
+const FREQUENCY_RATE_STRATEGIES: Record<string, (timesPerDay: number, protocol: AdherenceProtocol) => number> = {
   daily: (timesPerDay) => timesPerDay,
   diariamente: (timesPerDay) => timesPerDay,
   'diário': (timesPerDay) => timesPerDay,
@@ -59,7 +108,7 @@ const FREQUENCY_RATE_STRATEGIES = {
  * @param {Object} protocol - O objeto do protocolo
  * @returns {number} Taxa de doses por dia
  */
-export function getDailyDoseRate(protocol) {
+export function getDailyDoseRate(protocol: AdherenceProtocol | null | undefined): number {
   if (!protocol) return 0
   const frequency = (protocol.frequency || 'daily').toLowerCase()
   const timesPerDay = protocol.time_schedule?.length || 1
@@ -77,7 +126,7 @@ export function getDailyDoseRate(protocol) {
  * @param {Date} periodEnd - Fim do período de análise
  * @returns {number} Número de dias efetivos (interseção entre protocolo e período)
  */
-function getEffectiveDays(protocol, periodStart, periodEnd) {
+function getEffectiveDays(protocol: AdherenceProtocol, periodStart: Date, periodEnd: Date): number {
   // Sem start_date: assume ativo desde o início do período
   const protocolStartDate = protocol.start_date
     ? parseLocalDate(protocol.start_date)
@@ -97,7 +146,7 @@ function getEffectiveDays(protocol, periodStart, periodEnd) {
   return Math.ceil(diffTime / (1000 * 60 * 60 * 24))
 }
 
-export function calculateExpectedDoses(protocols, days, endDate = getNow()) {
+export function calculateExpectedDoses(protocols: AdherenceProtocol[] | null | undefined, days: number, endDate: Date = getNow()): number {
   if (!protocols || protocols.length === 0) return 0
 
   const periodStart = cloneDate(endDate)
@@ -123,12 +172,12 @@ export function calculateExpectedDoses(protocols, days, endDate = getNow()) {
  * @param {string} dateStr - Data local de referência "YYYY-MM-DD"
  * @returns {boolean}
  */
-export function isProtocolFollowed(scheduledTime, logs, dateStr) {
+export function isProtocolFollowed(scheduledTime: string, logs: AdherenceLog[] | null | undefined, dateStr: string): boolean {
   if (!scheduledTime || !logs || logs.length === 0) return false
 
   return logs.some((log) => {
     // 1. Verificar se o log é do mesmo dia local
-    const logDateStr = formatLocalDate(getSaoPauloTime(parseISO(log.taken_at)))
+    const logDateStr = formatLocalDate(getSaoPauloTime(parseISO(log.taken_at ?? '')))
 
     if (logDateStr !== dateStr) return false
 
@@ -144,7 +193,7 @@ export function isProtocolFollowed(scheduledTime, logs, dateStr) {
  * @param {string} logTakenAt - ISO timestamp do log (UTC)
  * @returns {boolean}
  */
-export function isDoseInToleranceWindow(scheduledTime, logTakenAt) {
+export function isDoseInToleranceWindow(scheduledTime: string | null | undefined, logTakenAt: string | null | undefined): boolean {
   if (!scheduledTime || !logTakenAt) return false
 
   const [sH, sM] = scheduledTime.split(':').map(Number)
@@ -168,7 +217,7 @@ export function isDoseInToleranceWindow(scheduledTime, logTakenAt) {
  * @param {Object} protocol
  * @returns {string} HH:mm ou '--:--'
  */
-export function getNextDoseTime(protocol) {
+export function getNextDoseTime(protocol: AdherenceProtocol | null | undefined): string {
   if (!protocol || !protocol.time_schedule || protocol.time_schedule.length === 0) {
     return '--:--'
   }
@@ -177,12 +226,12 @@ export function getNextDoseTime(protocol) {
   const currentMinutes = now.getHours() * 60 + now.getMinutes()
 
   // Converte horários do cronograma para minutos e ordena
-  const scheduleMinutes = protocol.time_schedule
-    .map((time) => {
+  const scheduleMinutes = (protocol.time_schedule ?? [])
+    .map((time: string) => {
       const [h, m] = time.split(':').map(Number)
       return h * 60 + m
     })
-    .sort((a, b) => a - b)
+    .sort((a: number, b: number) => a - b)
 
   // Janela de tolerância: 2 horas (120 minutos)
   const toleranceWindowMinutes = TOLERANCE_WINDOW_MINUTES
@@ -210,7 +259,7 @@ export function getNextDoseTime(protocol) {
  * @param {string} nextDoseTime - Horário da próxima dose no formato HH:mm
  * @returns {string|null} Horário final da janela (HH:mm) ou null
  */
-export function getNextDoseWindowEnd(nextDoseTime) {
+export function getNextDoseWindowEnd(nextDoseTime: string | null | undefined): string | null {
   if (!nextDoseTime || nextDoseTime === '--:--') {
     return null
   }
@@ -229,7 +278,7 @@ export function getNextDoseWindowEnd(nextDoseTime) {
  * @param {string} nextDoseTime - Horário da próxima dose no formato HH:mm
  * @returns {boolean} true se estiver dentro da janela de tolerância
  */
-export function isInToleranceWindow(nextDoseTime) {
+export function isInToleranceWindow(nextDoseTime: string | null | undefined): boolean {
   if (!nextDoseTime || nextDoseTime === '--:--') {
     return false
   }
@@ -262,7 +311,7 @@ export function isInToleranceWindow(nextDoseTime) {
  * @param {number|null} unitsPerMl - densidade (gotas ou UI por ml)
  * @returns {number} dose equivalente em ml (ou a dose original se não-líquido)
  */
-export function doseToMl(dosage, intakeUnit, unitsPerMl, mgConcentration = null) {
+export function doseToMl(dosage: number, intakeUnit: string | null | undefined, unitsPerMl: number | string | null | undefined, mgConcentration: number | string | null = null): number {
   if (intakeUnit === 'ml' || !intakeUnit) return dosage
   // mg → ml: divide pela CONCENTRAÇÃO (dosage_per_pill = mg/ml do cadastro). 012 Fase B2.
   // Sem concentração não inventa (retorna a dose crua — evita conversão fantasma).
@@ -284,7 +333,7 @@ export function doseToMl(dosage, intakeUnit, unitsPerMl, mgConcentration = null)
  * @param {{frequency?: string, weekdays?: string[]}} p
  * @returns {number} fração de dose por dia (diário=1, semanal=1/7, alternados=1/2...)
  */
-export function frequencyDailyFactor(p) {
+export function frequencyDailyFactor(p: AdherenceProtocol | null | undefined): number {
   switch (p?.frequency) {
     case 'semanal':
       return 1 / 7
@@ -308,7 +357,7 @@ export function frequencyDailyFactor(p) {
  * @param {Object|null} [medicine] - quando informado e líquido, converte doses p/ ml
  * @returns {number} consumo diário (em unidades de tomada, ou em ml se líquido)
  */
-export function calculateDailyIntake(medicineId, protocols, medicine = null) {
+export function calculateDailyIntake(medicineId: string | null | undefined, protocols: AdherenceProtocol[] | null | undefined, medicine: AdherenceProtocol['medicine'] = null): number {
   if (!protocols) return 0
 
   const isLiquid = Boolean(medicine?.dosage_unit?.endsWith('/ml'))
@@ -333,7 +382,7 @@ export function calculateDailyIntake(medicineId, protocols, medicine = null) {
  * @param {number} dailyIntake
  * @returns {number}
  */
-export function calculateDaysRemaining(totalQuantity, dailyIntake) {
+export function calculateDaysRemaining(totalQuantity: number, dailyIntake: number): number {
   if (dailyIntake <= 0) return Infinity
   return Math.floor(totalQuantity / dailyIntake)
 }
@@ -346,23 +395,28 @@ export function calculateDaysRemaining(totalQuantity, dailyIntake) {
  * @param {Array} protocols - Protocolos ativos
  * @returns {Object} { takenDoses: [], missedDoses: [], scheduledDoses: [] }
  */
-export function calculateDosesByDate(date, logs, protocols, now = getNow()) {
+export function calculateDosesByDate(
+  date: string,
+  logs: AdherenceLog[] | null | undefined,
+  protocols: AdherenceProtocol[] | null | undefined,
+  now: Date = getNow()
+): { takenDoses: DoseRecord[]; missedDoses: DoseRecord[]; scheduledDoses: DoseRecord[] } {
   if (!date || !protocols || protocols.length === 0) {
     return { takenDoses: [], missedDoses: [], scheduledDoses: [] }
   }
 
-  const takenDoses = []
-  const missedDoses = []
-  const scheduledDoses = []
+  const takenDoses: DoseRecord[] = []
+  const missedDoses: DoseRecord[] = []
+  const scheduledDoses: DoseRecord[] = []
 
   // Filtrar protocolos aplicáveis para esta data
-  const applicableProtocols = protocols.filter((p) => isProtocolActiveOnDate(p, date))
+  const applicableProtocols = protocols.filter((p: AdherenceProtocol) => isProtocolActiveOnDate(p, date))
 
   // Gerar slots de doses esperados para cada protocolo aplicável
-  const expectedDoses = []
-  applicableProtocols.forEach((protocol) => {
+  const expectedDoses: ExpectedDoseSlot[] = []
+  applicableProtocols.forEach((protocol: AdherenceProtocol) => {
     const schedule = protocol.time_schedule || []
-    schedule.forEach((time) => {
+    schedule.forEach((time: string) => {
       expectedDoses.push({
         protocolId: protocol.id,
         medicineId: protocol.medicine_id,
@@ -448,7 +502,7 @@ export function calculateDosesByDate(date, logs, protocols, now = getNow()) {
   // Logs restantes que não correspondem a nenhuma dose esperada
   // (doses extras, fora do horário, etc.) - adicionar como takenDoses
   unmatchedLogs.forEach((log) => {
-    const protocol = protocols.find((p) => p.id === log.protocol_id)
+    const protocol = protocols.find((p: AdherenceProtocol) => p.id === log.protocol_id)
     takenDoses.push({
       ...log,
       scheduledTime: null,
@@ -472,12 +526,16 @@ export function calculateDosesByDate(date, logs, protocols, now = getNow()) {
  * @param {Date} now - Hora atual de referência
  * @returns {Array} Array único e ordenado de doses com a propriedade timelineStatus
  */
-export function evaluateDoseTimelineState(date, dosesObj, now = getNow()) {
+export function evaluateDoseTimelineState(
+  date: string,
+  dosesObj: { takenDoses?: DoseRecord[]; missedDoses?: DoseRecord[]; scheduledDoses?: DoseRecord[] },
+  now: Date = getNow()
+): DoseRecord[] {
   const { takenDoses = [], missedDoses = [], scheduledDoses = [] } = dosesObj
   const nowMs = now.getTime()
 
   // Helper para criar Date consistente
-  const createScheduledDate = (timeStr) => {
+  const createScheduledDate = (timeStr: string) => {
     const [h, m] = timeStr.split(':').map(Number)
     const d = parseLocalDate(date)
     d.setHours(h, m, 0, 0)
@@ -486,11 +544,11 @@ export function evaluateDoseTimelineState(date, dosesObj, now = getNow()) {
 
   const allDoses = [
     // 1. TOMADAS (Independente do horário)
-    ...takenDoses.map((d) => ({ ...d, timelineStatus: 'TOMADA', isRegistered: true })),
+    ...takenDoses.map((d: DoseRecord) => ({ ...d, timelineStatus: 'TOMADA', isRegistered: true })),
 
     // 2. MISSES (No passado)
-    ...missedDoses.map((d) => {
-      const scheduledDate = createScheduledDate(d.scheduledTime)
+    ...missedDoses.map((d: DoseRecord) => {
+      const scheduledDate = createScheduledDate(d.scheduledTime ?? '00:00')
       const diffMs = nowMs - scheduledDate.getTime()
 
       // Se passou menos de 2h do horário agendado, ainda é ATRASADA
@@ -500,8 +558,8 @@ export function evaluateDoseTimelineState(date, dosesObj, now = getNow()) {
     }),
 
     // 3. SCHEDULED (No futuro)
-    ...scheduledDoses.map((d) => {
-      const scheduledDate = createScheduledDate(d.scheduledTime)
+    ...scheduledDoses.map((d: DoseRecord) => {
+      const scheduledDate = createScheduledDate(d.scheduledTime ?? '00:00')
       const diffMs = scheduledDate.getTime() - nowMs
 
       // Se falta menos de 2h para o horário agendado, é PROXIMA (Aviso prévio)
@@ -513,7 +571,7 @@ export function evaluateDoseTimelineState(date, dosesObj, now = getNow()) {
 
   // Ordenar por horário agendado (cronológico)
   return allDoses.sort((a, b) => {
-    const getTime = (d) => d.scheduledTime || (d.taken_at ? parseISO(d.taken_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false }) : '00:00')
+    const getTime = (d: DoseRecord) => d.scheduledTime || (d.taken_at ? parseISO(d.taken_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false }) : '00:00')
     return getTime(a).localeCompare(getTime(b))
   })
 }
@@ -535,7 +593,7 @@ const WEEKLY_DAY_MAP = {
  * @param {Object} protocol - O objeto do protocolo
  * @returns {string[]} Array com os dias da semana ativos
  */
-export function getProtocolDays(protocol) {
+export function getProtocolDays(protocol: AdherenceProtocol | null | undefined): string[] {
   if (!protocol) return []
   if (Array.isArray(protocol.weekdays) && protocol.weekdays.length > 0) {
     return protocol.weekdays
@@ -552,10 +610,10 @@ export function getProtocolDays(protocol) {
  * @param {number} dayOfWeek - Dia da semana (0=Domingo, 6=Sábado)
  * @returns {boolean}
  */
-function _isWeeklyMatch(protocol, dayOfWeek) {
+function _isWeeklyMatch(protocol: AdherenceProtocol, dayOfWeek: number): boolean {
   const daysArray = getProtocolDays(protocol)
   if (!daysArray || !Array.isArray(daysArray)) return false
-  return daysArray.some((day) => WEEKLY_DAY_MAP[day.toLowerCase()] === dayOfWeek)
+  return daysArray.some((day: string) => WEEKLY_DAY_MAP[day.toLowerCase() as keyof typeof WEEKLY_DAY_MAP] === dayOfWeek)
 }
 
 
@@ -565,7 +623,7 @@ function _isWeeklyMatch(protocol, dayOfWeek) {
  * @param {Date} targetDate - Data alvo
  * @returns {boolean}
  */
-function _isAlternatingMatch(protocol, targetDate) {
+function _isAlternatingMatch(protocol: AdherenceProtocol, targetDate: Date): boolean {
   if (!protocol.start_date) return true // Sem data de início, assume início hoje
   const startDate = parseLocalDate(protocol.start_date)
   return daysDifference(startDate, targetDate) % 2 === 0
@@ -577,7 +635,7 @@ function _isAlternatingMatch(protocol, targetDate) {
  * @param {Date} targetDate - Data alvo
  * @returns {boolean}
  */
-function _isHistoricalActive(protocol, targetDate) {
+function _isHistoricalActive(protocol: AdherenceProtocol, targetDate: Date): boolean {
   return Boolean(protocol.end_date && targetDate <= parseLocalDate(protocol.end_date))
 }
 
@@ -592,7 +650,7 @@ function _isHistoricalActive(protocol, targetDate) {
  * @param {string|Date} date - Data alvo (YYYY-MM-DD ou Date object)
  * @returns {boolean}
  */
-export function isProtocolActiveOnDate(protocol, date) {
+export function isProtocolActiveOnDate(protocol: AdherenceProtocol, date: string | Date): boolean {
   const dateStr = typeof date === 'string' ? date : formatLocalDate(date)
   const targetDate = parseLocalDate(dateStr)
   const dayOfWeek = targetDate.getDay() // 0=Domingo, 1=Segunda, etc.
@@ -609,7 +667,7 @@ export function isProtocolActiveOnDate(protocol, date) {
 }
 
 /** @type {Map<string, (protocol: Object, dayOfWeek: number, targetDate: Date) => boolean>} */
-const FREQUENCY_MATCHERS = new Map([
+const FREQUENCY_MATCHERS = new Map<string, (protocol: AdherenceProtocol, dayOfWeek: number, targetDate: Date) => boolean>([
   ['diário', () => true],
   ['diariamente', () => true],
   ['daily', () => true],
@@ -636,7 +694,7 @@ const FREQUENCY_MATCHERS = new Map([
  * @param {Date} targetDate - Data alvo
  * @returns {boolean}
  */
-function _matchesFrequency(frequency, protocol, dayOfWeek, targetDate) {
+function _matchesFrequency(frequency: string, protocol: AdherenceProtocol, dayOfWeek: number, targetDate: Date): boolean {
   const matcher = FREQUENCY_MATCHERS.get(frequency)
   if (matcher) return matcher(protocol, dayOfWeek, targetDate)
   return true // default: assume ativo
@@ -671,12 +729,12 @@ export const INSTANCE_STATUS = Object.freeze({
 })
 
 /** Número finito ou fallback (R-104: `??`/isFinite, nunca `||` — 0 é dose válida). */
-function _numOrFallback(value, fallback) {
-  return Number.isFinite(value) ? value : fallback
+function _numOrFallback(value: number | null | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
 }
 
 /** Limita x a [0, 1]. */
-function _clamp01(x) {
+function _clamp01(x: number): number {
   return Math.max(0, Math.min(1, x))
 }
 
@@ -700,7 +758,7 @@ function _clamp01(x) {
  * @param {string} [opts.mode='binary'] - ver ADHERENCE_MODE
  * @returns {{taken:number, missed:number, pending:number, skipped:number, rate:(number|null)}}
  */
-function processInstance(inst, stats) {
+function processInstance(inst: DoseInstance, stats: { taken: number; missed: number; pending: number; skipped: number; sumApplied: number; sumExpected: number }): void {
   const status = inst?.status
   const expected = _numOrFallback(inst?.expected_dose, 0)
 
@@ -724,7 +782,7 @@ function processInstance(inst, stats) {
   }
 }
 
-export function computeAdherenceFromInstances(instances, { mode = ADHERENCE_MODE.BINARY }: { mode?: string } = {}) {
+export function computeAdherenceFromInstances(instances: DoseInstance[] | null | undefined, { mode = ADHERENCE_MODE.BINARY }: { mode?: string } = {}) {
   const list = Array.isArray(instances) ? instances : []
 
   const stats = {
@@ -784,7 +842,7 @@ export function computeAdherenceFromInstances(instances, { mode = ADHERENCE_MODE
  * @returns {number} dias de streak
  */
 export function computeStreakFromInstances(
-  instances,
+  instances: DoseInstance[] | null | undefined,
   { tz = 'America/Sao_Paulo', today, minAdherenceRate = 0.8 }: { tz?: string; today?: string; minAdherenceRate?: number } = {}
 ) {
   const byDay = _buildDayStatusMap(instances, tz)
@@ -796,6 +854,7 @@ export function computeStreakFromInstances(
   let streak = 0
   for (const key of days) {
     const entry = byDay.get(key)
+    if (!entry) continue
     const expected = entry.taken + entry.missed
     if (expected === 0) continue // dia neutro (skipped-only / sem dose)
     if (entry.taken / expected >= minAdherenceRate) {
@@ -816,7 +875,7 @@ export function computeStreakFromInstances(
  * @param {string} tz
  * @returns {Map<string, {missed: number, taken: number}>}
  */
-function _buildDayStatusMap(instances, tz) {
+function _buildDayStatusMap(instances: DoseInstance[] | null | undefined, tz: string): Map<string, { missed: number; taken: number }> {
   const list = Array.isArray(instances) ? instances : []
   const byDay = new Map()
   for (const inst of list) {
@@ -847,7 +906,7 @@ function _buildDayStatusMap(instances, tz) {
  * @returns {number} maior streak
  */
 export function computeLongestStreakFromInstances(
-  instances,
+  instances: DoseInstance[] | null | undefined,
   { tz = 'America/Sao_Paulo', minAdherenceRate = 0.8 } = {}
 ) {
   const byDay = _buildDayStatusMap(instances, tz)
@@ -857,6 +916,7 @@ export function computeLongestStreakFromInstances(
   let run = 0
   for (const key of days) {
     const entry = byDay.get(key)
+    if (!entry) continue
     const expected = entry.taken + entry.missed
     if (expected === 0) continue // dia neutro: mantém run
     if (entry.taken / expected >= minAdherenceRate) {

--- a/packages/core/src/utils/adherenceLogic.ts
+++ b/packages/core/src/utils/adherenceLogic.ts
@@ -176,8 +176,9 @@ export function isProtocolFollowed(scheduledTime: string, logs: AdherenceLog[] |
   if (!scheduledTime || !logs || logs.length === 0) return false
 
   return logs.some((log) => {
+    if (!log.taken_at) return false
     // 1. Verificar se o log é do mesmo dia local
-    const logDateStr = formatLocalDate(getSaoPauloTime(parseISO(log.taken_at ?? '')))
+    const logDateStr = formatLocalDate(getSaoPauloTime(parseISO(log.taken_at)))
 
     if (logDateStr !== dateStr) return false
 

--- a/packages/core/src/utils/biomarkerDisplay.ts
+++ b/packages/core/src/utils/biomarkerDisplay.ts
@@ -10,7 +10,7 @@ import {
 } from '../schemas/biomarkerLogSchema'
 
 // Número PT-BR (ponto → vírgula). Não força casas decimais.
-function ptBR(n) {
+function ptBR(n: number): string {
   return String(n).replace('.', ',')
 }
 
@@ -22,7 +22,13 @@ function ptBR(n) {
  * @param {{value:number, value_secondary?:number|null, unit:string}} item
  * @returns {string}
  */
-export function formatBiomarkerDisplay(item) {
+interface BiomarkerMeasure {
+  value: number
+  value_secondary?: number | null
+  unit: string
+}
+
+export function formatBiomarkerDisplay(item: BiomarkerMeasure | null | undefined): string {
   if (!item || item.value == null) return ''
   const v = ptBR(item.value)
   if (item.value_secondary != null) {
@@ -38,9 +44,13 @@ export function formatBiomarkerDisplay(item) {
  * @param {string|null|undefined} context
  * @returns {string|null}
  */
-export function formatBiomarkerContext(context) {
+export function formatBiomarkerContext(context: string | null | undefined): string | null {
   if (!context) return null
-  return BIOMARKER_CONTEXT_LABELS[context] ?? BIOMARKER_PA_CONTEXT_LABELS[context] ?? null
+  return (
+    BIOMARKER_CONTEXT_LABELS[context as keyof typeof BIOMARKER_CONTEXT_LABELS] ??
+    BIOMARKER_PA_CONTEXT_LABELS[context as keyof typeof BIOMARKER_PA_CONTEXT_LABELS] ??
+    null
+  )
 }
 
 /**
@@ -50,6 +60,10 @@ export function formatBiomarkerContext(context) {
  * @param {string} type
  * @returns {string}
  */
-export function biomarkerCardLabel(type) {
-  return BIOMARKER_TYPE_SHORT_LABELS[type] ?? BIOMARKER_TYPE_LABELS[type] ?? type
+export function biomarkerCardLabel(type: string): string {
+  return (
+    BIOMARKER_TYPE_SHORT_LABELS[type as keyof typeof BIOMARKER_TYPE_SHORT_LABELS] ??
+    BIOMARKER_TYPE_LABELS[type as keyof typeof BIOMARKER_TYPE_LABELS] ??
+    type
+  )
 }

--- a/packages/core/src/utils/dateFormat.ts
+++ b/packages/core/src/utils/dateFormat.ts
@@ -12,7 +12,7 @@ const MONTHS_PT_BR = [
 
 // Aceita Date | timestamp ISO completo (com hora). Hermes sem ICU → NÃO usar
 // toLocale*; parse manual via parseISO (timestamp) e tabela de meses.
-function toLocalDate(input) {
+function toLocalDate(input: Date | string): Date | null {
   if (input instanceof Date) return input
   if (typeof input === 'string') return parseISO(input)
   return null
@@ -22,7 +22,7 @@ function toLocalDate(input) {
  * Formata um timestamp (Date|ISO com hora) para "HH:MM" 24h.
  * @example formatTimePtBR('2026-03-12T08:05:00Z') → '08:05'
  */
-export function formatTimePtBR(input) {
+export function formatTimePtBR(input: Date | string): string {
   const d = toLocalDate(input)
   if (!(d instanceof Date) || Number.isNaN(d.getTime())) return ''
   return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
@@ -32,7 +32,7 @@ export function formatTimePtBR(input) {
  * Formata um timestamp (Date|ISO com hora) para "DD mmm · HH:MM" PT-BR lowercase.
  * @example formatDateTimePtBR('2026-03-12T08:05:00Z') → '12 mar · 08:05'
  */
-export function formatDateTimePtBR(input) {
+export function formatDateTimePtBR(input: Date | string): string {
   const d = toLocalDate(input)
   if (!(d instanceof Date) || Number.isNaN(d.getTime())) return ''
   const day = String(d.getDate()).padStart(2, '0')
@@ -46,7 +46,7 @@ export function formatDateTimePtBR(input) {
  * com múltiplas entradas por dia ao longo da semana.
  * @example formatDateTimeShortPtBR('2026-03-12T08:05:00Z') → '12/mar · 08:05'
  */
-export function formatDateTimeShortPtBR(input) {
+export function formatDateTimeShortPtBR(input: Date | string): string {
   const d = toLocalDate(input)
   if (!(d instanceof Date) || Number.isNaN(d.getTime())) return ''
   const day = String(d.getDate()).padStart(2, '0')
@@ -60,7 +60,7 @@ export function formatDateTimeShortPtBR(input) {
  * @example formatDatePtBR('2026-03-12') → '12 mar 2026'
  * @example formatDatePtBR(null)         → ''
  */
-export function formatDatePtBR(isoDate) {
+export function formatDatePtBR(isoDate: string | Date | null | undefined): string {
   if (!isoDate) return ''
   const d = typeof isoDate === 'string' ? parseLocalDate(isoDate) : isoDate
   if (!(d instanceof Date) || Number.isNaN(d.getTime())) return ''
@@ -77,7 +77,7 @@ export function formatDatePtBR(isoDate) {
  * @example formatDateShortPtBR('2026-03-12') → '12/03/26'
  * @example formatDateShortPtBR(null)         → ''
  */
-export function formatDateShortPtBR(isoDate) {
+export function formatDateShortPtBR(isoDate: string | Date | null | undefined): string {
   if (!isoDate) return ''
   const d = typeof isoDate === 'string' ? parseLocalDate(isoDate) : isoDate
   if (!(d instanceof Date) || Number.isNaN(d.getTime())) return ''
@@ -93,7 +93,7 @@ export function formatDateShortPtBR(isoDate) {
  * @example formatEndDate(null)         → 'Uso contínuo'
  * @example formatEndDate('2026-12-31') → '31 dez 2026'
  */
-export function formatEndDate(isoDate) {
+export function formatEndDate(isoDate: string | Date | null | undefined): string {
   if (!isoDate) return 'Uso contínuo'
   return formatDatePtBR(isoDate)
 }

--- a/packages/core/src/utils/dateUtils.ts
+++ b/packages/core/src/utils/dateUtils.ts
@@ -16,7 +16,7 @@
  * @param {string} dateStr - Data no formato YYYY-MM-DD
  * @returns {Date} Date object em timezone local (meia-noite local)
  */
-export function parseLocalDate(dateStr) {
+export function parseLocalDate(dateStr: string): Date {
   return new Date(dateStr + 'T00:00:00')
 }
 
@@ -25,7 +25,7 @@ export function parseLocalDate(dateStr) {
  * @param {Date} date - Date object
  * @returns {string} Data no formato YYYY-MM-DD
  */
-export function formatLocalDate(date) {
+export function formatLocalDate(date: Date): string {
   const year = date.getFullYear()
   const month = String(date.getMonth() + 1).padStart(2, '0')
   const day = String(date.getDate()).padStart(2, '0')
@@ -40,7 +40,12 @@ export function formatLocalDate(date) {
  * @param {string|Date} date - Data a verificar (string YYYY-MM-DD ou Date object)
  * @returns {boolean} True se o protocolo estava ativo na data
  */
-export function isProtocolActiveOnDate(protocol, date) {
+interface ProtocolDateRange {
+  start_date?: string | null
+  end_date?: string | null
+}
+
+export function isProtocolActiveOnDate(protocol: ProtocolDateRange, date: string | Date): boolean {
   // Converte para Date em timezone local
   const currentDate = typeof date === 'string' ? parseLocalDate(date) : date
 
@@ -65,7 +70,7 @@ export function isProtocolActiveOnDate(protocol, date) {
  * @param {string} [tz='America/Sao_Paulo'] - Timezone IANA opcional (default São Paulo)
  * @returns {string} Data de hoje no formato YYYY-MM-DD
  */
-export function getTodayLocal(tz = 'America/Sao_Paulo') {
+export function getTodayLocal(tz = 'America/Sao_Paulo'): string {
   return formatLocalDate(getUserTime(new Date(), tz))
 }
 
@@ -74,7 +79,7 @@ export function getTodayLocal(tz = 'America/Sao_Paulo') {
  * @param {string} [tz='America/Sao_Paulo'] - Timezone IANA opcional (default São Paulo)
  * @returns {string} Data de ontem no formato YYYY-MM-DD
  */
-export function getYesterdayLocal(tz = 'America/Sao_Paulo') {
+export function getYesterdayLocal(tz = 'America/Sao_Paulo'): string {
   const yesterday = getUserTime(new Date(), tz)
   yesterday.setDate(yesterday.getDate() - 1)
   return formatLocalDate(yesterday)
@@ -86,7 +91,7 @@ export function getYesterdayLocal(tz = 'America/Sao_Paulo') {
  * @param {number} days - Número de dias a adicionar (pode ser negativo)
  * @returns {Date} Nova data em timezone local
  */
-export function addDays(date, days) {
+export function addDays(date: Date | string, days: number): Date {
   const baseDate = typeof date === 'string' ? parseLocalDate(date) : new Date(date)
   baseDate.setDate(baseDate.getDate() + days)
   return baseDate
@@ -98,7 +103,7 @@ export function addDays(date, days) {
  * @param {Date|string} date2 - Segunda data
  * @returns {number} Diferença em dias (positivo se date2 > date1)
  */
-export function daysDifference(date1, date2) {
+export function daysDifference(date1: Date | string, date2: Date | string): number {
   const d1 = typeof date1 === 'string' ? parseLocalDate(date1) : date1
   const d2 = typeof date2 === 'string' ? parseLocalDate(date2) : date2
   const diffTime = d2.getTime() - d1.getTime()
@@ -109,7 +114,7 @@ export function daysDifference(date1, date2) {
  * @param {string} timeStr - Horário no formato HH:mm
  * @returns {'Madrugada'|'Manhã'|'Tarde'|'Noite'}
  */
-export function getPeriodFromTime(timeStr) {
+export function getPeriodFromTime(timeStr: string): 'Madrugada' | 'Manhã' | 'Tarde' | 'Noite' {
   if (!timeStr) return 'Manhã'
   const [h] = timeStr.split(':').map(Number)
   if (h >= 5 && h < 12) return 'Manhã'
@@ -123,7 +128,7 @@ export function getPeriodFromTime(timeStr) {
  * @param {string} [tz='America/Sao_Paulo'] - Timezone IANA opcional (default São Paulo)
  * @returns {Date}
  */
-export function getNow(tz = 'America/Sao_Paulo') {
+export function getNow(tz = 'America/Sao_Paulo'): Date {
   return getUserTime(new Date(), tz)
 }
 
@@ -132,7 +137,7 @@ export function getNow(tz = 'America/Sao_Paulo') {
  * Útil para timers e momentos que serão processados por outras funções de fuso.
  * @returns {Date}
  */
-export function getRawNow() {
+export function getRawNow(): Date {
   return new Date()
 }
 
@@ -140,7 +145,7 @@ export function getRawNow() {
  * Retorna o timestamp atual em formato ISO (UTC)
  * @returns {string} ISO 8601 string
  */
-export function getServerTimestamp() {
+export function getServerTimestamp(): string {
   return new Date().toISOString()
 }
 
@@ -171,7 +176,7 @@ export function parseISOOrNull(value: string | number | Date | null | undefined)
  * @param {string} [tz='America/Sao_Paulo'] - Timezone IANA opcional (default São Paulo)
  * @returns {string} ISO 8601 string (UTC)
  */
-export function getStartOfDayISO(dateStr, tz = 'America/Sao_Paulo') {
+export function getStartOfDayISO(dateStr: string, tz = 'America/Sao_Paulo'): string {
   const d = new Date(dateStr + 'T00:00:00Z')
   // Descobrir o offset do fuso para esta data específica.
   // Reusa getUserTime (Intl.DateTimeFormat + formatToParts) em vez de
@@ -188,7 +193,7 @@ export function getStartOfDayISO(dateStr, tz = 'America/Sao_Paulo') {
  * @param {string} [tz='America/Sao_Paulo'] - Timezone IANA opcional (default São Paulo)
  * @returns {string} ISO 8601 string (UTC)
  */
-export function getEndOfDayISO(dateStr, tz = 'America/Sao_Paulo') {
+export function getEndOfDayISO(dateStr: string, tz = 'America/Sao_Paulo'): string {
   const start = new Date(getStartOfDayISO(dateStr, tz))
   return new Date(start.getTime() + 24 * 60 * 60 * 1000 - 1).toISOString()
 }
@@ -204,7 +209,7 @@ export function getEndOfDayISO(dateStr, tz = 'America/Sao_Paulo') {
  * @param {string} [tz='America/Sao_Paulo'] - Timezone IANA (ex: 'America/New_York')
  * @returns {Date}
  */
-export function getUserTime(date = new Date(), tz = 'America/Sao_Paulo') {
+export function getUserTime(date: Date = new Date(), tz = 'America/Sao_Paulo'): Date {
   const formatter = new Intl.DateTimeFormat('en-GB', {
     timeZone: tz,
     year: 'numeric',
@@ -246,7 +251,7 @@ export function getUserTime(date = new Date(), tz = 'America/Sao_Paulo') {
  * @param {Date} [date] - Data base (default: agora)
  * @returns {Date}
  */
-export function getSaoPauloTime(date = new Date()) {
+export function getSaoPauloTime(date: Date = new Date()): Date {
   return getUserTime(date, 'America/Sao_Paulo')
 }
 
@@ -255,7 +260,7 @@ export function getSaoPauloTime(date = new Date()) {
  * @param {Date} date 
  * @returns {Date}
  */
-export function cloneDate(date) {
+export function cloneDate(date: Date): Date {
   return new Date(date.getTime())
 }
 
@@ -265,7 +270,7 @@ export function cloneDate(date) {
  * @param {number} months - Número de meses a adicionar (pode ser negativo)
  * @returns {Date} Nova data
  */
-export function addMonths(date, months) {
+export function addMonths(date: Date | string, months: number): Date {
   const baseDate = typeof date === 'string' ? parseLocalDate(date) : cloneDate(date)
   baseDate.setDate(1) // Seta dia 1 para evitar problemas com meses curtos
   baseDate.setMonth(baseDate.getMonth() + months)
@@ -278,7 +283,7 @@ export function addMonths(date, months) {
  * @param {number} month - 0-11
  * @returns {number}
  */
-export function getLastDayOfMonth(year, month) {
+export function getLastDayOfMonth(year: number, month: number): number {
   return new Date(Date.UTC(year, month + 1, 0)).getUTCDate()
 }
 
@@ -287,7 +292,7 @@ export function getLastDayOfMonth(year, month) {
  * @param {string} datetimeStr 
  * @returns {Date}
  */
-export function parseLocalDatetime(datetimeStr) {
+export function parseLocalDatetime(datetimeStr: string): Date {
   if (!datetimeStr) return getNow()
   // Adiciona segundos e offset de Brasília se não houver
   const fullStr = datetimeStr.length === 16 ? `${datetimeStr}:00-03:00` : datetimeStr
@@ -299,7 +304,7 @@ export function parseLocalDatetime(datetimeStr) {
  * @param {number|string} timestamp 
  * @returns {Date}
  */
-export function parseTimestamp(timestamp) {
+export function parseTimestamp(timestamp: number | string): Date {
   if (!timestamp) return getNow()
   return new Date(Number(timestamp))
 }

--- a/packages/core/src/utils/doseActivityState.ts
+++ b/packages/core/src/utils/doseActivityState.ts
@@ -34,7 +34,45 @@ export const DOSE_ACTIVITY_STATES = Object.freeze({
   LATE: 'late', // atrasada (>10min depois, dentro da tolerância) — count-up
   DONE: 'done', // registrada — superfície encerra (cancel-on-resolve)
   MISSED: 'missed', // passou da tolerância sem registro — terminal
-})
+} as const)
+
+export type DoseActivityStateValue = (typeof DOSE_ACTIVITY_STATES)[keyof typeof DOSE_ACTIVITY_STATES]
+
+interface DoseActivityItemInput {
+  scheduledFor?: string | Date | null
+  scheduled_for?: string | Date | null
+  isRegistered?: boolean
+  status?: string
+  toleranceMinutes?: number | null
+  tolerance_minutes?: number | null
+  instanceId?: string | null
+  id?: string | null
+  treatmentPlanId?: string | null
+  treatment_plan_id?: string | null
+  critical?: boolean
+  critical_alarm?: boolean
+  medicineName?: string | null
+  medicine?: { name?: string | null } | null
+}
+
+interface SurfaceWindows {
+  laterMinutes: number
+  upcomingMinutes: number
+  lateMinutes: number
+  nowBeforeMinutes: number
+  nowAfterMinutes: number
+}
+
+export interface DoseActivityState {
+  state: DoseActivityStateValue
+  instanceId: string | null
+  treatmentId: string | null
+  scheduledFor: string | Date | null
+  remainingSeconds: number | null
+  isCritical: boolean
+  isRegistered: boolean
+  medicineLabel: string
+}
 
 /**
  * Janelas (minutos até a dose, `d = scheduled - now`; + futuro, − passado) da máquina de estados
@@ -78,12 +116,12 @@ const SURFACE_WINDOWS = Object.freeze({
  * acoplar o chamador a uma única forma.
  * @private
  */
-function pick(item, camel, snake) {
-  return item[camel] ?? item[snake] ?? null
+function pick<T>(item: DoseActivityItemInput, camel: keyof DoseActivityItemInput, snake: keyof DoseActivityItemInput): T | null {
+  return ((item[camel] as T | null | undefined) ?? (item[snake] as T | null | undefined) ?? null)
 }
 
 /** Instante é válido se presente e parseável. @private */
-function instantMs(scheduledFor) {
+function instantMs(scheduledFor: string | Date | null | undefined): number | null {
   if (!scheduledFor) return null
   const ms = scheduledFor instanceof Date ? scheduledFor.getTime() : parseISO(scheduledFor).getTime()
   return Number.isNaN(ms) ? null : ms
@@ -93,7 +131,7 @@ function instantMs(scheduledFor) {
  * Normaliza `now` (Date OU ISO string; paridade com splitDayTimeline/CON-024). Date inválido /
  * string não-parseável → getRawNow() (R-020, evita RangeError no Intl). @private
  */
-function resolveNow(now) {
+function resolveNow(now: Date | string | null | undefined): Date {
   const d = now instanceof Date ? now : now ? parseISO(now) : getRawNow()
   return Number.isNaN(d.getTime()) ? getRawNow() : d
 }
@@ -104,7 +142,11 @@ function resolveNow(now) {
  * (dose distante demais, d ≥ later). `missed` quando passou da tolerância.
  * @private
  */
-function resolveSurfaceState(diffMinutes, toleranceMinutes, w) {
+function resolveSurfaceState(
+  diffMinutes: number,
+  toleranceMinutes: number | null | undefined,
+  w: SurfaceWindows
+): DoseActivityStateValue | null {
   const tol = toleranceMinutes ?? w.lateMinutes // tolerância da ocorrência > fallback (lateMinutes)
   if (diffMinutes >= w.laterMinutes) return null // distante demais → sem superfície
   if (diffMinutes >= w.upcomingMinutes) return DOSE_ACTIVITY_STATES.LATER
@@ -132,32 +174,37 @@ function resolveSurfaceState(diffMinutes, toleranceMinutes, w) {
  *   upcomingMinutes, lateMinutes, nowBeforeMinutes, nowAfterMinutes
  * @returns {DoseActivityState|null} null = sem superfície
  */
-export function deriveDoseActivityState(item, now = getRawNow(), opts = {}) {
+export function deriveDoseActivityState(
+  item: DoseActivityItemInput | null | undefined,
+  now: Date | string = getRawNow(),
+  opts: Partial<SurfaceWindows> = {}
+): DoseActivityState | null {
   if (!item) return null
 
   const nowDate = resolveNow(now)
-  const scheduledFor = pick(item, 'scheduledFor', 'scheduled_for')
+  const scheduledFor = pick<string | Date>(item, 'scheduledFor', 'scheduled_for')
   const isRegistered = item.isRegistered === true || item.status === 'taken'
-  const toleranceMinutes = pick(item, 'toleranceMinutes', 'tolerance_minutes')
+  const toleranceMinutes = pick<number>(item, 'toleranceMinutes', 'tolerance_minutes')
   const ms = instantMs(scheduledFor)
 
-  let state
+  let state: DoseActivityStateValue
   if (isRegistered) {
     state = DOSE_ACTIVITY_STATES.DONE
   } else {
     if (ms === null) return null // instante inválido/ausente → sem superfície
     const diffMinutes = (ms - nowDate.getTime()) / 60000
     const w = { ...SURFACE_WINDOWS, ...opts }
-    state = resolveSurfaceState(diffMinutes, toleranceMinutes, w)
-    if (state === null) return null // distante demais → sem superfície
+    const resolved = resolveSurfaceState(diffMinutes, toleranceMinutes, w)
+    if (resolved === null) return null // distante demais → sem superfície
+    state = resolved
   }
 
   const remainingSeconds = ms === null ? null : Math.round((ms - nowDate.getTime()) / 1000)
 
   return {
     state,
-    instanceId: pick(item, 'instanceId', 'id'),
-    treatmentId: pick(item, 'treatmentPlanId', 'treatment_plan_id'),
+    instanceId: pick<string>(item, 'instanceId', 'id'),
+    treatmentId: pick<string>(item, 'treatmentPlanId', 'treatment_plan_id'),
     scheduledFor,
     remainingSeconds,
     isCritical: item.critical === true || item.critical_alarm === true,
@@ -177,7 +224,11 @@ export function deriveDoseActivityState(item, now = getRawNow(), opts = {}) {
  * @param {Object} [opts] - override das janelas (mesmo de deriveDoseActivityState)
  * @returns {number[]} timestamps absolutos (ms) ordenados asc; [] se instante inválido
  */
-export function doseActivityBoundaryTimes(scheduledFor, toleranceMinutes = null, opts = {}) {
+export function doseActivityBoundaryTimes(
+  scheduledFor: string | Date | null | undefined,
+  toleranceMinutes: number | null = null,
+  opts: Partial<SurfaceWindows> = {}
+): number[] {
   const ms = instantMs(scheduledFor)
   if (ms === null) return []
   const w = { ...SURFACE_WINDOWS, ...opts }
@@ -198,7 +249,7 @@ export function doseActivityBoundaryTimes(scheduledFor, toleranceMinutes = null,
  * terminais — não competem (a superfície encerra ou nem aparece).
  * @private
  */
-const ACTIONABLE = new Set([
+const ACTIONABLE: Set<DoseActivityStateValue> = new Set([
   DOSE_ACTIVITY_STATES.LATE,
   DOSE_ACTIVITY_STATES.NOW,
   DOSE_ACTIVITY_STATES.UPCOMING,
@@ -211,7 +262,7 @@ const ACTIONABLE = new Set([
  * `late` (uma dose atrasada é o sinal mais urgente, crítica ou não).
  * @private
  */
-function priorityRank(s) {
+function priorityRank(s: DoseActivityState): number {
   if (s.state === DOSE_ACTIVITY_STATES.LATE) return 0
   if (s.isCritical) return 1
   if (s.state === DOSE_ACTIVITY_STATES.NOW) return 2
@@ -238,7 +289,7 @@ function priorityRank(s) {
  * `c` vence `winner`? Maior prioridade; empate → mais urgente (menor remainingSeconds;
  * null por último). @private
  */
-function beats(c, winner) {
+function beats(c: DoseActivityState, winner: DoseActivityState): boolean {
   const dr = priorityRank(c) - priorityRank(winner)
   if (dr !== 0) return dr < 0
   const cr = c.remainingSeconds ?? Number.POSITIVE_INFINITY
@@ -246,10 +297,14 @@ function beats(c, winner) {
   return cr < wr
 }
 
-export function selectActiveDoseActivity(items, now = getRawNow(), opts = {}) {
+export function selectActiveDoseActivity(
+  items: DoseActivityItemInput[],
+  now: Date | string = getRawNow(),
+  opts: Partial<SurfaceWindows> = {}
+): (DoseActivityState & { groupSize: number }) | null {
   if (!Array.isArray(items) || items.length === 0) return null
 
-  const candidates = []
+  const candidates: DoseActivityState[] = []
   for (const item of items) {
     const st = deriveDoseActivityState(item, now, opts)
     if (st && ACTIONABLE.has(st.state)) candidates.push(st)

--- a/packages/core/src/utils/doseInstanceGenerator.ts
+++ b/packages/core/src/utils/doseInstanceGenerator.ts
@@ -26,7 +26,30 @@ import {
   parseTimestamp,
 } from './dateUtils'
 import { isProtocolActiveOnDate } from './adherenceLogic'
-import { resolveTitrationStageAt } from './titrationUtils'
+
+interface GeneratorProtocol extends TitrationProtocol {
+  id?: string
+  user_id?: string
+  frequency?: string | null
+  time_schedule?: string[] | null
+  dosage_per_intake?: number | null
+  critical_alarm?: boolean | null
+  start_date?: string | null
+  end_date?: string | null
+  active?: boolean
+  weekdays?: string[] | null
+  days?: string[] | null
+}
+
+type GeneratedInstance = {
+  user_id?: string
+  protocol_id?: string
+  scheduled_for: string
+  expected_dose: number
+  tolerance_minutes: number
+  critical_alarm: boolean
+}
+import { resolveTitrationStageAt, TitrationProtocol } from './titrationUtils'
 
 /**
  * Converte Date | ISO string | timestamp(ms) num Date absoluto.
@@ -34,7 +57,7 @@ import { resolveTitrationStageAt } from './titrationUtils'
  * @param {Date|string|number} value
  * @returns {Date}
  */
-function toInstant(value) {
+function toInstant(value: Date | string | number): Date {
   if (value instanceof Date) return value
   if (typeof value === 'number') return parseTimestamp(value)
   return parseISO(value)
@@ -53,7 +76,7 @@ const MAX_TOLERANCE_MINUTES = 120
  * não-diária (ADR-061/FR-007): a janela de perdão clínica de uma dose semanal
  * é dias, não horas. Frequências fora do mapa (personalizado etc.) mantêm 120.
  */
-const FREQUENCY_PERIOD_MINUTES = {
+const FREQUENCY_PERIOD_MINUTES: Record<string, number> = {
   semanal: 10080,
   semanalmente: 10080,
   weekly: 10080,
@@ -68,7 +91,7 @@ const FREQUENCY_PERIOD_MINUTES = {
  * @param {string} time
  * @returns {number|null}
  */
-function timeToMinutes(time) {
+function timeToMinutes(time: string): number | null {
   if (typeof time !== 'string') return null
   const [h, m] = time.split(':').map(Number)
   if (Number.isNaN(h) || Number.isNaN(m)) return null
@@ -94,7 +117,7 @@ function timeToMinutes(time) {
  * @param {string} frequency - frequência normalizada (lowercase) do protocolo
  * @returns {number[]} tolerância por slot (mesma ordem de sortedMinutes)
  */
-function computeTolerances(sortedMinutes, frequency) {
+function computeTolerances(sortedMinutes: number[], frequency: string): number[] {
   const isDaily = DAILY_FREQUENCIES.has(frequency)
   const periodMinutes = isDaily ? 1440 : FREQUENCY_PERIOD_MINUTES[frequency]
   // Sem período conhecido (personalizado etc.): comportamento legado, 120 fixo.
@@ -104,7 +127,7 @@ function computeTolerances(sortedMinutes, frequency) {
     return sortedMinutes.map(() => MAX_TOLERANCE_MINUTES)
   }
   const len = sortedMinutes.length
-  return sortedMinutes.map((minute, i) => {
+  return sortedMinutes.map((minute: number, i: number) => {
     // Para o 1º/último slot, o intervalo adjacente cruza o período (wrap-around):
     // diário = meia-noite; semanal/alternados = próxima ocorrência do ciclo.
     const prevGap = i > 0
@@ -129,7 +152,7 @@ function computeTolerances(sortedMinutes, frequency) {
  * @param {string} tz
  * @returns {string} ISO 8601 UTC
  */
-function buildScheduledFor(dateStr, minutesOfDay, tz) {
+function buildScheduledFor(dateStr: string, minutesOfDay: number, tz: string): string {
   const startOfDayMs = parseISO(getStartOfDayISO(dateStr, tz)).getTime()
   return parseTimestamp(startOfDayMs + minutesOfDay * 60 * 1000).toISOString()
 }
@@ -141,8 +164,8 @@ function buildScheduledFor(dateStr, minutesOfDay, tz) {
  * @param {string} tz
  * @returns {string[]}
  */
-function localDateRange(fromDate, toDate, tz) {
-  const dates = []
+function localDateRange(fromDate: Date, toDate: Date, tz: string): string[] {
+  const dates: string[] = []
   // Itera em UTC (T00:00:00Z + setUTCDate): imune a DST e ao fuso do ambiente de
   // execução (servidor Vercel ou device móvel em fuso arbitrário). UTC não tem
   // transições, então cada incremento é exatamente 24h. parseISO mantém R-020.
@@ -170,7 +193,12 @@ function localDateRange(fromDate, toDate, tz) {
  *                  expected_dose: number, tolerance_minutes: number}>}
  *          Ordenadas por scheduled_for; só dentro de [fromTs, toTs].
  */
-export function generateInstances(protocol, fromTs, toTs, tz = 'America/Sao_Paulo') {
+export function generateInstances(
+  protocol: GeneratorProtocol | null | undefined,
+  fromTs: Date | string | number,
+  toTs: Date | string | number,
+  tz = 'America/Sao_Paulo'
+): GeneratedInstance[] {
   if (!protocol || !protocol.id) return []
 
   const frequency = (protocol.frequency || 'diário').toLowerCase()
@@ -190,14 +218,14 @@ export function generateInstances(protocol, fromTs, toTs, tz = 'America/Sao_Paul
 
   // Slots do dia, ordenados, com tolerância pré-computada (estável dia a dia).
   const slots = schedule
-    .map((t) => ({ time: t, minutes: timeToMinutes(t) }))
-    .filter((s) => s.minutes !== null)
+    .map((t: string) => ({ time: t, minutes: timeToMinutes(t) }))
+    .filter((s): s is { time: string; minutes: number } => s.minutes !== null)
     .sort((a, b) => a.minutes - b.minutes)
   if (slots.length === 0) return []
 
   const tolerances = computeTolerances(slots.map((s) => s.minutes), frequency)
 
-  const instances = []
+  const instances: GeneratedInstance[] = []
   for (const dateStr of localDateRange(fromDate, toDate, tz)) {
     if (!isProtocolActiveOnDate(protocol, dateStr)) continue
     slots.forEach((slot, i) => {

--- a/packages/core/src/utils/doseUnit.ts
+++ b/packages/core/src/utils/doseUnit.ts
@@ -14,11 +14,27 @@
 
 import { DOSAGE_UNIT_LABELS } from '../schemas/medicineSchema'
 import { cleanFloat } from './formUtils'
+
+interface MedicineLike {
+  dosage_unit?: string | null
+  dosage_per_pill?: number | string | null
+  units_per_ml?: number | string | null
+  concentration_volume_ml?: number | string | null
+}
+
+interface DoseItemLike {
+  dosagePerIntake?: number | string
+  intakeUnit?: string | null
+  dosageUnit?: string | null
+  dosagePerPill?: number | string | null
+  unitsPerMl?: number | string | null
+}
+
 /**
  * Converte string ou número para número de forma segura.
  * @private
  */
-function parseNumber(val) {
+function parseNumber(val: number | string | null | undefined): number {
   if (typeof val === 'string') {
     return Number(val.replace(',', '.'))
   }
@@ -29,9 +45,9 @@ function parseNumber(val) {
  * Formata a parte líquida quando volumeMl não é nulo/1.
  * @private
  */
-function formatLiquidConcentration(ratio, vol, unit) {
+function formatLiquidConcentration(ratio: number, vol: number, unit: string | null | undefined): string {
   const baseUnit = (unit || 'mg/ml').split('/')[0]
-  const baseLabel = DOSAGE_UNIT_LABELS[baseUnit] || baseUnit
+  const baseLabel = DOSAGE_UNIT_LABELS[baseUnit as keyof typeof DOSAGE_UNIT_LABELS] || baseUnit
   return `${formatNumberPtBR(cleanFloat(ratio * vol))} ${baseLabel} / ${formatNumberPtBR(vol)}ml`
 }
 
@@ -39,8 +55,8 @@ function formatLiquidConcentration(ratio, vol, unit) {
  * Obtém o rótulo de dosagem formatado.
  * @private
  */
-function getConcentrationLabel(v, unit) {
-  const label = DOSAGE_UNIT_LABELS[unit] || unit || ''
+function getConcentrationLabel(v: string, unit: string | null | undefined): string {
+  const label = (unit && DOSAGE_UNIT_LABELS[unit as keyof typeof DOSAGE_UNIT_LABELS]) || unit || ''
   return label ? `${v} ${label}` : v
 }
 
@@ -60,7 +76,11 @@ function getConcentrationLabel(v, unit) {
  * @param {number|string|null} [volumeMl=null] - concentration_volume_ml (denominador do rótulo)
  * @returns {string} ex: '100 UI/ml' · '500 mg' · '2,5 mg / 0,5 mL' · '' se value vazio
  */
-export function formatConcentration(value, unit, volumeMl = null) {
+export function formatConcentration(
+  value: number | string | null | undefined,
+  unit: string | null | undefined,
+  volumeMl: number | string | null = null
+): string {
   if (value === undefined || value === null || value === '') return ''
   const ratio = parseNumber(value)
   const vol = parseNumber(volumeMl)
@@ -87,7 +107,7 @@ export function formatConcentration(value, unit, volumeMl = null) {
  * @param {{dosage_per_pill?: number|string|null, dosage_unit?: string|null, concentration_volume_ml?: number|string|null}|null} medicine
  * @returns {string}
  */
-export function formatMedicineConcentration(medicine) {
+export function formatMedicineConcentration(medicine: MedicineLike | null | undefined): string {
   if (!medicine) return ''
   return formatConcentration(
     medicine.dosage_per_pill,
@@ -104,7 +124,7 @@ export function formatMedicineConcentration(medicine) {
  * @param {{dosage_unit?: string}|null} medicine
  * @returns {boolean}
  */
-export function isLiquidMedicine(medicine) {
+export function isLiquidMedicine(medicine: { dosage_unit?: string | null } | null | undefined): boolean {
   return Boolean(medicine?.dosage_unit?.endsWith('/ml'))
 }
 
@@ -115,7 +135,7 @@ export function isLiquidMedicine(medicine) {
  * @param {{dosage_unit?: string}|null} medicine
  * @returns {'ml'|'un.'}
  */
-export function stockUnitLabel(medicine) {
+export function stockUnitLabel(medicine: { dosage_unit?: string | null } | null | undefined): 'ml' | 'un.' {
   return isLiquidMedicine(medicine) ? 'ml' : 'un.'
 }
 
@@ -130,7 +150,7 @@ export function stockUnitLabel(medicine) {
  * @example formatStockCount(30, {dosage_unit:'mg/ml'}) → '30 ml'
  * @example formatStockCount(30, {dosage_unit:'mg'})    → '30 unidades'
  */
-export function formatStockCount(qty, medicine) {
+export function formatStockCount(qty: number | string, medicine: { dosage_unit?: string | null } | null | undefined): string {
   if (isLiquidMedicine(medicine)) return formatDose(qty, 'ml')
   return formatDoseUnit(qty)
 }
@@ -143,7 +163,7 @@ export function formatStockCount(qty, medicine) {
  * @param {{dosage_unit?: string, dosage_per_pill?: number}|null} medicine
  * @returns {string}
  */
-export function formatStockQuantity(qty, medicine) {
+export function formatStockQuantity(qty: number | string, medicine: MedicineLike | null | undefined): string {
   if (isLiquidMedicine(medicine)) return formatDose(qty, 'ml')
   return (
     formatActiveIngredientHint(qty, medicine?.dosage_per_pill, medicine?.dosage_unit) ||
@@ -190,7 +210,11 @@ export function formatConcentrationLabel(mgPerMl: number | string | null, volume
  * @example formatStockApplications(1.5, 0.37, null)    → '≈ 4 aplicações'
  * @example formatStockApplications(10, 0, 'caneta')    → '10 ml'
  */
-export function formatStockApplications(mlRemaining, mlPerApplication, containerSingular) {
+export function formatStockApplications(
+  mlRemaining: number | string,
+  mlPerApplication: number | string,
+  containerSingular: string | null
+): string {
   const ml = Number(typeof mlRemaining === 'string' ? mlRemaining.replace(',', '.') : mlRemaining)
   const perApp = Number(
     typeof mlPerApplication === 'string' ? mlPerApplication.replace(',', '.') : mlPerApplication
@@ -208,7 +232,7 @@ export function formatStockApplications(mlRemaining, mlPerApplication, container
  * Plural simples de rótulos de container PT-BR (caneta→canetas, frasco→frascos,
  * aplicação→aplicações). Regra mínima: termina em vogal → +s; em 'ão' → 'ões'.
  */
-function pluralizeContainer(singular) {
+function pluralizeContainer(singular: string): string {
   if (singular.endsWith('ão')) return `${singular.slice(0, -2)}ões`
   return `${singular}s`
 }
@@ -223,7 +247,7 @@ function pluralizeContainer(singular) {
  * @example pluralizeDoseUnit('1') → 'unidade'
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- assinatura legada (2º arg ignorado)
-export function pluralizeDoseUnit(qty, _legacyUnit?: string) {
+export function pluralizeDoseUnit(qty: number | string, _legacyUnit?: string): string {
   return Number(qty) === 1 ? 'unidade' : 'unidades'
 }
 
@@ -236,7 +260,7 @@ export function pluralizeDoseUnit(qty, _legacyUnit?: string) {
  * @example formatNumberPtBR(1.5)    → '1,5'
  * @example formatNumberPtBR(15000)  → '15.000'
  */
-export function formatNumberPtBR(num) {
+export function formatNumberPtBR(num: number | string | null | undefined): string {
   if (num == null) return ''
   const normalized = typeof num === 'string' ? num.replace(',', '.') : num
   if (isNaN(Number(normalized))) return ''
@@ -255,7 +279,7 @@ export function formatNumberPtBR(num) {
  * @example formatDoseUnit(0.5)  → '0,5 unidades'
  * @example formatDoseUnit(15.5) → '15,5 unidades'
  */
-export function formatDoseUnit(qty) {
+export function formatDoseUnit(qty: number | string): string {
   const display = formatNumberPtBR(qty)
   return `${display} ${pluralizeDoseUnit(qty)}`
 }
@@ -271,7 +295,7 @@ export function formatDoseUnit(qty) {
  * @example formatDose(10, 'UI')    → '10 UI'
  * @example formatDose(null, 'ml')  → ''
  */
-export function formatDose(value, unit) {
+export function formatDose(value: number | string | null | undefined, unit: string | null | undefined): string {
   if (value === undefined || value === null) return ''
   const v = formatNumberPtBR(value)
   if (v === '') return ''
@@ -312,7 +336,7 @@ export function formatDose(value, unit) {
  * @param {number|string|null} unitsPerMl - densidade explícita do cadastro
  * @returns {number|null} densidade a aplicar, ou null se indefinível
  */
-export function densityFor(intakeUnit, unitsPerMl) {
+export function densityFor(intakeUnit: string | null | undefined, unitsPerMl: number | string | null | undefined): number | null {
   const explicit = Number(typeof unitsPerMl === 'string' ? unitsPerMl.replace(',', '.') : unitsPerMl)
   if (explicit > 0) return explicit
   switch ((intakeUnit || '').toLowerCase()) {
@@ -322,7 +346,7 @@ export function densityFor(intakeUnit, unitsPerMl) {
   }
 }
 
-export function formatIntakeDose(qty, intakeUnit, medicine) {
+export function formatIntakeDose(qty: number | string, intakeUnit: string | null | undefined, medicine: MedicineLike | null | undefined): string {
   const isLiquid = Boolean(medicine?.dosage_unit?.endsWith('/ml'))
   if (!isLiquid) {
     return (
@@ -341,7 +365,7 @@ export function formatIntakeDose(qty, intakeUnit, medicine) {
   const divisor =
     intake === 'mg'
       ? Number(medicine?.dosage_per_pill) > 0
-        ? Number(medicine.dosage_per_pill)
+        ? Number(medicine?.dosage_per_pill)
         : null
       : densityFor(intake, medicine?.units_per_ml)
   if (!divisor) return base // sem concentração/densidade não há como exibir ≈ml
@@ -360,7 +384,7 @@ export function formatIntakeDose(qty, intakeUnit, medicine) {
  * @param {{dosage_unit?: string, dosage_per_pill?: number, units_per_ml?: number}|null} medicine
  * @returns {string}
  */
-export function formatDoseHint(qty, intakeUnit, medicine) {
+export function formatDoseHint(qty: number | string, intakeUnit: string | null | undefined, medicine: MedicineLike | null | undefined): string {
   if (isLiquidMedicine(medicine)) return formatIntakeDose(qty, intakeUnit, medicine)
   return formatActiveIngredientFormula(qty, medicine?.dosage_per_pill, medicine?.dosage_unit)
 }
@@ -373,7 +397,7 @@ export function formatDoseHint(qty, intakeUnit, medicine) {
  * @param {{dosagePerIntake?: number, intakeUnit?: string|null, dosageUnit?: string|null, dosagePerPill?: number|null, unitsPerMl?: number|null}} item
  * @returns {string}
  */
-export function formatDoseItem(item) {
+export function formatDoseItem(item: DoseItemLike | null | undefined): string {
   if (!item) return ''
   return formatIntakeDose(item.dosagePerIntake ?? 1, item.intakeUnit, {
     dosage_unit: item.dosageUnit,
@@ -390,7 +414,7 @@ export function formatDoseItem(item) {
  * @example formatActiveIngredientShort(1.5, 100, 'ui')  → '150 UI'
  * @example formatActiveIngredientShort(3, 1, 'gotas')  → ''
  */
-function convertMetricUnit(total, unit) {
+function convertMetricUnit(total: number, unit: string | null | undefined): { total: number; currentUnit: string | null | undefined } {
   if (total >= 5000) {
     if (unit === 'mcg') return { total: total / 1000, currentUnit: 'mg' }
     if (unit === 'mg') return { total: total / 1000, currentUnit: 'g' }
@@ -400,20 +424,21 @@ function convertMetricUnit(total, unit) {
   return { total, currentUnit: unit }
 }
 
-export function formatActiveIngredientShort(qty, dosagePerPill, unit) {
+export function formatActiveIngredientShort(qty: number | string | null | undefined, dosagePerPill: number | string | null | undefined, unit: string | null | undefined): string {
   if (
     qty == null ||
     qty === '' ||
     isNaN(Number(String(qty).replace(',', '.'))) ||
     dosagePerPill == null ||
-    dosagePerPill <= 0
+    Number(dosagePerPill) <= 0
   ) {
     return ''
   }
   const qtyNum = Number(String(qty).replace(',', '.'))
+  const dosagePerPillNum = Number(dosagePerPill)
   // cleanFloat no produto (R-277): formatNumberPtBR não arredonda, então o artefato
   // de float (1,5×0,1=0,15000000000000002) vazaria pro chip de estoque (AP-226).
-  const { total, currentUnit } = convertMetricUnit(cleanFloat(qtyNum * dosagePerPill), unit)
+  const { total, currentUnit } = convertMetricUnit(cleanFloat(qtyNum * dosagePerPillNum), unit)
 
   const displayTotal = formatNumberPtBR(total)
 
@@ -429,7 +454,7 @@ export function formatActiveIngredientShort(qty, dosagePerPill, unit) {
     gotas: total === 1 ? 'gota' : 'gotas',
   }
 
-  const displayTotalUnit = totalUnitLabels[currentUnit] || currentUnit || ''
+  const displayTotalUnit = (currentUnit && totalUnitLabels[currentUnit as keyof typeof totalUnitLabels]) || currentUnit || ''
 
   // Se o próprio medicamento for medido em unidades ou gotas e a dosagem unitária for 1,
   // a quantidade física já é a quantidade ativa (ex: "3 gotas"). Não precisa de concentração separada.
@@ -449,7 +474,7 @@ export function formatActiveIngredientShort(qty, dosagePerPill, unit) {
  * @example formatActiveIngredientHint(3, 1, 'gotas') → '3 gotas'
  * @example formatActiveIngredientHint(1, 1, 'un')    → '1 unidade'
  */
-export function formatActiveIngredientHint(qty, dosagePerPill, unit) {
+export function formatActiveIngredientHint(qty: number | string | null | undefined, dosagePerPill: number | string | null | undefined, unit: string | null | undefined): string {
   if (
     qty == null ||
     qty === '' ||
@@ -470,7 +495,7 @@ export function formatActiveIngredientHint(qty, dosagePerPill, unit) {
     gotas: qtyNum === 1 ? 'gota' : 'gotas',
   }
 
-  const displayUnit = unitLabels[unit] || 'un.'
+  const displayUnit = (unit && unitLabels[unit as keyof typeof unitLabels]) || 'un.'
 
   // Se o próprio medicamento for medido em unidades ou gotas e a dosagem unitária for 1
   if ((unit === 'un' || unit === 'gotas') && (dosagePerPill == null || dosagePerPill === 1)) {
@@ -500,7 +525,7 @@ export function formatActiveIngredientHint(qty, dosagePerPill, unit) {
  * @example formatActiveIngredientFormula(1.5, 100, 'ui') → 'Equivale a 150 UI'
  * @example formatActiveIngredientFormula(3, 1, 'gotas') → 'Equivale a 3 gotas'
  */
-export function formatActiveIngredientFormula(qty, dosagePerPill, unit) {
+export function formatActiveIngredientFormula(qty: number | string | null | undefined, dosagePerPill: number | string | null | undefined, unit: string | null | undefined): string {
   if (
     qty == null ||
     qty === '' ||
@@ -522,7 +547,7 @@ export function formatActiveIngredientFormula(qty, dosagePerPill, unit) {
     gotas: qtyNum === 1 ? 'gota' : 'gotas',
   }
 
-  const displayUnit = unitLabels[unit] || 'un.'
+  const displayUnit = (unit && unitLabels[unit as keyof typeof unitLabels]) || 'un.'
 
   if ((unit === 'un' || unit === 'gotas') && (dosagePerPill == null || dosagePerPill === 1)) {
     return `Equivale a ${displayQty} ${displayUnit}`

--- a/packages/core/src/utils/doseZones.ts
+++ b/packages/core/src/utils/doseZones.ts
@@ -46,6 +46,43 @@ const TAKEN_STATUS = 'taken'
 /** Status que não devem aparecer no "hoje" (pulados não são pendência). */
 const SKIPPED_STATUS = new Set(['skipped_paused', 'skipped_user'])
 
+interface DoseZoneMedicine {
+  name?: string | null
+  type?: string | null
+  presentation?: string | null
+  dosage_per_pill?: number | null
+  dosage_unit?: string | null
+  concentration_volume_ml?: number | null
+  units_per_ml?: number | null
+}
+
+interface DoseZoneTreatmentPlan {
+  name?: string | null
+  emoji?: string | null
+  color?: string | null
+}
+
+export interface DoseZoneProtocol {
+  id?: string
+  medicine?: DoseZoneMedicine | null
+  medicine_id?: string | null
+  intake_unit?: string | null
+  dosage_per_intake?: number | null
+  treatment_plan_id?: string | null
+  treatment_plan?: DoseZoneTreatmentPlan | null
+}
+
+export interface DoseZoneInstance {
+  id?: string
+  protocol_id?: string
+  scheduled_for?: string | null
+  status?: string
+  tolerance_minutes?: number | null
+  expected_dose?: number | null
+  critical_alarm?: boolean
+  snoozed_until?: string | null
+}
+
 /**
  * Tipo DoseItem — Representa uma ocorrência de dose do dia.
  * @typedef {Object} DoseItem
@@ -115,7 +152,7 @@ export function classifyDose(
  * Cria o badge do plano de tratamento.
  * @private
  */
-function getPlanBadge(plan) {
+function getPlanBadge(plan: DoseZoneTreatmentPlan | null | undefined) {
   if (!plan) return null
   return {
     emoji: plan.emoji || '📋',
@@ -127,7 +164,7 @@ function getPlanBadge(plan) {
  * Formata "HH:MM" local a partir de um instante absoluto, no tz informado.
  * @private
  */
-function toLocalHHMM(scheduledFor, tz) {
+function toLocalHHMM(scheduledFor: string, tz: string) {
   const parsed = parseISO(scheduledFor)
   // Date inválido → fallback amigável (getUserTime/Intl estoura em Invalid Date).
   if (Number.isNaN(parsed.getTime())) return '--:--'
@@ -141,7 +178,7 @@ function toLocalHHMM(scheduledFor, tz) {
  * Mapeia propriedades e fallbacks do medicamento.
  * @private
  */
-function getMedicineDetails(medicine) {
+function getMedicineDetails(medicine: DoseZoneMedicine | null | undefined) {
   const med = medicine || {}
   return {
     name: med.name || 'Desconhecido',
@@ -158,7 +195,7 @@ function getMedicineDetails(medicine) {
  * Cria um DoseItem a partir de uma dose_instance e do protocolo correspondente.
  * @private
  */
-function createDoseItem(instance, protocol, tz) {
+function createDoseItem(instance: DoseZoneInstance, protocol: DoseZoneProtocol, tz: string) {
   const med = getMedicineDetails(protocol.medicine)
   const isRegistered = instance.status === TAKEN_STATUS
   return {
@@ -177,7 +214,7 @@ function createDoseItem(instance, protocol, tz) {
     // p/ exibir dose na unidade certa (gotas/ml/UI) e converter p/ ml.
     intakeUnit: protocol.intake_unit ?? null,
     unitsPerMl: med.units_per_ml,
-    scheduledTime: toLocalHHMM(instance.scheduled_for, tz),
+    scheduledTime: toLocalHHMM(instance.scheduled_for ?? '', tz),
     scheduledFor: instance.scheduled_for,
     toleranceMinutes: instance.tolerance_minutes ?? null,
     status: instance.status,
@@ -202,14 +239,18 @@ function createDoseItem(instance, protocol, tz) {
  * @param {string} [tz=DEFAULT_TZ]
  * @returns {DoseItem[]}
  */
-export function buildDoseItemsFromInstances(instances, protocols, tz = DEFAULT_TZ) {
+export function buildDoseItemsFromInstances(
+  instances: DoseZoneInstance[],
+  protocols: DoseZoneProtocol[],
+  tz = DEFAULT_TZ
+) {
   if (!Array.isArray(instances) || instances.length === 0) return []
   const protocolsList = Array.isArray(protocols) ? protocols : []
   const byId = new Map(protocolsList.filter(Boolean).map((p) => [p.id, p]))
 
   const doses = []
   for (const inst of instances) {
-    if (!inst?.scheduled_for || SKIPPED_STATUS.has(inst.status)) continue
+    if (!inst?.scheduled_for || (inst.status && SKIPPED_STATUS.has(inst.status))) continue
     const protocol = byId.get(inst.protocol_id)
     if (!protocol) continue
     doses.push(createDoseItem(inst, protocol, tz))
@@ -244,7 +285,12 @@ export function buildDoseItemsFromInstances(instances, protocols, tz = DEFAULT_T
  * @param {{ now: Date, tz?: string }} opts
  * @returns {{ carryOver: DoseItem[], today: DoseItem[], lookAhead: DoseItem[] }}
  */
-function classifyInstanceDay(inst, dayStart, dayEnd, nowMs) {
+function classifyInstanceDay(
+  inst: DoseZoneInstance,
+  dayStart: number,
+  dayEnd: number,
+  nowMs: number
+): 'today' | 'carry' | 'ahead' | null {
   if (!inst?.scheduled_for) return null
   const t = parseISO(inst.scheduled_for).getTime()
   if (Number.isNaN(t)) return null
@@ -271,7 +317,7 @@ function classifyInstanceDay(inst, dayStart, dayEnd, nowMs) {
  * @param {string} [tz]
  * @returns {string|null} null = mesmo dia; 'ontem'; 'há N dias'
  */
-export function daysAgoLabel(scheduledFor, now, tz = DEFAULT_TZ) {
+export function daysAgoLabel(scheduledFor: string | Date | null | undefined, now: Date, tz = DEFAULT_TZ) {
   if (!scheduledFor || !(now instanceof Date)) return null
   const sched = scheduledFor instanceof Date ? scheduledFor : parseISO(scheduledFor)
   if (Number.isNaN(sched.getTime()) || Number.isNaN(now.getTime())) return null
@@ -284,7 +330,11 @@ export function daysAgoLabel(scheduledFor, now, tz = DEFAULT_TZ) {
   return days === 1 ? 'ontem' : `há ${days} dias`
 }
 
-export function splitDayTimeline(instances, protocols, { now, tz = DEFAULT_TZ }: { now?: Date | string; tz?: string } = {}) {
+export function splitDayTimeline(
+  instances: DoseZoneInstance[],
+  protocols: DoseZoneProtocol[],
+  { now, tz = DEFAULT_TZ }: { now?: Date | string; tz?: string } = {}
+) {
   const list = Array.isArray(instances) ? instances : []
   // `now` ausente/inválido → fallback p/ getRawNow (respeita offset dev) + guard NaN:
   // getUserTime usa Intl e estoura RangeError em Invalid Date (AP-194/PR #623).

--- a/packages/core/src/utils/formUtils.ts
+++ b/packages/core/src/utils/formUtils.ts
@@ -1,4 +1,8 @@
-export const getFieldDescribedBy = (fieldName, errors, hintId = null) =>
+export const getFieldDescribedBy = (
+  fieldName: string,
+  errors: Record<string, unknown> | null | undefined,
+  hintId: string | null = null
+): string | undefined =>
   [hintId, errors?.[fieldName] ? `${fieldName}-error` : null].filter(Boolean).join(' ') || undefined
 
 /**
@@ -9,7 +13,8 @@ export const getFieldDescribedBy = (fieldName, errors, hintId = null) =>
  * @param {string|number|null|undefined} value
  * @returns {number} NaN quando vazio/ inválido (deixa a validação decidir)
  */
-export const coerceDecimal = (value) => parseFloat(String(value ?? '').replace(',', '.'))
+export const coerceDecimal = (value: string | number | null | undefined): number =>
+  parseFloat(String(value ?? '').replace(',', '.'))
 
 /**
  * Limpa artefatos de ponto flutuante do JS (012 Fase B3; review Gemini #661).
@@ -22,7 +27,7 @@ export const coerceDecimal = (value) => parseFloat(String(value ?? '').replace('
  * @returns {number}
  * @example cleanFloat(1.2 * 0.3) → 0.36
  */
-export const cleanFloat = (value) => {
+export const cleanFloat = (value: number | string | null | undefined): number => {
   const n = Number(value)
   return Number.isFinite(n) ? parseFloat(n.toPrecision(12)) : n
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -60,6 +60,7 @@ export {
   ADHERENCE_MODE,
   INSTANCE_STATUS,
 } from './adherenceLogic'
+export type { AdherenceProtocol } from './adherenceLogic'
 
 // Dose instance generation engine (ADR-048, Fase 2)
 export {

--- a/packages/core/src/utils/injectionSites.ts
+++ b/packages/core/src/utils/injectionSites.ts
@@ -48,7 +48,7 @@ const SITE_ABSORPTION = Object.fromEntries(INJECTION_SITES.map((s) => [s.value, 
  * @param {string|null|undefined} value
  * @returns {string|null} label PT, ou null quando value é vazio/null
  */
-export function getInjectionSiteLabel(value) {
+export function getInjectionSiteLabel(value: string | null | undefined): string | null {
   if (!value) return null
   return SITE_LABELS[value] ?? value
 }
@@ -58,7 +58,7 @@ export function getInjectionSiteLabel(value) {
  * @param {string|null|undefined} value
  * @returns {string|null}
  */
-export function getInjectionSiteAbsorption(value) {
+export function getInjectionSiteAbsorption(value: string | null | undefined): string | null {
   if (!value) return null
   return SITE_ABSORPTION[value] ?? null
 }
@@ -70,6 +70,6 @@ export function getInjectionSiteAbsorption(value) {
  * @param {{ presentation?: string|null }|null|undefined} medicine
  * @returns {boolean}
  */
-export function isInjectable(medicine) {
+export function isInjectable(medicine: { presentation?: string | null } | null | undefined): boolean {
   return medicine?.presentation === 'injetavel'
 }

--- a/packages/core/src/utils/medicineIcon.ts
+++ b/packages/core/src/utils/medicineIcon.ts
@@ -27,11 +27,19 @@ export const SUPPLEMENT_ICON = 'pill-bottle'
  * @param {{type?: string, presentation?: string|null, dosage_unit?: string|null}|null} medicine
  * @returns {'pill'|'tablets'|'droplets'|'syringe'|'soap-dispenser-droplet'|'spray-can'|'pill-bottle'}
  */
-export function getMedicineIconName(medicine) {
+interface MedicineIconInput {
+  type?: string
+  presentation?: string | null
+  dosage_unit?: string | null
+}
+
+export function getMedicineIconName(medicine: MedicineIconInput | null | undefined): string {
   if (!medicine) return 'pill'
   if (medicine.type === 'suplemento') return SUPPLEMENT_ICON
 
-  const byPresentation = MEDICINE_ICON_BY_PRESENTATION[medicine.presentation]
+  const byPresentation = medicine.presentation
+    ? MEDICINE_ICON_BY_PRESENTATION[medicine.presentation as keyof typeof MEDICINE_ICON_BY_PRESENTATION]
+    : undefined
   if (byPresentation) return byPresentation
 
   // Legado sem presentation: líquido derivado da unidade (decisão-mãe 022).

--- a/packages/core/src/utils/notificationIconMapper.ts
+++ b/packages/core/src/utils/notificationIconMapper.ts
@@ -7,7 +7,13 @@ import { parseISO } from './dateUtils'
  * @param {string} type - Valor do campo notification_type no DB
  * @returns {{ iconName: string, color: string, bgColor: string, label: string, deepLinkAction: string|null }}
  */
-export function getNotificationIcon(type) {
+export function getNotificationIcon(type: string): {
+  iconName: string
+  color: string
+  bgColor: string
+  label: string
+  deepLinkAction: string | null
+} {
   const map = {
     dose_reminder: {
       iconName: 'Pill',
@@ -73,7 +79,7 @@ export function getNotificationIcon(type) {
       deepLinkAction: 'stats-monthly',
     },
   }
-  return map[type] ?? {
+  return map[type as keyof typeof map] ?? {
     iconName: 'Bell',
     color: '#6b7280',
     bgColor: 'rgba(107, 114, 128, 0.10)',
@@ -88,7 +94,7 @@ export function getNotificationIcon(type) {
  * @param {string} isoString - Data ISO do campo sent_at
  * @returns {string}
  */
-export function formatRelativeTime(isoString) {
+export function formatRelativeTime(isoString: string): string {
   if (!isoString) return ''
   const now = Date.now()
   const then = parseISO(isoString).getTime()

--- a/packages/core/src/utils/nudgeScheduler.ts
+++ b/packages/core/src/utils/nudgeScheduler.ts
@@ -7,11 +7,30 @@
 import { satisfiesSemver } from './semver'
 import { getNow, parseISO } from './dateUtils'
 
+export interface Nudge {
+  id: string
+  version?: string
+  platform?: 'ios' | 'android' | 'web' | 'all'
+  start_at?: string | null
+  end_at?: string | null
+  min_app_version?: string | null
+  max_app_version?: string | null
+  priority?: number | null
+  [key: string]: unknown
+}
+
+interface BuildNudgeListOpts {
+  platform?: 'ios' | 'android' | 'web'
+  appVersion?: string | null
+  dismissed?: Set<string>
+  now?: Date
+}
+
 /**
  * Chave de dismiss para um nudge (remote ou local).
  * Formato: "<id>:<version>"
  */
-export function dismissKey(nudge) {
+export function dismissKey(nudge: Nudge): string {
   return `${nudge.id}:${nudge.version}`
 }
 
@@ -20,7 +39,7 @@ export function dismissKey(nudge) {
  * @param {object[]} nudges
  * @param {'ios'|'android'|'web'} platform
  */
-function filterByPlatform(nudges, platform) {
+function filterByPlatform(nudges: Nudge[], platform: string | undefined): Nudge[] {
   if (!platform) return nudges
   return nudges.filter((n) => n.platform === 'all' || n.platform === platform)
 }
@@ -30,7 +49,7 @@ function filterByPlatform(nudges, platform) {
  * @param {object[]} nudges
  * @param {Date} now
  */
-function filterByDates(nudges, now) {
+function filterByDates(nudges: Nudge[], now: Date): Nudge[] {
   return nudges.filter((n) => {
     if (n.start_at && parseISO(n.start_at) > now) return false
     if (n.end_at && parseISO(n.end_at) < now) return false
@@ -43,10 +62,10 @@ function filterByDates(nudges, now) {
  * @param {object[]} nudges
  * @param {string|null} appVersion  ex: "0.3.4"
  */
-function filterByVersion(nudges, appVersion) {
+function filterByVersion(nudges: Nudge[], appVersion: string | null | undefined): Nudge[] {
   if (!appVersion) return nudges
   return nudges.filter((n) =>
-    satisfiesSemver(appVersion, n.min_app_version, n.max_app_version)
+    satisfiesSemver(appVersion, n.min_app_version ?? null, n.max_app_version ?? null)
   )
 }
 
@@ -56,14 +75,14 @@ function filterByVersion(nudges, appVersion) {
  * @param {object[]} nudges
  * @param {Set<string>} dismissed  conjunto de chaves já lidas do storage
  */
-function filterDismissed(nudges, dismissed) {
+function filterDismissed(nudges: Nudge[], dismissed: Set<string>): Nudge[] {
   return nudges.filter((n) => !dismissed.has(dismissKey(n)))
 }
 
 /**
  * Ordena por prioridade decrescente; empate mantém ordem original.
  */
-function sortByPriority(nudges) {
+function sortByPriority(nudges: Nudge[]): Nudge[] {
   return [...nudges].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0))
 }
 
@@ -80,17 +99,17 @@ function sortByPriority(nudges) {
  *
  * @returns {object[]} nudges ordenados por prioridade, prontos para exibição
  */
-export function buildNudgeList(remoteNudges, localNudges, opts) {
+export function buildNudgeList(remoteNudges: Nudge[] | null | undefined, localNudges: Nudge[] | null | undefined, opts: BuildNudgeListOpts | null | undefined): Nudge[] {
   const {
     platform,
     appVersion = null,
-    dismissed = new Set(),
+    dismissed = new Set<string>(),
     now = getNow(),
   } = opts ?? {}
 
   const all = [...(remoteNudges ?? []), ...(localNudges ?? [])]
 
-  const pipeline = [
+  const pipeline: Array<(n: Nudge[]) => Nudge[]> = [
     (n) => filterByPlatform(n, platform),
     (n) => filterByDates(n, now),
     (n) => filterByVersion(n, appVersion),

--- a/packages/core/src/utils/prescriptionStatus.ts
+++ b/packages/core/src/utils/prescriptionStatus.ts
@@ -42,7 +42,12 @@ const MS_PER_DAY = 86400000
  * @param {Date} [now] — referência temporal; default = agora (America/Sao_Paulo)
  * @returns {'ativa'|'vencendo'|'vencida'|'finalizada'}
  */
-export function derivePrescriptionStatus(protocol, now = getNow()) {
+interface PrescriptionStatusProtocol {
+  end_date?: string | null
+  active?: boolean | null
+}
+
+export function derivePrescriptionStatus(protocol: PrescriptionStatusProtocol | null | undefined, now = getNow()): string {
   if (!protocol?.end_date) return PRESCRIPTION_STATUS.ATIVA
   const end = parseLocalDate(protocol.end_date)
   // Meia-noite local de hoje, sem `new Date()` (R-020): formata→reparse.

--- a/packages/core/src/utils/profile.ts
+++ b/packages/core/src/utils/profile.ts
@@ -15,7 +15,7 @@ import { parseLocalDate, getSaoPauloTime } from './dateUtils'
  * @param {string|null|undefined} birthDate - YYYY-MM-DD
  * @returns {number|null} idade em anos, ou null se ausente/inválida
  */
-export function calculateAge(birthDate) {
+export function calculateAge(birthDate: string | null | undefined): number | null {
   if (!birthDate) return null
   try {
     const birth = parseLocalDate(birthDate)
@@ -37,7 +37,7 @@ export function calculateAge(birthDate) {
  * @param {string|null|undefined} name
  * @returns {string}
  */
-export function getInitials(name) {
+export function getInitials(name: string | null | undefined): string {
   if (!name || typeof name !== 'string') return ''
   return name
     .trim()

--- a/packages/core/src/utils/semver.ts
+++ b/packages/core/src/utils/semver.ts
@@ -4,7 +4,7 @@
  * Ignora pre-release e build metadata.
  */
 
-function parseSemver(version) {
+function parseSemver(version: string | null | undefined): number[] | null {
   if (!version || typeof version !== 'string') return null
   const clean = version.trim().split('-')[0].split('+')[0]
   const parts = clean.split('.')
@@ -20,7 +20,7 @@ function parseSemver(version) {
  * Retorna -1 se a < b, 0 se a == b, 1 se a > b.
  * Retorna null se alguma versão for inválida.
  */
-export function compareSemver(a, b) {
+export function compareSemver(a: string | null | undefined, b: string | null | undefined): number | null {
   const pa = parseSemver(a)
   const pb = parseSemver(b)
   if (!pa || !pb) return null
@@ -36,7 +36,11 @@ export function compareSemver(a, b) {
  * `min` e `max` são opcionais (null/undefined = sem limite).
  * Retorna false para versões inválidas.
  */
-export function satisfiesSemver(version, min, max) {
+export function satisfiesSemver(
+  version: string | null | undefined,
+  min: string | null | undefined,
+  max: string | null | undefined
+): boolean {
   const pv = parseSemver(version)
   if (!pv) return false
   if (min) {

--- a/packages/core/src/utils/stock.ts
+++ b/packages/core/src/utils/stock.ts
@@ -30,6 +30,32 @@ export const STOCK_THRESHOLDS = Object.freeze({
   EXPIRY_WARNING_DAYS: 90,
 })
 
+interface StockProtocol {
+  active?: boolean
+  dosage_per_intake?: number | null
+  intake_unit?: string | null
+  medicine_id?: string
+  time_schedule?: string[] | null
+  frequency?: string | null
+}
+
+interface StockMedicine {
+  dosage_unit?: string | null
+  units_per_ml?: number | null
+  dosage_per_pill?: number | null
+  shelf_life_days?: number | null
+}
+
+interface StockRow {
+  opened_at?: string | Date | null
+}
+
+interface Purchase {
+  quantity_bought?: number | null
+  quantity?: number | null
+  unit_price?: number | null
+}
+
 /**
  * resolveStockStatus — deriva status do estoque a partir de saldo + consumo
  * + data de validade mais proxima.
@@ -41,7 +67,12 @@ export const STOCK_THRESHOLDS = Object.freeze({
  * @param {string} [today] - data ref em YYYY-MM-DD (default: hoje local)
  * @returns {'critico'|'baixo'|'normal'|'alto'|'vencido'}
  */
-export function resolveStockStatus(qty, dailyConsumption, nearestExpiryYYYYMM = null, today = null) {
+export function resolveStockStatus(
+  qty: number,
+  dailyConsumption: number,
+  nearestExpiryYYYYMM: string | null = null,
+  today: string | null = null
+): string {
   const ref = today ?? formatLocalDate(getNow())
 
   // Vencido sobrepoe qualquer outra classificacao por seguranca.
@@ -81,7 +112,11 @@ export function resolveStockStatus(qty, dailyConsumption, nearestExpiryYYYYMM = 
  * @param {{dosage_unit?: string, units_per_ml?: number, dosage_per_pill?: number}|null} [medicine]
  * @returns {{dosesRemaining: number, runwayDias: number, dosesPorDia: number, isDaily: boolean}}
  */
-export function stockDoseMetrics(qty, protocols = [], medicine = null) {
+export function stockDoseMetrics(
+  qty: number,
+  protocols: StockProtocol[] = [],
+  medicine: StockMedicine | null = null
+) {
   const active = (protocols || []).filter((p) => p && p.active !== false)
   if (active.length === 0 || !(qty > 0)) {
     return { dosesRemaining: 0, runwayDias: 0, dosesPorDia: 0, isDaily: true }
@@ -127,7 +162,7 @@ export function stockDoseMetrics(qty, protocols = [], medicine = null) {
  * @param {Array<{quantity_bought?: number, quantity?: number, unit_price: number}>} purchases
  * @returns {number} preco medio (0 se nao houver compras validas)
  */
-export function computeAverageUnitPrice(purchases) {
+export function computeAverageUnitPrice(purchases: Purchase[]): number {
   if (!Array.isArray(purchases) || purchases.length === 0) return 0
 
   let totalCost = 0
@@ -157,7 +192,7 @@ export function computeAverageUnitPrice(purchases) {
  * @param {string} [today] - data ref YYYY-MM-DD (default: hoje local)
  * @returns {number|null} dias (negativo se vencido) ou null se invalido
  */
-export function computeExpiryDays(expiry, today = null) {
+export function computeExpiryDays(expiry: string, today: string | null = null): number | null {
   if (!expiry || typeof expiry !== 'string') return null
   const ref = today ?? formatLocalDate(getNow())
 
@@ -199,7 +234,11 @@ export function computeExpiryDays(expiry, today = null) {
  * @param {Date} [now] - instante de referência (injetável p/ teste)
  * @returns {boolean}
  */
-export function isBiologicallyExpired(stockRow, medicine, now = null) {
+export function isBiologicallyExpired(
+  stockRow: StockRow | null | undefined,
+  medicine: StockMedicine | null | undefined,
+  now: Date | null = null
+): boolean {
   const openedAt = stockRow?.opened_at
   const shelfDays = Number(medicine?.shelf_life_days)
   if (!openedAt || !Number.isFinite(shelfDays) || shelfDays <= 0) return false
@@ -226,7 +265,11 @@ export function isBiologicallyExpired(stockRow, medicine, now = null) {
  * @param {Date} [now]
  * @returns {number|null} dias restantes (negativo se expirado) ou null se eixo inativo
  */
-export function biologicalExpiryDaysLeft(stockRow, medicine, now = null) {
+export function biologicalExpiryDaysLeft(
+  stockRow: StockRow | null | undefined,
+  medicine: StockMedicine | null | undefined,
+  now: Date | null = null
+): number | null {
   const openedAt = stockRow?.opened_at
   const shelfDays = Number(medicine?.shelf_life_days)
   if (!openedAt || !Number.isFinite(shelfDays) || shelfDays <= 0) return null
@@ -252,7 +295,7 @@ export function biologicalExpiryDaysLeft(stockRow, medicine, now = null) {
  * @param {number} value
  * @returns {string}
  */
-export function formatBRL(value) {
+export function formatBRL(value: number | string): string {
   const n = Number.isFinite(Number(value)) ? Number(value) : 0
   const sign = n < 0 ? '-' : ''
   const [intPart, decPart] = Math.abs(n).toFixed(2).split('.')

--- a/packages/core/src/utils/stringUtils.ts
+++ b/packages/core/src/utils/stringUtils.ts
@@ -3,7 +3,7 @@
  * @param {string} str - Texto a converter
  * @returns {string} Texto convertido ou string vazia
  */
-export const toSentenceCase = (str) => {
+export const toSentenceCase = (str: string): string => {
   if (!str) return ''
   const lower = str.toLowerCase()
   return lower.charAt(0).toUpperCase() + lower.slice(1)
@@ -19,13 +19,13 @@ export const toSentenceCase = (str) => {
  * @param {string} str - Texto a converter
  * @returns {string} Texto em Title Case ou string vazia
  */
-export const toTitleCase = (str) => {
+export const toTitleCase = (str: string): string => {
   if (!str) return ''
   const lower = str.toLowerCase()
   const exceptions = new Set(['de', 'da', 'do', 'das', 'dos', 'e', 'com', 'em', 'para', 'por'])
   return lower
     .split(/\s+/)
-    .map((word, index) => {
+    .map((word: string, index: number) => {
       if (index > 0 && exceptions.has(word)) return word
       return word.charAt(0).toUpperCase() + word.slice(1)
     })

--- a/packages/core/src/utils/timeline.ts
+++ b/packages/core/src/utils/timeline.ts
@@ -42,6 +42,14 @@ export const TIMELINE_ORDER = Object.freeze({
 
 const DEFAULT_TZ = 'America/Sao_Paulo'
 
+export interface TimelineEvent {
+  id: string
+  type: string
+  occurred_at: string
+  payload?: Record<string, unknown>
+  localDay?: string | null
+}
+
 /**
  * Deriva o dia local (YYYY-MM-DD) de um instante absoluto no fuso informado.
  * Cross-meia-noite: um evento 23:50 e outro 00:10 (UTC convertidos ao tz) caem
@@ -51,7 +59,7 @@ const DEFAULT_TZ = 'America/Sao_Paulo'
  * @param {string} [tz=DEFAULT_TZ] - Timezone IANA.
  * @returns {string|null} YYYY-MM-DD no fuso, ou null se inválido.
  */
-export function deriveLocalDay(occurredAt, tz = DEFAULT_TZ) {
+export function deriveLocalDay(occurredAt: string, tz = DEFAULT_TZ): string | null {
   const d = parseISO(occurredAt)
   if (Number.isNaN(d.getTime())) return null
   return formatLocalDate(getUserTime(d, tz))
@@ -73,10 +81,13 @@ export function deriveLocalDay(occurredAt, tz = DEFAULT_TZ) {
  * @param {'asc'|'desc'} [opts.order=TIMELINE_ORDER.DESC] - Ordem por instante.
  * @returns {TimelineEvent[]} Eventos ordenados, cada um com `localDay`.
  */
-export function buildTimeline(events, { tz = DEFAULT_TZ, order = TIMELINE_ORDER.DESC as 'asc' | 'desc' } = {}) {
+export function buildTimeline(
+  events: TimelineEvent[],
+  { tz = DEFAULT_TZ, order = TIMELINE_ORDER.DESC as 'asc' | 'desc' } = {}
+): TimelineEvent[] {
   if (!Array.isArray(events)) return []
 
-  const annotated = []
+  const annotated: Array<{ ev: TimelineEvent; ts: number }> = []
   for (const ev of events) {
     if (!ev || !ev.occurred_at) continue
     const ts = parseISO(ev.occurred_at).getTime()
@@ -105,10 +116,10 @@ export function buildTimeline(events, { tz = DEFAULT_TZ, order = TIMELINE_ORDER.
  * @param {TimelineEvent[]} events - Saída de `buildTimeline` (com `localDay`).
  * @returns {Array<{ localDay: string, events: TimelineEvent[] }>}
  */
-export function groupByLocalDay(events) {
+export function groupByLocalDay(events: TimelineEvent[]): Array<{ localDay: string | null; events: TimelineEvent[] }> {
   if (!Array.isArray(events)) return []
-  const groups = []
-  let current = null
+  const groups: Array<{ localDay: string | null; events: TimelineEvent[] }> = []
+  let current: { localDay: string | null; events: TimelineEvent[] } | null = null
   for (const ev of events) {
     const day = ev.localDay ?? deriveLocalDay(ev.occurred_at)
     if (!current || current.localDay !== day) {

--- a/packages/core/src/utils/titrationUtils.ts
+++ b/packages/core/src/utils/titrationUtils.ts
@@ -2,17 +2,32 @@ import { getNow, parseISO } from './dateUtils'
 
 const MS_DAY = 24 * 60 * 60 * 1000
 
+interface TitrationStage {
+  dosage?: number
+  duration_days?: number
+  days?: number
+  description?: string
+  note?: string
+}
+
+export interface TitrationProtocol {
+  titration_schedule?: TitrationStage[] | null
+  current_stage_index?: number | null
+  stage_started_at?: string | null
+  titration_status?: string | null
+}
+
 /**
  * Verifica se a titulação está inativa.
  * @private
  */
-function isTitrationInactive(protocol) {
+function isTitrationInactive(protocol: TitrationProtocol | null | undefined): boolean {
   const schedule = protocol?.titration_schedule
   return (
     !Array.isArray(schedule) ||
     schedule.length === 0 ||
-    !protocol.stage_started_at ||
-    protocol.titration_status !== 'titulando'
+    !protocol?.stage_started_at ||
+    protocol?.titration_status !== 'titulando'
   )
 }
 
@@ -20,7 +35,7 @@ function isTitrationInactive(protocol) {
  * Obtém o timestamp MS de um instante.
  * @private
  */
-function getTimestamp(at) {
+function getTimestamp(at: Date | string | number): number {
   if (typeof at === 'number') return at
   if (at instanceof Date) return at.getTime()
   return parseISO(String(at)).getTime()
@@ -30,7 +45,7 @@ function getTimestamp(at) {
  * Obtém a duração em dias da etapa.
  * @private
  */
-function getStageDurationDays(stage) {
+function getStageDurationDays(stage: TitrationStage | null | undefined): number | null {
   const days = Number(stage?.duration_days ?? stage?.days)
   return Number.isFinite(days) && days > 0 ? days : null
 }
@@ -51,9 +66,13 @@ function getStageDurationDays(stage) {
  * @param {Date|string|number} at - instante da ocorrência
  * @returns {{stageIndex: number, dosage: number}|null}
  */
-export function resolveTitrationStageAt(protocol, at) {
+export function resolveTitrationStageAt(
+  protocol: TitrationProtocol | null | undefined,
+  at: Date | string | number
+): { stageIndex: number; dosage: number } | null {
   if (isTitrationInactive(protocol)) return null
-  const schedule = protocol.titration_schedule
+  const schedule = protocol?.titration_schedule
+  if (!schedule || !protocol?.stage_started_at) return null
   let index = protocol.current_stage_index || 0
   if (index >= schedule.length) return null
 
@@ -78,7 +97,17 @@ export function resolveTitrationStageAt(protocol, at) {
   return { stageIndex: index, dosage }
 }
 
-export function calculateTitrationData(protocol) {
+export function calculateTitrationData(protocol: TitrationProtocol): {
+  currentStep: number
+  totalSteps: number
+  day: number
+  realDay: number
+  totalDays: number
+  progressPercent: number
+  isTransitionDue: boolean
+  stageNote: string | undefined
+  daysRemaining: number
+} | null {
   if (!protocol.titration_schedule || protocol.titration_schedule.length === 0) return null
   if (!protocol.stage_started_at) return null
 
@@ -98,7 +127,7 @@ export function calculateTitrationData(protocol) {
 
   // Clamp day to at least 1
   const currentDay = Math.max(1, daysElapsed)
-  const totalDays = currentStage.duration_days ?? currentStage.days
+  const totalDays = currentStage.duration_days ?? currentStage.days ?? 0
 
   // Calculate progress percent (capped at 100)
   const progressPercent = Math.min(100, (currentDay / totalDays) * 100)

--- a/packages/core/src/utils/titrationUtils.ts
+++ b/packages/core/src/utils/titrationUtils.ts
@@ -130,7 +130,7 @@ export function calculateTitrationData(protocol: TitrationProtocol): {
   const totalDays = currentStage.duration_days ?? currentStage.days ?? 0
 
   // Calculate progress percent (capped at 100)
-  const progressPercent = Math.min(100, (currentDay / totalDays) * 100)
+  const progressPercent = totalDays > 0 ? Math.min(100, (currentDay / totalDays) * 100) : 0
 
   const isTransitionDue = currentDay > totalDays // Or >= depending on logic. Let's say > implies finished yesterday.
 

--- a/packages/core/src/utils/treatmentStatus.ts
+++ b/packages/core/src/utils/treatmentStatus.ts
@@ -25,7 +25,13 @@ export const TREATMENT_STATUS = Object.freeze({
  * @param {string} [today] — YYYY-MM-DD; default = hoje local
  * @returns {'ativo'|'pausado'|'finalizado'}
  */
-export function resolveTreatmentStatus(protocol, today?: string) {
+interface TreatmentStatusProtocol {
+  active?: boolean | null
+  end_date?: string | null
+  start_date?: string | null
+}
+
+export function resolveTreatmentStatus(protocol: TreatmentStatusProtocol | null | undefined, today?: string): string {
   const ref = today ?? formatLocalDate(getNow())
   if (protocol?.end_date && protocol.end_date < ref) return TREATMENT_STATUS.FINALIZADO
   if (protocol?.active === false) return TREATMENT_STATUS.PAUSADO
@@ -41,7 +47,7 @@ export function resolveTreatmentStatus(protocol, today?: string) {
  * @param {string} [today] — YYYY-MM-DD; default = hoje local
  * @returns {boolean}
  */
-export function isTreatmentActive(protocol, today?: string) {
+export function isTreatmentActive(protocol: TreatmentStatusProtocol | null | undefined, today?: string): boolean {
   if (!protocol) return false
   return resolveTreatmentStatus(protocol, today) === TREATMENT_STATUS.ATIVO
 }
@@ -63,7 +69,7 @@ export function isTreatmentActive(protocol, today?: string) {
  * @param {string} [today] — YYYY-MM-DD; default = hoje local
  * @returns {boolean}
  */
-export function isTreatmentSchedulableOn(protocol, today?: string) {
+export function isTreatmentSchedulableOn(protocol: TreatmentStatusProtocol | null | undefined, today?: string): boolean {
   if (!protocol) return false
   const ref = today ?? formatLocalDate(getNow())
   return isTreatmentActive(protocol, ref) && isProtocolActiveOnDate(protocol, ref)

--- a/packages/core/src/zodSetup.ts
+++ b/packages/core/src/zodSetup.ts
@@ -12,7 +12,7 @@ import pt from 'zod/v4/locales/pt.js'
 
 // Mensagens base por código (sem mencionar tipo/recebido/expected etc).
 // eslint-disable-next-line complexity
-function friendlyMessage(issue) {
+function friendlyMessage(issue: z.core.$ZodRawIssue) {
   switch (issue.code) {
     case 'invalid_type': {
       // Vazio/null/undefined → obrigatório.
@@ -57,7 +57,6 @@ function friendlyMessage(issue) {
       return 'Formato inválido'
     }
     case 'invalid_value':
-    case 'invalid_enum_value':
       return 'Escolha uma das opções disponíveis'
     case 'not_multiple_of':
       return 'Valor inválido'

--- a/packages/shared-data/src/query-cache/_cacheBuilder.ts
+++ b/packages/shared-data/src/query-cache/_cacheBuilder.ts
@@ -7,21 +7,71 @@
  * @module _cacheBuilder
  */
 
+import type { StorageAdapter } from '@dosiq/storage'
+
 const GC_INTERVAL = 60_000
+
+/** Logger opcional com métodos log/warn/error. */
+export interface CacheLogger {
+  log?: (msg: string) => void
+  warn?: (msg: string) => void
+  error?: (msg: string) => void
+  [level: string]: ((msg: string) => void) | undefined
+}
+
+/** Entrada armazenada no cache. */
+interface CacheEntry<T = unknown> {
+  data: T
+  timestamp: number
+  isRevalidating: boolean
+}
+
+/** Dependências injetadas pela factory (createQueryCache). */
+interface CacheDeps {
+  storage: StorageAdapter
+  logger?: CacheLogger | null
+  staleTime: number
+  maxEntries: number
+  persistKey: string
+  setJSON: (storage: StorageAdapter, key: string, value: unknown) => Promise<void>
+  getJSON: <T>(storage: StorageAdapter, key: string, fallback: T | null) => Promise<T | null>
+}
+
+/** Estado interno completo do cache (deps + estruturas de runtime). */
+interface CacheState extends CacheDeps {
+  cache: Map<string, CacheEntry>
+  pendingRequests: Map<string, Promise<unknown>>
+  accessCount: Map<string, number>
+  accessCounter: number
+  cacheGeneration: number
+  gcInterval: ReturnType<typeof setInterval> | null
+  persistTimer: ReturnType<typeof setTimeout> | null
+  initialized: boolean
+}
+
+interface CachedQueryOptions {
+  dedupe?: boolean
+  staleTime?: number
+}
 
 // --- helpers puros (sem estado) ---
 
-function _log(logger, level, msg) {
+function _log(logger: CacheLogger | null | undefined, level: string, msg: string) {
   if (!logger) return
   const fn = logger[level] ?? logger.log
   if (fn) fn(`[QueryCache] ${msg}`)
 }
 
-function _isStale(timestamp, staleTime, customStaleTime?) {
+function _isStale(timestamp: number, staleTime: number, customStaleTime?: number) {
   return Date.now() - timestamp > (customStaleTime ?? staleTime)
 }
 
-function _deleteFromMaps(key, cache, accessCount, pendingRequests) {
+function _deleteFromMaps(
+  key: string,
+  cache: CacheState['cache'],
+  accessCount: CacheState['accessCount'],
+  pendingRequests: CacheState['pendingRequests']
+) {
   cache.delete(key)
   accessCount.delete(key)
   pendingRequests.delete(key)
@@ -29,7 +79,7 @@ function _deleteFromMaps(key, cache, accessCount, pendingRequests) {
 
 // --- helpers com estado injetado ---
 
-function _schedulePersist(state) {
+function _schedulePersist(state: CacheState) {
   const { cache, maxEntries, persistKey, storage, logger, setJSON } = state
   if (state.persistTimer) clearTimeout(state.persistTimer)
   state.persistTimer = setTimeout(async () => {
@@ -39,13 +89,14 @@ function _schedulePersist(state) {
         .slice(0, maxEntries)
       await setJSON(storage, persistKey, entries)
     } catch (err) {
-      _log(logger, 'warn', `Falha ao persistir cache: ${err.message}`)
+      const message = err instanceof Error ? err.message : String(err)
+      _log(logger, 'warn', `Falha ao persistir cache: ${message}`)
     }
     state.persistTimer = null
   }, 500)
 }
 
-function _garbageCollect(state) {
+function _garbageCollect(state: CacheState) {
   const { cache, accessCount, pendingRequests, maxEntries, staleTime, logger } = state
   const now = Date.now()
   const ttlThreshold = staleTime * 2
@@ -71,7 +122,12 @@ function _garbageCollect(state) {
   }
 }
 
-async function _revalidateStale(key, fetcher, cached, state) {
+async function _revalidateStale(
+  key: string,
+  fetcher: () => Promise<unknown>,
+  cached: CacheEntry,
+  state: CacheState
+) {
   const { cache, logger } = state
   try {
     const capturedGen = state.cacheGeneration
@@ -85,13 +141,14 @@ async function _revalidateStale(key, fetcher, cached, state) {
     }
     return data
   } catch (err) {
-    _log(logger, 'warn', `Revalidacao falhou: ${key} — ${err.message}`)
+    const message = err instanceof Error ? err.message : String(err)
+    _log(logger, 'warn', `Revalidacao falhou: ${key} — ${message}`)
     cached.isRevalidating = false
     throw err
   }
 }
 
-async function _fetchAndStore(key, fetcher, state) {
+async function _fetchAndStore(key: string, fetcher: () => Promise<unknown>, state: CacheState) {
   const { cache, pendingRequests, logger } = state
   try {
     const capturedGen = state.cacheGeneration
@@ -105,7 +162,8 @@ async function _fetchAndStore(key, fetcher, state) {
     }
     return data
   } catch (err) {
-    _log(logger, 'warn', `Fetch falhou: ${key} — ${err.message}`)
+    const message = err instanceof Error ? err.message : String(err)
+    _log(logger, 'warn', `Fetch falhou: ${key} — ${message}`)
     throw err
   } finally {
     pendingRequests.delete(key)
@@ -114,23 +172,29 @@ async function _fetchAndStore(key, fetcher, state) {
 
 // --- API publica ---
 
-async function _init(state) {
+async function _init(state: CacheState) {
   if (state.initialized) return
   const { storage, persistKey, cache, logger, getJSON: _getJSON } = state
   try {
-    const persisted = await _getJSON(storage, persistKey, null)
+    const persisted = await _getJSON<Array<[string, CacheEntry]>>(storage, persistKey, null)
     if (Array.isArray(persisted)) {
       persisted.forEach(([key, value]) => cache.set(key, { ...value, isRevalidating: false }))
       _log(logger, 'log', `Hidracao: ${persisted.length} entradas carregadas`)
     }
   } catch (err) {
-    _log(logger, 'warn', `Falha ao hidratar cache: ${err.message}`)
+    const message = err instanceof Error ? err.message : String(err)
+    _log(logger, 'warn', `Falha ao hidratar cache: ${message}`)
   }
   state.gcInterval = setInterval(() => _garbageCollect(state), GC_INTERVAL)
   state.initialized = true
 }
 
-async function _cachedQuery(key, fetcher, options, state) {
+async function _cachedQuery(
+  key: string,
+  fetcher: () => Promise<unknown>,
+  options: CachedQueryOptions,
+  state: CacheState
+) {
   const { dedupe = true, staleTime: customStaleTime } = options
   const { cache, pendingRequests, logger, staleTime } = state
   const cached = cache.get(key)
@@ -160,7 +224,7 @@ async function _cachedQuery(key, fetcher, options, state) {
   return fetchPromise
 }
 
-function _invalidate(pattern, state) {
+function _invalidate(pattern: string | RegExp, state: CacheState) {
   const { cache, accessCount, pendingRequests, logger } = state
   let count = 0
   if (typeof pattern === 'string') {
@@ -182,7 +246,7 @@ function _invalidate(pattern, state) {
   return count
 }
 
-function _clear(state) {
+function _clear(state: CacheState) {
   const { cache, accessCount, pendingRequests, logger } = state
   if (state.persistTimer) { clearTimeout(state.persistTimer); state.persistTimer = null }
   state.cacheGeneration++
@@ -192,7 +256,7 @@ function _clear(state) {
   _log(logger, 'log', `Cache limpo: ${size} entradas removidas`)
 }
 
-function _getStats(state) {
+function _getStats(state: CacheState) {
   const { cache, pendingRequests, maxEntries, staleTime } = state
   const entries = Array.from(cache.entries())
   const staleCount = entries.filter(([, v]) => _isStale(v.timestamp, staleTime)).length
@@ -204,11 +268,11 @@ function _getStats(state) {
 
 /**
  * Constrói e retorna uma instância do QueryCache com estado encapsulado.
- * @param {Object} deps - Dependências injetadas pela factory
- * @returns {QueryCache}
+ * @param deps - Dependências injetadas pela factory
+ * @returns QueryCache
  */
-export function _buildCache(deps) {
-  const state = {
+export function _buildCache(deps: CacheDeps) {
+  const state: CacheState = {
     ...deps,
     cache: new Map(),
     pendingRequests: new Map(),
@@ -222,10 +286,11 @@ export function _buildCache(deps) {
 
   return {
     init: () => _init(state),
-    cachedQuery: (key, fetcher, options = {}) => _cachedQuery(key, fetcher, options, state),
-    invalidate: (pattern) => _invalidate(pattern, state),
+    cachedQuery: (key: string, fetcher: () => Promise<unknown>, options: CachedQueryOptions = {}) =>
+      _cachedQuery(key, fetcher, options, state),
+    invalidate: (pattern: string | RegExp) => _invalidate(pattern, state),
     clear: () => _clear(state),
-    prefetch(key, data) {
+    prefetch(key: string, data: unknown) {
       state.cache.set(key, { data, timestamp: Date.now(), isRevalidating: false })
       state.accessCounter++
       state.accessCount.set(key, state.accessCounter)

--- a/packages/shared-data/src/query-cache/createQueryCache.ts
+++ b/packages/shared-data/src/query-cache/createQueryCache.ts
@@ -14,7 +14,8 @@
  */
 
 import { setJSON, getJSON } from '@dosiq/storage'
-import { _buildCache } from './_cacheBuilder'
+import type { StorageAdapter } from '@dosiq/storage'
+import { _buildCache, type CacheLogger } from './_cacheBuilder'
 
 /**
  * Cria uma instancia de query cache com dependencias injetadas.
@@ -34,12 +35,12 @@ export function createQueryCache({
   maxEntries = 200,
   persistKey = 'dosiq_query_cache',
 }: {
-  storage: unknown
-  logger?: unknown
+  storage?: StorageAdapter
+  logger?: CacheLogger | null
   staleTime?: number
   maxEntries?: number
   persistKey?: string
-} = {} as any) { // TODO(040-strict)
+} = {}) {
   if (!storage) throw new Error('createQueryCache: storage adapter is required')
   return _buildCache({ storage, logger, staleTime, maxEntries, persistKey, setJSON, getJSON })
 }

--- a/packages/shared-data/src/services/createNotificationLogRepository.ts
+++ b/packages/shared-data/src/services/createNotificationLogRepository.ts
@@ -18,24 +18,36 @@ import { z } from 'zod'
 /**
  * Cria uma instância do repositório de logs de notificações.
  *
- * @param {Object} deps
- * @param {import('@supabase/supabase-js').SupabaseClient} deps.supabase - Cliente Supabase injetado
+ * @param deps
+ * @param deps.supabase - Cliente Supabase injetado
  * @returns {NotificationLogRepository}
  */
-export function createNotificationLogRepository({ supabase }) {
+export function createNotificationLogRepository({
+  supabase,
+}: {
+  // TODO(040-strict): `SupabaseClient<Database>` nominal diverge entre generic
+  // instantiations de plataformas (web/mobile) dependendo da versão resolvida de
+  // @supabase/supabase-js — tipagem estrutural equivalente causa "type instantiation
+  // excessively deep" no consumidor (hooks nível A). Mantido como injeção duck-typed.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any
+}) {
   if (!supabase) throw new Error('createNotificationLogRepository: supabase client is required')
 
   /**
    * Retorna os logs de notificação de um usuário, ordenados por data de envio.
    * R-130: Validado via Zod para garantir integridade do contrato.
    *
-   * @param {string} userId - ID do usuário (UUID)
-   * @param {Object} [options]
-   * @param {number} [options.limit=20] - Limite de logs (padrão 20)
-   * @param {number} [options.offset=0] - Ponto de partida (padrão 0)
-   * @returns {Promise<Array>} Lista de logs validados
+   * @param userId - ID do usuário (UUID)
+   * @param options
+   * @param options.limit - Limite de logs (padrão 20)
+   * @param options.offset - Ponto de partida (padrão 0)
+   * @returns Lista de logs validados
    */
-  async function listByUserId(userId, { limit = 20, offset = 0 } = {}) {
+  async function listByUserId(
+    userId: string,
+    { limit = 20, offset = 0 }: { limit?: number; offset?: number } = {}
+  ) {
     if (!userId) {
       throw new Error('listByUserId: userId is required')
     }

--- a/packages/shared-data/src/services/createUserSessionRepository.ts
+++ b/packages/shared-data/src/services/createUserSessionRepository.ts
@@ -9,12 +9,26 @@
  * const user = await repo.getCurrentUser()
  */
 
+import type { AuthError, Session, User } from '@supabase/supabase-js'
+
 /**
- * @param {Object} deps
- * @param {import('@supabase/supabase-js').SupabaseClient} deps.supabase
+ * Shape mínimo do client Supabase consumido aqui (apenas `.auth`) — estrutural, para
+ * não acoplar a uma instanciação genérica específica de `SupabaseClient<Database>`.
+ */
+interface SupabaseLike {
+  auth: {
+    getUser(): Promise<{ data: { user: User | null }; error: AuthError | null }>
+    getSession(): Promise<{ data: { session: Session | null }; error: AuthError | null }>
+    signOut(): Promise<{ error: AuthError | null }>
+  }
+}
+
+/**
+ * @param deps
+ * @param deps.supabase
  * @returns {UserSessionRepository}
  */
-export function createUserSessionRepository({ supabase }) {
+export function createUserSessionRepository({ supabase }: { supabase: SupabaseLike }) {
   if (!supabase) throw new Error('createUserSessionRepository: supabase client is required')
 
   /**

--- a/packages/shared-data/src/supabase/createSupabaseClient.ts
+++ b/packages/shared-data/src/supabase/createSupabaseClient.ts
@@ -7,9 +7,12 @@
  * @param {Object} options - Mesmas opcoes de createSupabaseDependencies
  * @returns {import('@supabase/supabase-js').SupabaseClient}
  */
-import { createSupabaseDependencies } from './createSupabaseDependencies'
+import {
+  createSupabaseDependencies,
+  type CreateSupabaseDependenciesOptions,
+} from './createSupabaseDependencies'
 
-export function createSupabaseClient(options) {
+export function createSupabaseClient(options: CreateSupabaseDependenciesOptions) {
   const { supabase } = createSupabaseDependencies(options)
   return supabase
 }

--- a/packages/shared-data/src/supabase/createSupabaseDependencies.ts
+++ b/packages/shared-data/src/supabase/createSupabaseDependencies.ts
@@ -9,16 +9,44 @@
  * Tests:  injetar mock de createClient
  */
 
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { StorageAdapter } from '@dosiq/storage'
+
+/**
+ * Implementacao de createClient injetada pelo caller (evita acoplar o pacote
+ * a uma versao especifica de @supabase/supabase-js).
+ */
+type CreateClientImpl = (
+  url: string,
+  anonKey: string,
+  options: {
+    auth: {
+      storage: StorageAdapter
+      persistSession: boolean
+      autoRefreshToken: boolean
+      detectSessionInUrl: boolean
+    }
+  }
+) => SupabaseClient
+
+export interface CreateSupabaseDependenciesOptions {
+  url: string
+  anonKey: string
+  authStorage: StorageAdapter
+  detectSessionInUrl?: boolean
+  createClientImpl: CreateClientImpl
+}
+
 /**
  * Cria as dependencias Supabase para a plataforma atual.
  *
- * @param {Object} options
- * @param {string} options.url - URL do projeto Supabase (https://...)
- * @param {string} options.anonKey - Anon key publica do projeto
- * @param {Object} options.authStorage - Adapter de storage async para sessao de autenticacao
- * @param {boolean} [options.detectSessionInUrl=false] - Detectar sessao na URL (apenas web)
- * @param {Function} options.createClientImpl - Implementacao de createClient (injetada)
- * @returns {{ supabase: import('@supabase/supabase-js').SupabaseClient }}
+ * @param options
+ * @param options.url - URL do projeto Supabase (https://...)
+ * @param options.anonKey - Anon key publica do projeto
+ * @param options.authStorage - Adapter de storage async para sessao de autenticacao
+ * @param options.detectSessionInUrl - Detectar sessao na URL (apenas web)
+ * @param options.createClientImpl - Implementacao de createClient (injetada)
+ * @returns { supabase: SupabaseClient }
  */
 export function createSupabaseDependencies({
   url,
@@ -26,7 +54,7 @@ export function createSupabaseDependencies({
   authStorage,
   detectSessionInUrl = false,
   createClientImpl,
-}) {
+}: CreateSupabaseDependenciesOptions) {
   if (!url) throw new Error('createSupabaseDependencies: url is required')
   if (!anonKey) throw new Error('createSupabaseDependencies: anonKey is required')
   if (!authStorage) throw new Error('createSupabaseDependencies: authStorage is required')

--- a/packages/storage/src/contracts.ts
+++ b/packages/storage/src/contracts.ts
@@ -6,14 +6,25 @@
  */
 
 /**
+ * Interface que todo storage adapter (web/mobile/server) deve implementar.
+ */
+export interface StorageAdapter {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+  removeItem(key: string): Promise<void>
+}
+
+/**
  * Assert that an object implements the storage adapter interface.
- * @param {Object} adapter - Candidato para adapter de storage
+ * @param adapter - Candidato para adapter de storage
  * @throws {Error} Se adapter não tiver os métodos obrigatórios
  */
-export function assertStorageAdapter(adapter) {
+export function assertStorageAdapter(
+  adapter: Partial<StorageAdapter> | null | undefined
+): asserts adapter is StorageAdapter {
   if (!adapter) throw new Error('Storage adapter is required')
 
-  const required = ['getItem', 'setItem', 'removeItem']
+  const required = ['getItem', 'setItem', 'removeItem'] as const
 
   for (const method of required) {
     if (typeof adapter[method] !== 'function') {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -12,7 +12,7 @@
  *   const json = await getJSON(adapter, 'jsonKey', defaultValue)
  */
 
-export { assertStorageAdapter } from './contracts'
+export { assertStorageAdapter, type StorageAdapter } from './contracts'
 export { createWebStorageAdapter } from './webStorage'
 export { createMemoryStorageAdapter } from './memoryStorage'
 export { getJSON, setJSON } from './json'

--- a/packages/storage/src/json.ts
+++ b/packages/storage/src/json.ts
@@ -5,14 +5,20 @@
  * Usa try-catch para fallback seguro em caso de parse error.
  */
 
+import type { StorageAdapter } from './contracts'
+
 /**
  * Le um valor JSON do storage.
- * @param {Object} adapter - Storage adapter (deve implementar getItem)
- * @param {string} key - Chave de armazenamento
- * @param {*} fallback - Valor padrao se chave nao existir ou JSON for invalido
- * @returns {Promise<*>} Valor desserializado ou fallback
+ * @param adapter - Storage adapter (deve implementar getItem)
+ * @param key - Chave de armazenamento
+ * @param fallback - Valor padrao se chave nao existir ou JSON for invalido
+ * @returns Valor desserializado ou fallback
  */
-export async function getJSON(adapter, key, fallback = null) {
+export async function getJSON<T = unknown>(
+  adapter: Pick<StorageAdapter, 'getItem'>,
+  key: string,
+  fallback: T | null = null
+): Promise<T | null> {
   const raw = await adapter.getItem(key)
   if (!raw) return fallback
 
@@ -26,19 +32,23 @@ export async function getJSON(adapter, key, fallback = null) {
 
 /**
  * Escreve um valor JSON no storage.
- * @param {Object} adapter - Storage adapter (deve implementar setItem)
- * @param {string} key - Chave de armazenamento
- * @param {*} value - Valor a serializar
- * @returns {Promise<void>}
+ * @param adapter - Storage adapter (deve implementar setItem)
+ * @param key - Chave de armazenamento
+ * @param value - Valor a serializar
  * @throws {Error} Se JSON.stringify ou adapter.setItem falharem
  */
-export async function setJSON(adapter, key, value) {
+export async function setJSON(
+  adapter: Pick<StorageAdapter, 'setItem'>,
+  key: string,
+  value: unknown
+): Promise<void> {
   try {
     const serialized = JSON.stringify(value)
     await adapter.setItem(key, serialized)
   } catch (error) {
     // Log error para debugging (mesmo que falha seja silenciosa para caller)
-    console.error(`[setJSON] Failed to store key "${key}":`, error.message)
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`[setJSON] Failed to store key "${key}":`, message)
     throw error
   }
 }

--- a/packages/storage/src/memoryStorage.ts
+++ b/packages/storage/src/memoryStorage.ts
@@ -5,24 +5,24 @@
  * Dados sao perdidos ao reiniciar a sessao (esperado).
  */
 
-import { assertStorageAdapter } from './contracts'
+import { assertStorageAdapter, type StorageAdapter } from './contracts'
 
 /**
  * Cria um adapter de storage que usa Map em memoria.
  * Util para testes, SSR, e fallback em ambientes sem localStorage.
- * @returns {Object} Storage adapter assincronos
+ * @returns Storage adapter assincronos
  */
-export function createMemoryStorageAdapter() {
-  const store = new Map()
+export function createMemoryStorageAdapter(): StorageAdapter {
+  const store = new Map<string, string>()
 
-  const adapter = {
-    async getItem(key) {
-      return store.has(key) ? store.get(key) : null
+  const adapter: StorageAdapter = {
+    async getItem(key: string) {
+      return store.has(key) ? (store.get(key) ?? null) : null
     },
-    async setItem(key, value) {
+    async setItem(key: string, value: string) {
       store.set(key, value)
     },
-    async removeItem(key) {
+    async removeItem(key: string) {
       store.delete(key)
     },
   }

--- a/packages/storage/src/webStorage.ts
+++ b/packages/storage/src/webStorage.ts
@@ -5,24 +5,31 @@
  * Injetável em packages/shared-data sem acoplamento direto a window.
  */
 
-import { assertStorageAdapter } from './contracts'
+import { assertStorageAdapter, type StorageAdapter } from './contracts'
+
+/** Superfície mínima de Storage usada pelo adapter (aceita fallbacks de teste). */
+export interface WebStorageLike {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
 
 /**
  * Cria um adapter de storage que wraps window.localStorage.
- * @param {Storage} storage - window.localStorage ou window.sessionStorage
- * @returns {Object} Storage adapter com métodos assincronos
+ * @param storage - window.localStorage ou window.sessionStorage
+ * @returns Storage adapter com métodos assincronos
  */
-export function createWebStorageAdapter(storage) {
+export function createWebStorageAdapter(storage: WebStorageLike): StorageAdapter {
   if (!storage) throw new Error('Web storage provider is required')
 
-  const adapter = {
-    async getItem(key) {
+  const adapter: StorageAdapter = {
+    async getItem(key: string) {
       return storage.getItem(key)
     },
-    async setItem(key, value) {
+    async setItem(key: string, value: string) {
       storage.setItem(key, value)
     },
-    async removeItem(key) {
+    async removeItem(key: string) {
       storage.removeItem(key)
     },
   }

--- a/scripts/strict-island.sh
+++ b/scripts/strict-island.sh
@@ -18,11 +18,11 @@ set -uo pipefail
 cd "$(dirname "$0")/.."
 
 # ── Tetos por bucket (baseline 2026-07-06, F6 Bloco 0; lotes 6.x abaixam) ──
-MAX_B_PACKAGES=444        # packages/* nível-B transitivo (core 381 + shared-data 44 + storage 15 + config 4)
+MAX_B_PACKAGES=0          # packages/* nível-B transitivo (zerado no lote 6.5 — utils clínicos + chatbot + shared-data + storage + config tipados)
 MAX_B_WEB=37              # apps/web nível-B transitivo
 MAX_B_MOBILE=0            # apps/mobile nível-B transitivo (zerado no lote 6.4 — secureStore/asyncStorageAdapter/debugLog/haptics tipados)
 MAX_B_SERVER=36           # server/* nível-B transitivo (utils 25 + bot 10 + services 1)
-MAX_A_TESTS_CORE=85       # testes dos domínios A do core (lote 6.3: 350→85, repos tipados; alvo ≤120 batido)
+MAX_A_TESTS_CORE=0        # testes dos domínios A do core (zerado no lote 6.5 — triagem TIPA: narrow pós-expect via `!` + fixtures anvisaDatabase)
 MAX_A_TESTS_SERVER=0      # testes de server/notifications (zerado no lote 6.2)
 MAX_A_TESTS_WEB=0         # testes hooks web (já zerado — trava)
 MAX_A_TESTS_MOBILE=0      # testes hooks mobile (zerado no lote 6.4 — useMedicineDatabase/useMutation tipados)


### PR DESCRIPTION
## Escopo (lote extra decidido no Bloco 2)
Residual de `packages/*` é lógica clínica que o 044 dose-only-mode vai tocar (on-touch dispararia lá) — queimado agora via 3 sub-agentes Sonnet em clusters disjuntos. **Congelado por decisão**: B web 37 (paridade web congelada) e B server 36 (cópias próprias; on-touch no 043).

## Contadores antes→depois (catraca no mesmo commit)
| Bucket | Antes | Depois |
|---|---|---|
| MAX_B_PACKAGES | 444 | **0** |
| MAX_A_TESTS_CORE | 85 | **0** |
| demais buckets | inalterados (verdes) | — |

## Clusters
- **utils clínicos core (338 erros)**: adherenceLogic, doseUnit, doseInstanceGenerator, stock, nudgeScheduler, dateUtils, doseZones etc — interfaces locais por arquivo, zero `any`. Consolidação futura em `types/` = follow-up.
- **infra packages (106)**: chatbot, shared-data (query-cache, repositories), storage, config, markdown, zodSetup. 1 `any` + TODO(040-strict): `createNotificationLogRepository` (divergência nominal de generics @supabase entre node_modules root×mobile).
- **testes A core (85)**: triagem rubrica — TODOS TIPA (nenhum MATA); causa raiz = `{success:boolean}` não-discriminado não estreita pós-`expect`; fix `!` pós-asserção + fixtures reais em anvisaDatabase.

## Integração cross-program (fallout de tipar o core)
- `fetchChatbotContextData`: `!validation.success` **não estreita união sob non-strict** (mobile) — trocado por `=== false` (candidato a AP/regra no C5 da fase).
- `AdherenceProtocol` exportado no barrel; `GeneratedInstance` interface→type (index signature); `WebStorageLike`; `DoseItemLike` aceita `number|string` (contrato runtime real).
- 2 casts documentados TODO(040-strict): supabase client mobile (nominal) + Row `time_schedule: Json` → `AdherenceProtocol` em stockService.

## Testes stale corrigidos (backlog F6 + achados no gate local)
Profile.test (`maybeSingle` ausente no mock), Treatment.test (`cached*Service`), ChatWindow (não existe teste — item encerrado), StockForm (labels `500 mg`, inputs `type=text`, `injection_container`), ProtocolForm/TitrationWizard (campos novos no payload), EmergencyCardForm (emojis→ícones), ProtocolChecklistItem (`comp.`→`un.` ADR-065/066), SparklineAdesao (**flaky pós-21h BRT**: fixture usava `toISOString` — data UTC ≠ janela local do hook).

## Fix de produção (1 linha — deveria ser commit separado, foi junto: anotado)
`protocolFormUtils.ts:116`: validação aceitava **dose 0** (`n < 0` → `n <= 0`) — bug clínico real achado por teste que esperava rejeição.

## Gates
strict-island verde (tetos novos) · test:changed web/packages **1668/1668** · jest mobile changedSince verde · lint 0 erros/117 warnings pré-existentes · validate:agent fica pro PR consolidado da fase.

## Triagem pendente
Nenhuma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)