### PR TITLE
feat(044): F4a — ciclo de opt-out do estoque (toggle + congelamento + reconciliação)

### DIFF
--- a/.agent/state.json
+++ b/.agent/state.json
@@ -7,7 +7,7 @@
     "status": "completed",
     "plan": "plans/specs/029-treatment-level-titration/plan.md",
     "tasks": "plans/specs/044-dose-only-mode/tasks.md",
-    "goal": "044 F3 mergeada (#738) — próximo: F4a (T013-T016)",
+    "goal": "044 F4a (T013-T016) — PR #739 aberto, aguardando review Gemini + smoke do PO",
     "goal_type": "feature",
     "spec_dirs": [
       "plans/specs/049-docs-revamp",
@@ -118,7 +118,7 @@
     "tier": 2,
     "spec_dir": "plans/specs/044-dose-only-mode",
     "spec": "plans/specs/044-dose-only-mode/spec.md",
-    "previous_session_note": "044 F3 MERGEADA (#738, squash 226c5614) — PO-2 fechado com smoke manual do PO. LIÇÃO CENTRAL DA FASE: os gates automáticos passaram limpos o tempo todo (1542 testes, strict-island, lint) e os 4 bugs que importavam só apareceram no SMOKE — todos de ciclo de vida (cache não reconciliado pós-escrita, validação em campo invisível, wizard gravando no passo errado), não de lógica. Cada peça isolada estava correta; o furo morava ENTRE elas. Teste de unidade não pega essa classe. Segunda lição: o inventário por grep (T009) desmentiu o design em 11 superfícies — confiar na lista de memória teria entregue metade da fase. O risco R2 do plano estava certo. Terceira: sub-agentes Sonnet entregam render condicional bem, mas o principal PRECISA auditar o caminho do dado (os 4 furos que passaram eram todos de propagação de flag / allowlist de payload). ⚠️ F4a: o toggle de Settings tem a MESMA classe do AP-281 — gravar + refresh(). PRÓXIMO: F4a (T013-T016). SQP do épico na F5. journal=14, threshold=15 → distill logo.",
+    "previous_session_note": "044 F4a implementada (PR #739): ciclo de opt-out — toggle na seção ESTOQUE do Settings (mobile + espelho web), sheet de congelamento (cadeado, NÃO danger), retomada <30d silenciosa com anúncio TEXTUAL, sheet de reconciliação >=30d (default 'começar do zero'; fechar sem decidir NÃO ativa). Hook useStockToggle espelhado consome o stockResumeService da F2 — gap não reimplementado na UI. 'Nunca teve estoque' vs 'congelado' sai de stock_paused_at (null vs carimbo), sem query extra. AP-281 aplicado por desenho (refresh() após TODA escrita da preferência). RC5 do próprio diff pegou 1 furo de ciclo de vida (estado interno do sheet sobrevivia ao fechamento → default visual errado no reabrir); montagem condicional resolve. Gates: 1551 testes, tsc 0, ratchet OK, lint 0 errors. PO-5 SEGUE ABERTO até o smoke do PO — a classe de bug desta feature (ciclo de vida do cache/estado) não aparece em unit test, foi assim na F3. PRÓXIMO: F4b (T017-T021, opt-in: saldo inicial + upsell + analytics), depois F5 (POs com evidência + SQP do épico + C5). journal=15 → distill DEVIDO.",
     "ceremonies_run": [
       "eng-review",
       "security-review"
@@ -143,12 +143,12 @@
   },
   "memory": {
     "last_distillation": "2026-07-09T22:30:00.000Z",
-    "journal_entries_since_distillation": 14,
+    "journal_entries_since_distillation": 15,
     "rules_count": 237,
     "anti_patterns_count": 279,
     "decisions_count": 80,
     "contracts_count": 30,
-    "distillation_due": false
+    "distillation_due": true
   },
   "genes": {
     "memory_distillation_threshold": 15,

--- a/apps/mobile/src/features/profile/components/StockFreezeSheet.tsx
+++ b/apps/mobile/src/features/profile/components/StockFreezeSheet.tsx
@@ -1,0 +1,145 @@
+// StockFreezeSheet.tsx — confirmação do opt-out do controle de estoque (spec 044, T014).
+//
+// Congela, NÃO deleta: ícone de cadeado, botão primário comum — deliberadamente NÃO é uma
+// ação `danger` (§7 das decisões de design). Copy canônica (§9): 2 frases, máximo.
+// R-233: statusBarTranslucent + spacer Android + SafeAreaView edges=['bottom'].
+
+import { View, Text, Modal, Pressable, StyleSheet, Platform, StatusBar, ActivityIndicator } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+// TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob nodenext
+import * as LucideIcons from 'lucide-react-native'
+const { Lock } = LucideIcons as any
+import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
+
+interface Props {
+  visible: boolean
+  applying: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export default function StockFreezeSheet({ visible, applying, onConfirm, onCancel }: Props) {
+  if (!visible) return null
+
+  return (
+    <Modal visible transparent animationType="slide" onRequestClose={onCancel} statusBarTranslucent>
+      {Platform.OS === 'android' ? <View style={{ height: StatusBar.currentHeight ?? 0 }} /> : null}
+      <Pressable style={styles.backdrop} onPress={applying ? undefined : onCancel} />
+      <SafeAreaView edges={['bottom']} style={styles.sheet}>
+        <View style={styles.handle} />
+
+        <View style={styles.iconWrap}>
+          <Lock size={24} color={colors.primary[600]} strokeWidth={2} />
+        </View>
+
+        <Text style={styles.title}>Desativar o controle de estoque?</Text>
+        <Text style={styles.description}>
+          Seu estoque fica guardado como está — nada é apagado. Você deixa de ver saldos e avisos
+          de reposição até reativar.
+        </Text>
+
+        <Pressable
+          onPress={onConfirm}
+          disabled={applying}
+          style={({ pressed }) => [styles.btnPrimary, (pressed || applying) && styles.pressed]}
+          accessibilityRole="button"
+          accessibilityLabel="Desativar o controle de estoque"
+        >
+          {applying ? (
+            <ActivityIndicator size="small" color={colors.text.inverse} />
+          ) : (
+            <Text style={styles.btnPrimaryText}>Desativar</Text>
+          )}
+        </Pressable>
+
+        <Pressable
+          onPress={onCancel}
+          disabled={applying}
+          style={({ pressed }) => [styles.btnCancel, pressed && styles.pressed]}
+          accessibilityRole="button"
+          accessibilityLabel="Cancelar"
+        >
+          <Text style={styles.btnCancelText}>Cancelar</Text>
+        </Pressable>
+      </SafeAreaView>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: colors.bg.overlay,
+  },
+  sheet: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: colors.bg.card,
+    borderTopLeftRadius: borderRadius.xl,
+    borderTopRightRadius: borderRadius.xl,
+    paddingHorizontal: spacing[5],
+    paddingTop: spacing[2],
+    paddingBottom: spacing[6],
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: colors.neutral[300],
+    alignSelf: 'center',
+    marginBottom: spacing[4],
+  },
+  iconWrap: {
+    width: 48,
+    height: 48,
+    borderRadius: borderRadius.lg,
+    backgroundColor: colors.primary[50],
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: spacing[3],
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.text.primary,
+    fontFamily: typography.fontFamily.bold,
+    marginBottom: spacing[2],
+  },
+  description: {
+    fontSize: 14,
+    color: colors.text.secondary,
+    lineHeight: 20,
+    marginBottom: spacing[5],
+  },
+  btnPrimary: {
+    height: 52,
+    borderRadius: borderRadius.lg,
+    backgroundColor: colors.primary[500],
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: spacing[3],
+  },
+  btnPrimaryText: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.text.inverse,
+  },
+  btnCancel: {
+    height: 52,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  btnCancelText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.text.primary,
+  },
+  pressed: {
+    opacity: 0.85,
+  },
+})

--- a/apps/mobile/src/features/profile/components/StockFreezeSheet.tsx
+++ b/apps/mobile/src/features/profile/components/StockFreezeSheet.tsx
@@ -22,7 +22,15 @@ export default function StockFreezeSheet({ visible, applying, onConfirm, onCance
   if (!visible) return null
 
   return (
-    <Modal visible transparent animationType="slide" onRequestClose={onCancel} statusBarTranslucent>
+    // `onRequestClose` = botão voltar do Android: inibido enquanto a escrita está em voo, senão
+    // o sheet some no meio da operação e a UI passa a opinar sobre um resultado inexistente.
+    <Modal
+      visible
+      transparent
+      animationType="slide"
+      onRequestClose={applying ? undefined : onCancel}
+      statusBarTranslucent
+    >
       {Platform.OS === 'android' ? <View style={{ height: StatusBar.currentHeight ?? 0 }} /> : null}
       <Pressable style={styles.backdrop} onPress={applying ? undefined : onCancel} />
       <SafeAreaView edges={['bottom']} style={styles.sheet}>

--- a/apps/mobile/src/features/profile/components/StockReconcileSheet.tsx
+++ b/apps/mobile/src/features/profile/components/StockReconcileSheet.tsx
@@ -11,7 +11,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob nodenext
 import * as LucideIcons from 'lucide-react-native'
 const { Check } = LucideIcons as any
-import { parseISO } from '@dosiq/core'
+import { parseISO, formatDatePtBR } from '@dosiq/core'
 import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
 
 type Choice = 'zero' | 'resume'
@@ -27,12 +27,17 @@ interface Props {
   onClose: () => void
 }
 
-/** Data do congelamento em PT-BR; carimbo ausente/inválido → null (o rótulo cai no genérico). */
+/**
+ * Data do congelamento em PT-BR; carimbo ausente/inválido → null (o rótulo cai no genérico).
+ * `formatDatePtBR` (tabela manual de meses), NUNCA `toLocaleDateString('pt-BR')`: o Hermes não
+ * tem ICU completo e cairia no formato US, mostrando "Retomar o saldo de 06/12/2026" para um
+ * congelamento de 12 de junho.
+ */
 function pausedDateLabel(pausedAt: string | null): string | null {
   if (!pausedAt) return null
   const date = parseISO(pausedAt)
   if (Number.isNaN(date.getTime())) return null
-  return date.toLocaleDateString('pt-BR')
+  return formatDatePtBR(date) || null
 }
 
 function Option({
@@ -82,7 +87,16 @@ export default function StockReconcileSheet({
   const resumeTitle = dateLabel ? `Retomar o saldo de ${dateLabel}` : 'Retomar o saldo congelado'
 
   return (
-    <Modal visible transparent animationType="slide" onRequestClose={onClose} statusBarTranslucent>
+    // `onRequestClose` = botão voltar do Android: inibido durante a escrita (o zeramento por
+    // medicamento leva tempo) — fechar no meio deixaria a UI opinando sobre um resultado que
+    // ainda não existe.
+    <Modal
+      visible
+      transparent
+      animationType="slide"
+      onRequestClose={applying ? undefined : onClose}
+      statusBarTranslucent
+    >
       {Platform.OS === 'android' ? <View style={{ height: StatusBar.currentHeight ?? 0 }} /> : null}
       <Pressable style={styles.backdrop} onPress={applying ? undefined : onClose} />
       <SafeAreaView edges={['bottom']} style={styles.sheet}>

--- a/apps/mobile/src/features/profile/components/StockReconcileSheet.tsx
+++ b/apps/mobile/src/features/profile/components/StockReconcileSheet.tsx
@@ -1,0 +1,256 @@
+// StockReconcileSheet.tsx — reconciliação na reativação após gap >= 30 dias (spec 044, T016).
+//
+// Default VISUAL = "Começar do zero" (pré-selecionado); a escolha é sempre do usuário — nunca
+// há reset automático por tempo. Fechar sem decidir NÃO ativa: a preferência continua OFF e o
+// sheet reaparece na próxima tentativa (§6 das decisões de design).
+// R-233: statusBarTranslucent + spacer Android + SafeAreaView edges=['bottom'].
+
+import { useState } from 'react'
+import { View, Text, Modal, Pressable, StyleSheet, Platform, StatusBar, ActivityIndicator } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+// TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob nodenext
+import * as LucideIcons from 'lucide-react-native'
+const { Check } = LucideIcons as any
+import { parseISO } from '@dosiq/core'
+import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
+
+type Choice = 'zero' | 'resume'
+
+// Montado apenas enquanto o sheet está aberto (SettingsScreen): a desmontagem é o que devolve
+// o `choice` ao default "Começar do zero" a cada nova tentativa.
+interface Props {
+  gapDays: number
+  pausedAt: string | null
+  applying: boolean
+  onZero: () => void
+  onResume: () => void
+  onClose: () => void
+}
+
+/** Data do congelamento em PT-BR; carimbo ausente/inválido → null (o rótulo cai no genérico). */
+function pausedDateLabel(pausedAt: string | null): string | null {
+  if (!pausedAt) return null
+  const date = parseISO(pausedAt)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toLocaleDateString('pt-BR')
+}
+
+function Option({
+  selected,
+  title,
+  description,
+  onPress,
+  disabled,
+}: {
+  selected: boolean
+  title: string
+  description: string
+  onPress: () => void
+  disabled: boolean
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      style={[styles.option, selected && styles.optionSelected]}
+      accessibilityRole="radio"
+      accessibilityState={{ checked: selected, disabled }}
+      accessibilityLabel={`${title}. ${description}`}
+    >
+      <View style={[styles.radio, selected && styles.radioSelected]}>
+        {selected ? <Check size={12} color={colors.text.inverse} strokeWidth={3} /> : null}
+      </View>
+      <View style={styles.optionText}>
+        <Text style={[styles.optionTitle, selected && styles.optionTitleSelected]}>{title}</Text>
+        <Text style={styles.optionDesc}>{description}</Text>
+      </View>
+    </Pressable>
+  )
+}
+
+export default function StockReconcileSheet({
+  gapDays,
+  pausedAt,
+  applying,
+  onZero,
+  onResume,
+  onClose,
+}: Props) {
+  const [choice, setChoice] = useState<Choice>('zero')
+
+  const dateLabel = pausedDateLabel(pausedAt)
+  const resumeTitle = dateLabel ? `Retomar o saldo de ${dateLabel}` : 'Retomar o saldo congelado'
+
+  return (
+    <Modal visible transparent animationType="slide" onRequestClose={onClose} statusBarTranslucent>
+      {Platform.OS === 'android' ? <View style={{ height: StatusBar.currentHeight ?? 0 }} /> : null}
+      <Pressable style={styles.backdrop} onPress={applying ? undefined : onClose} />
+      <SafeAreaView edges={['bottom']} style={styles.sheet}>
+        <View style={styles.handle} />
+
+        <Text style={styles.title}>
+          Seu estoque está congelado há {gapDays} {gapDays === 1 ? 'dia' : 'dias'}
+        </Text>
+        <Text style={styles.description}>Como você quer voltar a usar o estoque?</Text>
+
+        <View accessibilityRole="radiogroup">
+          <Option
+            selected={choice === 'zero'}
+            title="Começar do zero"
+            description="O saldo volta a zero. O histórico de compras fica guardado."
+            onPress={() => setChoice('zero')}
+            disabled={applying}
+          />
+          <Option
+            selected={choice === 'resume'}
+            title={resumeTitle}
+            description="Volta exatamente como estava quando você desativou."
+            onPress={() => setChoice('resume')}
+            disabled={applying}
+          />
+        </View>
+
+        <Pressable
+          onPress={choice === 'zero' ? onZero : onResume}
+          disabled={applying}
+          style={({ pressed }) => [styles.btnPrimary, (pressed || applying) && styles.pressed]}
+          accessibilityRole="button"
+          accessibilityLabel="Ativar o controle de estoque"
+        >
+          {applying ? (
+            <ActivityIndicator size="small" color={colors.text.inverse} />
+          ) : (
+            <Text style={styles.btnPrimaryText}>Ativar estoque</Text>
+          )}
+        </Pressable>
+
+        <Pressable
+          onPress={onClose}
+          disabled={applying}
+          style={({ pressed }) => [styles.btnCancel, pressed && styles.pressed]}
+          accessibilityRole="button"
+          accessibilityLabel="Cancelar — o controle de estoque continua desativado"
+        >
+          <Text style={styles.btnCancelText}>Cancelar</Text>
+        </Pressable>
+      </SafeAreaView>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: colors.bg.overlay,
+  },
+  sheet: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: colors.bg.card,
+    borderTopLeftRadius: borderRadius.xl,
+    borderTopRightRadius: borderRadius.xl,
+    paddingHorizontal: spacing[5],
+    paddingTop: spacing[2],
+    paddingBottom: spacing[6],
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: colors.neutral[300],
+    alignSelf: 'center',
+    marginBottom: spacing[4],
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.text.primary,
+    fontFamily: typography.fontFamily.bold,
+    marginBottom: spacing[1],
+  },
+  description: {
+    fontSize: 14,
+    color: colors.text.secondary,
+    lineHeight: 20,
+    marginBottom: spacing[4],
+  },
+  option: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    minHeight: 76,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1.5,
+    borderColor: colors.border.light,
+    backgroundColor: colors.bg.screen,
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    marginBottom: spacing[3],
+  },
+  optionSelected: {
+    borderColor: colors.primary[500],
+    backgroundColor: colors.primary[50],
+  },
+  radio: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    borderWidth: 1.5,
+    borderColor: colors.border.default,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  radioSelected: {
+    borderColor: colors.primary[500],
+    backgroundColor: colors.primary[500],
+  },
+  optionText: {
+    flex: 1,
+  },
+  optionTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.text.primary,
+    marginBottom: 2,
+  },
+  optionTitleSelected: {
+    color: colors.primary[700],
+  },
+  optionDesc: {
+    fontSize: 12,
+    color: colors.text.secondary,
+    lineHeight: 16,
+  },
+  btnPrimary: {
+    height: 52,
+    borderRadius: borderRadius.lg,
+    backgroundColor: colors.primary[500],
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: spacing[3],
+    marginTop: spacing[1],
+  },
+  btnPrimaryText: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.text.inverse,
+  },
+  btnCancel: {
+    height: 52,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  btnCancelText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.text.primary,
+  },
+  pressed: {
+    opacity: 0.85,
+  },
+})

--- a/apps/mobile/src/features/profile/hooks/useStockToggle.ts
+++ b/apps/mobile/src/features/profile/hooks/useStockToggle.ts
@@ -1,0 +1,187 @@
+// useStockToggle — máquina de estados do toggle "Controle de estoque" (spec 044, F4a / PO-5).
+//
+// Invariante desta fase: OPT-OUT SEMPRE CONGELA. Zero mutação de saldo/compras; o único
+// caminho que muta estoque é o "começar do zero" da reconciliação (adjustment append-only
+// `legacy_unrecoverable`, R-226), e só quando o usuário escolhe.
+//
+// Transições (o serviço do core faz as escritas — aqui só a orquestração da UI):
+//   ON  → toggle  → sheet 'freeze' → [Desativar] setStockTracking(false) (carimba stock_paused_at)
+//   OFF → toggle  → assessResume() (SÓ LEITURA)
+//                     gap < 30d ou sem carimbo → resumeAsIs() silencioso + toast textual
+//                     gap >= 30d               → sheet 'reconcile' (NENHUMA escrita ainda)
+//                        [Começar do zero]   → resumeAndZero()
+//                        [Retomar o saldo]   → resumeAsIs()
+//                        fechar sem decidir  → nada é escrito; segue OFF; reaparece na próxima
+//
+// ⚠️ AP-281: toda escrita da preferência chama `refresh()` do provider ANTES de concluir —
+// senão as superfícies de estoque continuam contradizendo a escolha até o app recarregar.
+// R-010: States → Memos → Effects → Handlers.
+
+import { useCallback, useMemo, useState } from 'react'
+import {
+  createProfileRepository,
+  createStockRepository,
+  createStockResumeService,
+} from '@dosiq/core'
+import { supabase } from '@platform/supabase/nativeSupabaseClient'
+import { useStockTracking } from '@shared/hooks/useStockTracking'
+
+async function getUserId(): Promise<string> {
+  const { data, error } = await supabase.auth.getUser()
+  const user = data?.user
+  if (error || !user) throw new Error('Sessão expirada. Faça login novamente.')
+  return user.id
+}
+
+const profileRepo = createProfileRepository({ client: supabase as never, getUserId })
+const stockRepo = createStockRepository({ client: supabase as never, getUserId })
+const resumeService = createStockResumeService({ profileRepo, stockRepo })
+
+/** Sheet aberto no momento (null = nenhum). */
+export type StockToggleSheet = null | 'freeze' | 'reconcile'
+
+export interface StockToggleReconcile {
+  /** Dias inteiros de congelamento (>= STOCK_RESUME_RECONCILE_DAYS). */
+  gapDays: number
+  /** Carimbo do opt-out (ISO) — alimenta "Retomar o saldo de {data}". */
+  pausedAt: string | null
+}
+
+export interface UseStockToggle {
+  enabled: boolean
+  ready: boolean
+  /** Nunca teve estoque: off e sem carimbo de congelamento (jamais desativou — nasceu dose-only). */
+  neverHadStock: boolean
+  sheet: StockToggleSheet
+  reconcile: StockToggleReconcile | null
+  busy: boolean
+  /** Mensagem de sucesso a anunciar por TEXTO (toast/live region) — a11y §10 do design. */
+  announcement: string | null
+  clearAnnouncement: () => void
+  error: string | null
+  requestToggle: () => void
+  confirmFreeze: () => Promise<void>
+  resumeAsIs: () => Promise<void>
+  resumeAndZero: () => Promise<void>
+  /** Fechar sem decidir: NÃO ativa. Zero escrita. */
+  closeSheet: () => void
+}
+
+export function useStockToggle(): UseStockToggle {
+  // States
+  const { enabled, pausedAt, ready, refresh } = useStockTracking()
+  const [sheet, setSheet] = useState<StockToggleSheet>(null)
+  const [reconcile, setReconcile] = useState<StockToggleReconcile | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [announcement, setAnnouncement] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // Memos
+  const neverHadStock = useMemo(() => !enabled && !pausedAt, [enabled, pausedAt])
+
+  // Handlers
+  const clearAnnouncement = useCallback(() => setAnnouncement(null), [])
+
+  const closeSheet = useCallback(() => {
+    // Fechar sem decidir nunca ativa: a preferência no banco continua como está.
+    setSheet(null)
+    setReconcile(null)
+  }, [])
+
+  /** Liga o estoque retomando o saldo as-is (gap curto ou escolha explícita do usuário). */
+  const resumeAsIs = useCallback(async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await resumeService.resumeAsIs()
+      await refresh() // AP-281
+      setSheet(null)
+      setReconcile(null)
+      setAnnouncement('Controle de estoque reativado · saldo retomado como estava')
+    } catch (err) {
+      setError((err as Error)?.message ?? 'Erro ao reativar o controle de estoque')
+    } finally {
+      setBusy(false)
+    }
+  }, [refresh])
+
+  /** "Começar do zero": zera por medicamento (append-only) e só então liga a preferência. */
+  const resumeAndZero = useCallback(async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await resumeService.resumeAndZero()
+      await refresh() // AP-281
+      setSheet(null)
+      setReconcile(null)
+      setAnnouncement('Controle de estoque reativado · saldo zerado, histórico de compras preservado')
+    } catch (err) {
+      // Falha no meio do zeramento → a preferência continua OFF (o service só liga no fim):
+      // o sheet reaparece na próxima tentativa, nunca religa o FIFO sobre saldo meio-zerado.
+      setError((err as Error)?.message ?? 'Erro ao reativar o controle de estoque')
+    } finally {
+      setBusy(false)
+    }
+  }, [refresh])
+
+  const confirmFreeze = useCallback(async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      // Congela: carimba stock_paused_at. ZERO mutação de saldo/compras.
+      await profileRepo.setStockTracking(false)
+      await refresh() // AP-281
+      setSheet(null)
+      setAnnouncement('Controle de estoque desativado · seu saldo ficou guardado como estava')
+    } catch (err) {
+      setError((err as Error)?.message ?? 'Erro ao desativar o controle de estoque')
+    } finally {
+      setBusy(false)
+    }
+  }, [refresh])
+
+  const requestToggle = useCallback(() => {
+    if (busy || !ready) return
+    setError(null)
+    if (enabled) {
+      setSheet('freeze')
+      return
+    }
+    // OFF → ON: avalia o gap ANTES de escrever (assessResume só lê).
+    void (async () => {
+      setBusy(true)
+      try {
+        const assessment = await resumeService.assessResume()
+        if (assessment.needsReconciliation && assessment.gapDays !== null) {
+          setReconcile({ gapDays: assessment.gapDays, pausedAt: assessment.pausedAt })
+          setSheet('reconcile')
+          return
+        }
+        await resumeService.resumeAsIs()
+        await refresh() // AP-281
+        setAnnouncement('Controle de estoque reativado · saldo retomado como estava')
+      } catch (err) {
+        setError((err as Error)?.message ?? 'Erro ao reativar o controle de estoque')
+      } finally {
+        setBusy(false)
+      }
+    })()
+  }, [busy, ready, enabled, refresh])
+
+  return {
+    enabled,
+    ready,
+    neverHadStock,
+    sheet,
+    reconcile,
+    busy,
+    announcement,
+    clearAnnouncement,
+    error,
+    requestToggle,
+    confirmFreeze,
+    resumeAsIs,
+    resumeAndZero,
+    closeSheet,
+  }
+}

--- a/apps/mobile/src/features/profile/hooks/useStockToggle.ts
+++ b/apps/mobile/src/features/profile/hooks/useStockToggle.ts
@@ -86,6 +86,9 @@ export function useStockToggle(): UseStockToggle {
     // Fechar sem decidir nunca ativa: a preferência no banco continua como está.
     setSheet(null)
     setReconcile(null)
+    // O erro pertence à tentativa que acabou de ser abandonada — mantê-lo faria a mensagem
+    // ressurgir fora de contexto na próxima interação.
+    setError(null)
   }, [])
 
   /** Liga o estoque retomando o saldo as-is (gap curto ou escolha explícita do usuário). */

--- a/apps/mobile/src/features/profile/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/features/profile/screens/SettingsScreen.tsx
@@ -1,7 +1,7 @@
-// SettingsScreen.jsx — Configurações (Fase 4): densidade da interface + fuso horário + segurança
+// SettingsScreen.jsx — Configurações (Fase 4): densidade da interface + estoque + fuso horário + segurança
 // R-010: States → Memos → Effects → Handlers
 
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   View,
   Text,
@@ -9,20 +9,24 @@ import {
   Pressable,
   StyleSheet,
   ActivityIndicator,
+  Switch,
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useNavigation } from '@react-navigation/native'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob nodenext
 import * as LucideIcons from 'lucide-react-native'
-const { ChevronLeft, ChevronRight, AlignLeft, Sparkles, LayoutGrid, Shield, Trash2, Globe, } = LucideIcons as any
+const { ChevronLeft, ChevronRight, AlignLeft, Sparkles, LayoutGrid, Shield, Trash2, Globe, Package, } = LucideIcons as any
 import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'
 import { ROUTES } from '@navigation/routes'
 import { useProfile } from '@profile/hooks/useProfile'
 import { useProfileMutation } from '@profile/hooks/useProfileMutation'
+import { useStockToggle } from '@profile/hooks/useStockToggle'
 import { useToast } from '@shared/components/feedback/Toast'
 import FormSelect from '@shared/components/form/FormSelect'
 import { TIMEZONE_OPTIONS } from '@dosiq/core'
 import TzIntentSheet from '@profile/components/TzIntentSheet'
+import StockFreezeSheet from '@profile/components/StockFreezeSheet'
+import StockReconcileSheet from '@profile/components/StockReconcileSheet'
 
 // ─── Opções de densidade ──────────────────────────────────────────────────────
 
@@ -161,6 +165,55 @@ function PreferencesCard({ loading, currentComplexity, activeLabel, onSelect }) 
   )
 }
 
+// ─── Sub-componente: controle de estoque (spec 044 · T013) ───────────────────
+
+/**
+ * Subtítulo por estado (§5 das decisões de design):
+ *  on                → saldos e avisos ativos
+ *  off + já congelou → desligado (o saldo está guardado)
+ *  off + nunca teve  → convite + hint do que acontece ao ativar
+ */
+function stockSubtitle(enabled, neverHadStock) {
+  if (enabled) return 'Saldos e avisos de reposição ativos.'
+  if (neverHadStock) return 'Avisa quando o remédio estiver acabando.'
+  return 'Desligado — só lembretes e registro de doses.'
+}
+
+function StockCard({ ready, enabled, neverHadStock, busy, onToggle }) {
+  const subtitle = stockSubtitle(enabled, neverHadStock)
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.stockRow}>
+        <View style={styles.stockInfo}>
+          <Text style={styles.securityRowTitle}>Controle de estoque</Text>
+          <Text style={styles.securityRowSub}>{subtitle}</Text>
+          {!enabled && neverHadStock ? (
+            <Text style={styles.stockHint}>
+              Ao ativar, a gente pergunta quanto você tem de cada remédio agora.
+            </Text>
+          ) : null}
+        </View>
+        {ready && !busy ? (
+          <Switch
+            value={enabled}
+            onValueChange={onToggle}
+            trackColor={{ false: colors.neutral[300], true: colors.primary[500] }}
+            thumbColor={colors.bg.card}
+            accessibilityRole="switch"
+            accessibilityLabel={
+              enabled ? 'Controle de estoque ativado' : 'Controle de estoque desativado'
+            }
+            accessibilityState={{ checked: enabled }}
+          />
+        ) : (
+          <ActivityIndicator size="small" color={colors.primary[500]} />
+        )}
+      </View>
+    </View>
+  )
+}
+
 function TimezoneCard({ loading, timezone, options, onChange }) {
   return (
     <View style={styles.card}>
@@ -195,6 +248,7 @@ export default function SettingsScreen() {
   // Memos/hooks de dados
   const { profile, settings, loading: profileLoading, refresh, updateTimezone, checkFuturePendingDoses } = useProfile()
   const { setComplexity, loading: mutating } = useProfileMutation()
+  const stock = useStockToggle()
   const toast = useToast()
 
   const currentComplexity = useMemo(
@@ -211,6 +265,18 @@ export default function SettingsScreen() {
     () => settings?.timezone ?? 'America/Sao_Paulo',
     [settings],
   )
+
+  // Effects — o anúncio da retomada/congelamento é TEXTUAL (leitor de tela), não só visual.
+  const { announcement: stockAnnouncement, clearAnnouncement: clearStockAnnouncement } = stock
+  useEffect(() => {
+    if (!stockAnnouncement) return
+    toast.show(stockAnnouncement, { variant: 'success' })
+    clearStockAnnouncement()
+  }, [stockAnnouncement, clearStockAnnouncement, toast])
+
+  useEffect(() => {
+    if (stock.error) toast.show(stock.error, { variant: 'error' })
+  }, [stock.error, toast])
 
   // Handlers
   const persistTimezone = useCallback(
@@ -301,6 +367,20 @@ export default function SettingsScreen() {
           onSelect={handleSelectDensity}
         />
 
+        {/* ── Seção ESTOQUE (spec 044 · T013) ── */}
+        <View style={[styles.sectionLabel, styles.sectionLabelMargin]}>
+          <Package size={12} color={colors.text.muted} />
+          <Text style={styles.sectionLabelText}>ESTOQUE</Text>
+        </View>
+
+        <StockCard
+          ready={stock.ready}
+          enabled={stock.enabled}
+          neverHadStock={stock.neverHadStock}
+          busy={stock.busy}
+          onToggle={stock.requestToggle}
+        />
+
         {/* ── Seção FUSO HORÁRIO ── */}
         <View style={[styles.sectionLabel, styles.sectionLabelMargin]}>
           <Globe size={12} color={colors.text.muted} />
@@ -320,6 +400,26 @@ export default function SettingsScreen() {
           onDeleteAccount={handleDeleteAccount}
         />
       </ScrollView>
+
+      <StockFreezeSheet
+        visible={stock.sheet === 'freeze'}
+        applying={stock.busy}
+        onConfirm={stock.confirmFreeze}
+        onCancel={stock.closeSheet}
+      />
+
+      {/* Montagem condicional (não só `visible`): desmontar reseta o `choice` interno para o
+          default "Começar do zero" — senão a escolha da tentativa anterior voltaria pré-marcada. */}
+      {stock.sheet === 'reconcile' && stock.reconcile ? (
+        <StockReconcileSheet
+          gapDays={stock.reconcile.gapDays}
+          pausedAt={stock.reconcile.pausedAt}
+          applying={stock.busy}
+          onZero={stock.resumeAndZero}
+          onResume={stock.resumeAsIs}
+          onClose={stock.closeSheet}
+        />
+      ) : null}
 
       <TzIntentSheet
         prompt={tzPrompt}
@@ -436,6 +536,21 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: colors.text.muted,
     marginTop: spacing[3],
+  },
+  stockRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    minHeight: 48,
+  },
+  stockInfo: {
+    flex: 1,
+  },
+  stockHint: {
+    fontSize: 12,
+    color: colors.text.muted,
+    lineHeight: 16,
+    marginTop: spacing[1],
   },
   securityRow: {
     flexDirection: 'row',

--- a/apps/mobile/src/shared/components/feedback/Toast.tsx
+++ b/apps/mobile/src/shared/components/feedback/Toast.tsx
@@ -38,6 +38,25 @@ const VARIANT_CONFIG = {
   },
 }
 
+// ─── Duração de leitura ───────────────────────────────────────────────────────
+
+const TOAST_BASE_MS = 2500 // tempo para notar o toast antes de começar a ler
+const TOAST_MS_PER_WORD = 450 // ~130 palavras/min: leitura em tela, com distração
+const TOAST_MIN_MS = 3000
+const TOAST_MAX_MS = 9000
+
+/**
+ * Duração default proporcional ao tamanho da mensagem.
+ * Toast de confirmação com frase longa (ex.: "Controle de estoque reativado · saldo
+ * retomado como estava") sumia antes de dar tempo de ler com os 3s fixos anteriores.
+ * Chamadas com `duration` explícito continuam mandando.
+ */
+export function readingDuration(message: string): number {
+  const words = String(message ?? '').trim().split(/\s+/).filter(Boolean).length
+  const ms = TOAST_BASE_MS + words * TOAST_MS_PER_WORD
+  return Math.min(TOAST_MAX_MS, Math.max(TOAST_MIN_MS, ms))
+}
+
 // ─── ToastItem ────────────────────────────────────────────────────────────────
 
 const ToastItem = memo(function ToastItem({ toast, onDismiss }: { toast: any; onDismiss: () => void }) {
@@ -126,7 +145,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   const show = useCallback((message: string, opts: { variant?: string; duration?: number } = {}) => {
     const id = ++counterRef.current
     const variant = opts.variant ?? 'info'
-    const duration = opts.duration ?? 3000
+    const duration = opts.duration ?? readingDuration(message)
     const toast = { id, message, variant, duration }
 
     // Dispara haptic conforme variante

--- a/apps/mobile/src/shared/components/feedback/Toast.tsx
+++ b/apps/mobile/src/shared/components/feedback/Toast.tsx
@@ -40,7 +40,7 @@ const VARIANT_CONFIG = {
 
 // ─── Duração de leitura ───────────────────────────────────────────────────────
 
-const TOAST_BASE_MS = 2500 // tempo para notar o toast antes de começar a ler
+const TOAST_BASE_MS = 2000 // tempo para notar o toast antes de começar a ler
 const TOAST_MS_PER_WORD = 450 // ~130 palavras/min: leitura em tela, com distração
 const TOAST_MIN_MS = 3000
 const TOAST_MAX_MS = 9000

--- a/apps/mobile/src/shared/components/feedback/__tests__/toastDuration.test.ts
+++ b/apps/mobile/src/shared/components/feedback/__tests__/toastDuration.test.ts
@@ -1,0 +1,27 @@
+// readingDuration — duração default do toast proporcional ao tamanho da mensagem.
+// Motivo: os 3s fixos anteriores cortavam a leitura das confirmações longas de mudança de
+// estado (smoke da 044 F4a: "Controle de estoque reativado · saldo retomado como estava").
+
+import { readingDuration } from '../Toast'
+
+describe('readingDuration', () => {
+  it('mensagem curta fica perto do piso (nunca abaixo de 3s)', () => {
+    const ms = readingDuration('Preferência salva')
+    expect(ms).toBeGreaterThanOrEqual(3000)
+    expect(ms).toBeLessThan(4000)
+  })
+
+  it('confirmação longa de mudança de estado passa de 6s', () => {
+    const msg = 'Controle de estoque reativado · saldo retomado como estava'
+    expect(readingDuration(msg)).toBeGreaterThanOrEqual(6000)
+  })
+
+  it('mensagem muito longa é limitada ao teto de 9s', () => {
+    expect(readingDuration('palavra '.repeat(50))).toBe(9000)
+  })
+
+  it('mensagem vazia/inválida cai no piso, nunca em NaN', () => {
+    expect(readingDuration('')).toBe(3000)
+    expect(readingDuration(undefined as unknown as string)).toBe(3000)
+  })
+})

--- a/apps/mobile/src/shared/hooks/useStockTracking.tsx
+++ b/apps/mobile/src/shared/hooks/useStockTracking.tsx
@@ -13,6 +13,8 @@
 
 import { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react'
 import type { ReactNode } from 'react'
+import { AppState } from 'react-native'
+import type { AppStateStatus } from 'react-native'
 import { createProfileRepository } from '@dosiq/core'
 import { supabase } from '@platform/supabase/nativeSupabaseClient'
 
@@ -84,6 +86,19 @@ export function StockTrackingProvider({ children, session = undefined }: Provide
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     refresh()
+  }, [refresh])
+
+  // Revalidação multi-device: a preferência é uma POLÍTICA DE CONTA, não um estado de tela —
+  // desligar o estoque na web tem que refletir no celular que estava minimizado. O `refresh()`
+  // do AP-281 só cobre a escrita feita NESTE device; aqui cobrimos a escrita feita em OUTRO.
+  // Ponto de retomada = volta ao primeiro plano (1 query numa linha; sem polling e sem canal
+  // realtime vivo para um valor que muda uma vez por mês).
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (next: AppStateStatus) => {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      if (next === 'active') refresh()
+    })
+    return () => sub.remove()
   }, [refresh])
 
   return (

--- a/apps/web/src/features/settings/hooks/__tests__/useStockToggle.test.tsx
+++ b/apps/web/src/features/settings/hooks/__tests__/useStockToggle.test.tsx
@@ -205,6 +205,29 @@ describe('useStockToggle (044 F4a)', () => {
     expect(result.current.announcement).toBeNull()
   })
 
+  it('fechar o sheet limpa o erro da tentativa abandonada', async () => {
+    trackingState = { enabled: false, pausedAt: '2026-05-01T10:00:00Z', ready: true }
+    assessResume.mockResolvedValue({
+      pausedAt: '2026-05-01T10:00:00Z',
+      gapDays: 47,
+      needsReconciliation: true,
+    })
+    resumeAndZero.mockRejectedValue(new Error('falha no ajuste'))
+    const { result } = renderHook(() => useStockToggle())
+
+    act(() => result.current.requestToggle())
+    await waitFor(() => expect(result.current.sheet).toBe('reconcile'))
+    await act(async () => {
+      await result.current.resumeAndZero()
+    })
+    expect(result.current.error).toBe('falha no ajuste')
+
+    act(() => result.current.closeSheet())
+
+    // Erro de uma ação que o usuário desistiu de fazer não pode sobreviver ao fechamento.
+    expect(result.current.error).toBeNull()
+  })
+
   it('usuário que nunca teve estoque (off sem carimbo) é distinguido do congelado', () => {
     trackingState = { enabled: false, pausedAt: null, ready: true }
     const { result } = renderHook(() => useStockToggle())

--- a/apps/web/src/features/settings/hooks/__tests__/useStockToggle.test.tsx
+++ b/apps/web/src/features/settings/hooks/__tests__/useStockToggle.test.tsx
@@ -1,0 +1,218 @@
+// useStockToggle — máquina de estados do toggle de estoque (spec 044, F4a / PO-5).
+//
+// O que estes testes protegem (e por quê):
+//  • opt-out CONGELA: grava a preferência e NUNCA toca em saldo (`adjustToBalance`/`resumeAndZero`).
+//  • retomada < 30d é SILENCIOSA e anunciada por TEXTO (sem sheet).
+//  • retomada >= 30d NÃO escreve nada até o usuário escolher.
+//  • fechar o sheet sem decidir NÃO ativa (zero escrita) e o sheet reaparece na próxima tentativa.
+//  • AP-281: TODA escrita da preferência chama `refresh()` do provider.
+//
+// AP-279: os mocks honram a semântica que os testes afirmam — `assessResume` devolve o gap que o
+// cenário declara e as escritas são spies distintos, para que "não mutou saldo" seja verificável.
+
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const assessResume = vi.fn()
+const resumeAsIs = vi.fn()
+const resumeAndZero = vi.fn()
+const setStockTracking = vi.fn()
+const refresh = vi.fn()
+
+let trackingState = { enabled: true, pausedAt: null as string | null, ready: true }
+
+vi.mock('@dosiq/core', () => ({
+  createProfileRepository: () => ({ setStockTracking }),
+  createStockRepository: () => ({}),
+  createStockResumeService: () => ({ assessResume, resumeAsIs, resumeAndZero }),
+}))
+
+vi.mock('@shared/utils/supabase', () => ({ supabase: {}, getUserId: vi.fn() }))
+
+vi.mock('@shared/hooks/useStockTracking', () => ({
+  useStockTracking: () => ({ ...trackingState, refresh }),
+}))
+
+const { useStockToggle } = await import('../useStockToggle')
+
+describe('useStockToggle (044 F4a)', () => {
+  beforeEach(() => {
+    trackingState = { enabled: true, pausedAt: null, ready: true }
+    assessResume.mockResolvedValue({ pausedAt: null, gapDays: null, needsReconciliation: false })
+    resumeAsIs.mockResolvedValue({ pausedAt: null, gapDays: null, needsReconciliation: false })
+    resumeAndZero.mockResolvedValue({ zeroedMedicineIds: [] })
+    setStockTracking.mockResolvedValue({ stock_tracking_enabled: false, stock_paused_at: '2026-06-01T10:00:00Z' })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.clearAllTimers()
+  })
+
+  it('on→off: abre o sheet de congelamento sem escrever nada', () => {
+    const { result } = renderHook(() => useStockToggle())
+
+    act(() => result.current.requestToggle())
+
+    expect(result.current.sheet).toBe('freeze')
+    expect(setStockTracking).not.toHaveBeenCalled()
+    expect(resumeAndZero).not.toHaveBeenCalled()
+  })
+
+  it('on→off confirmado: congela (preferência false) sem mutar saldo e chama refresh (AP-281)', async () => {
+    const { result } = renderHook(() => useStockToggle())
+
+    act(() => result.current.requestToggle())
+    await act(async () => {
+      await result.current.confirmFreeze()
+    })
+
+    expect(setStockTracking).toHaveBeenCalledWith(false)
+    // OPT-OUT SEMPRE CONGELA: zero mutação de saldo.
+    expect(resumeAndZero).not.toHaveBeenCalled()
+    expect(refresh).toHaveBeenCalled()
+    expect(result.current.sheet).toBeNull()
+    expect(result.current.announcement).toMatch(/guardado como estava/i)
+  })
+
+  it('off→on com gap < 30d: retoma as-is, sem sheet, com anúncio textual', async () => {
+    trackingState = { enabled: false, pausedAt: '2026-07-01T10:00:00Z', ready: true }
+    assessResume.mockResolvedValue({
+      pausedAt: '2026-07-01T10:00:00Z',
+      gapDays: 11,
+      needsReconciliation: false,
+    })
+    const { result } = renderHook(() => useStockToggle())
+
+    act(() => result.current.requestToggle())
+
+    await waitFor(() => expect(resumeAsIs).toHaveBeenCalledTimes(1))
+    expect(result.current.sheet).toBeNull()
+    expect(resumeAndZero).not.toHaveBeenCalled()
+    expect(refresh).toHaveBeenCalled()
+    expect(result.current.announcement).toBe(
+      'Controle de estoque reativado · saldo retomado como estava',
+    )
+  })
+
+  it('off→on com gap >= 30d: abre a reconciliação e NÃO escreve nada ainda', async () => {
+    trackingState = { enabled: false, pausedAt: '2026-05-01T10:00:00Z', ready: true }
+    assessResume.mockResolvedValue({
+      pausedAt: '2026-05-01T10:00:00Z',
+      gapDays: 47,
+      needsReconciliation: true,
+    })
+    const { result } = renderHook(() => useStockToggle())
+
+    act(() => result.current.requestToggle())
+
+    await waitFor(() => expect(result.current.sheet).toBe('reconcile'))
+    expect(result.current.reconcile).toEqual({ gapDays: 47, pausedAt: '2026-05-01T10:00:00Z' })
+    expect(resumeAsIs).not.toHaveBeenCalled()
+    expect(resumeAndZero).not.toHaveBeenCalled()
+    expect(setStockTracking).not.toHaveBeenCalled()
+  })
+
+  it('reconciliação → "começar do zero": zera por medicamento e reativa (append-only)', async () => {
+    trackingState = { enabled: false, pausedAt: '2026-05-01T10:00:00Z', ready: true }
+    assessResume.mockResolvedValue({
+      pausedAt: '2026-05-01T10:00:00Z',
+      gapDays: 47,
+      needsReconciliation: true,
+    })
+    const { result } = renderHook(() => useStockToggle())
+
+    act(() => result.current.requestToggle())
+    await waitFor(() => expect(result.current.sheet).toBe('reconcile'))
+
+    await act(async () => {
+      await result.current.resumeAndZero()
+    })
+
+    expect(resumeAndZero).toHaveBeenCalledTimes(1)
+    expect(resumeAsIs).not.toHaveBeenCalled()
+    expect(refresh).toHaveBeenCalled()
+    expect(result.current.sheet).toBeNull()
+  })
+
+  it('reconciliação → "retomar o saldo": reativa sem mutar saldo', async () => {
+    trackingState = { enabled: false, pausedAt: '2026-05-01T10:00:00Z', ready: true }
+    assessResume.mockResolvedValue({
+      pausedAt: '2026-05-01T10:00:00Z',
+      gapDays: 47,
+      needsReconciliation: true,
+    })
+    const { result } = renderHook(() => useStockToggle())
+
+    act(() => result.current.requestToggle())
+    await waitFor(() => expect(result.current.sheet).toBe('reconcile'))
+
+    await act(async () => {
+      await result.current.resumeAsIs()
+    })
+
+    expect(resumeAsIs).toHaveBeenCalledTimes(1)
+    expect(resumeAndZero).not.toHaveBeenCalled()
+    expect(refresh).toHaveBeenCalled()
+  })
+
+  it('reconciliação fechada sem decidir: NÃO ativa, zero escrita, e o sheet reaparece depois', async () => {
+    trackingState = { enabled: false, pausedAt: '2026-05-01T10:00:00Z', ready: true }
+    assessResume.mockResolvedValue({
+      pausedAt: '2026-05-01T10:00:00Z',
+      gapDays: 47,
+      needsReconciliation: true,
+    })
+    const { result } = renderHook(() => useStockToggle())
+
+    act(() => result.current.requestToggle())
+    await waitFor(() => expect(result.current.sheet).toBe('reconcile'))
+
+    act(() => result.current.closeSheet())
+
+    expect(result.current.sheet).toBeNull()
+    expect(result.current.reconcile).toBeNull()
+    expect(resumeAsIs).not.toHaveBeenCalled()
+    expect(resumeAndZero).not.toHaveBeenCalled()
+    expect(setStockTracking).not.toHaveBeenCalled()
+    expect(refresh).not.toHaveBeenCalled()
+
+    // Próxima tentativa: o sheet reaparece (a preferência continua OFF no banco).
+    act(() => result.current.requestToggle())
+    await waitFor(() => expect(result.current.sheet).toBe('reconcile'))
+  })
+
+  it('falha ao zerar mantém o controle OFF (o service só liga no fim) e reporta o erro', async () => {
+    trackingState = { enabled: false, pausedAt: '2026-05-01T10:00:00Z', ready: true }
+    assessResume.mockResolvedValue({
+      pausedAt: '2026-05-01T10:00:00Z',
+      gapDays: 47,
+      needsReconciliation: true,
+    })
+    resumeAndZero.mockRejectedValue(new Error('falha no ajuste'))
+    const { result } = renderHook(() => useStockToggle())
+
+    act(() => result.current.requestToggle())
+    await waitFor(() => expect(result.current.sheet).toBe('reconcile'))
+
+    await act(async () => {
+      await result.current.resumeAndZero()
+    })
+
+    expect(result.current.error).toBe('falha no ajuste')
+    // Sheet segue aberto: o usuário pode escolher de novo; nada ficou meio-ligado.
+    expect(result.current.sheet).toBe('reconcile')
+    expect(result.current.announcement).toBeNull()
+  })
+
+  it('usuário que nunca teve estoque (off sem carimbo) é distinguido do congelado', () => {
+    trackingState = { enabled: false, pausedAt: null, ready: true }
+    const { result } = renderHook(() => useStockToggle())
+
+    expect(result.current.neverHadStock).toBe(true)
+
+    trackingState = { enabled: false, pausedAt: '2026-05-01T10:00:00Z', ready: true }
+    const frozen = renderHook(() => useStockToggle())
+    expect(frozen.result.current.neverHadStock).toBe(false)
+  })
+})

--- a/apps/web/src/features/settings/hooks/useStockToggle.ts
+++ b/apps/web/src/features/settings/hooks/useStockToggle.ts
@@ -43,10 +43,15 @@ export function useStockToggle() {
   const neverHadStock = useMemo(() => !enabled && !pausedAt, [enabled, pausedAt])
 
   // Handlers
+  const clearAnnouncement = useCallback(() => setAnnouncement(null), [])
+
   const closeSheet = useCallback(() => {
     // Fechar sem decidir NÃO ativa: nada é escrito, a preferência continua OFF.
     setSheet(null)
     setReconcile(null)
+    // O erro é da tentativa abandonada: na web ele fica renderizado abaixo do toggle, então
+    // deixá-lo vivo mostraria a falha de uma ação que o usuário já desistiu de fazer.
+    setError(null)
   }, [])
 
   const resumeAsIs = useCallback(async () => {
@@ -134,6 +139,7 @@ export function useStockToggle() {
     reconcile,
     busy,
     announcement,
+    clearAnnouncement,
     error,
     requestToggle,
     confirmFreeze,

--- a/apps/web/src/features/settings/hooks/useStockToggle.ts
+++ b/apps/web/src/features/settings/hooks/useStockToggle.ts
@@ -1,0 +1,144 @@
+// useStockToggle (web) — espelho do hook mobile: máquina de estados do toggle "Controle de
+// estoque" (spec 044, F4a / PO-5). MESMA preferência global, MESMO serviço do core — a web e o
+// mobile não podem divergir (senão uma consome FIFO e a outra não: corrupção, classe AP-231).
+//
+// Invariante: OPT-OUT SEMPRE CONGELA (zero mutação de saldo/compras). Único caminho que muta
+// estoque = "começar do zero" da reconciliação (adjustment append-only, R-226), por escolha
+// explícita do usuário.
+//
+// ⚠️ AP-281: toda escrita da preferência chama `refresh()` do provider — senão as superfícies
+// de estoque (sidebar, cards, export) continuam contradizendo a escolha até dar reload.
+// R-010: States → Memos → Effects → Handlers.
+
+import { useCallback, useMemo, useState } from 'react'
+import {
+  createProfileRepository,
+  createStockRepository,
+  createStockResumeService,
+} from '@dosiq/core'
+import { supabase, getUserId } from '@shared/utils/supabase'
+import { useStockTracking } from '@shared/hooks/useStockTracking'
+
+const profileRepo = createProfileRepository({ client: supabase, getUserId })
+const stockRepo = createStockRepository({ client: supabase, getUserId })
+const resumeService = createStockResumeService({ profileRepo, stockRepo })
+
+export type StockToggleSheet = null | 'freeze' | 'reconcile'
+
+export interface StockToggleReconcile {
+  gapDays: number
+  pausedAt: string | null
+}
+
+export function useStockToggle() {
+  // States
+  const { enabled, pausedAt, ready, refresh } = useStockTracking()
+  const [sheet, setSheet] = useState<StockToggleSheet>(null)
+  const [reconcile, setReconcile] = useState<StockToggleReconcile | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [announcement, setAnnouncement] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // Memos
+  const neverHadStock = useMemo(() => !enabled && !pausedAt, [enabled, pausedAt])
+
+  // Handlers
+  const closeSheet = useCallback(() => {
+    // Fechar sem decidir NÃO ativa: nada é escrito, a preferência continua OFF.
+    setSheet(null)
+    setReconcile(null)
+  }, [])
+
+  const resumeAsIs = useCallback(async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await resumeService.resumeAsIs()
+      await refresh() // AP-281
+      setSheet(null)
+      setReconcile(null)
+      setAnnouncement('Controle de estoque reativado · saldo retomado como estava')
+    } catch (err) {
+      setError((err as Error)?.message ?? 'Erro ao reativar o controle de estoque')
+    } finally {
+      setBusy(false)
+    }
+  }, [refresh])
+
+  const resumeAndZero = useCallback(async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      // Zera por medicamento (append-only) e só então liga a preferência: falha no meio
+      // deixa o controle OFF e o sheet reaparece — nunca religa o FIFO sobre saldo parcial.
+      await resumeService.resumeAndZero()
+      await refresh() // AP-281
+      setSheet(null)
+      setReconcile(null)
+      setAnnouncement('Controle de estoque reativado · saldo zerado, histórico de compras preservado')
+    } catch (err) {
+      setError((err as Error)?.message ?? 'Erro ao reativar o controle de estoque')
+    } finally {
+      setBusy(false)
+    }
+  }, [refresh])
+
+  const confirmFreeze = useCallback(async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await profileRepo.setStockTracking(false) // carimba stock_paused_at; zero mutação de saldo
+      await refresh() // AP-281
+      setSheet(null)
+      setAnnouncement('Controle de estoque desativado · seu saldo ficou guardado como estava')
+    } catch (err) {
+      setError((err as Error)?.message ?? 'Erro ao desativar o controle de estoque')
+    } finally {
+      setBusy(false)
+    }
+  }, [refresh])
+
+  const requestToggle = useCallback(() => {
+    if (busy || !ready) return
+    setError(null)
+    if (enabled) {
+      setSheet('freeze')
+      return
+    }
+    void (async () => {
+      setBusy(true)
+      try {
+        // Só leitura: decide entre retomada silenciosa e reconciliação ANTES de escrever.
+        const assessment = await resumeService.assessResume()
+        if (assessment.needsReconciliation && assessment.gapDays !== null) {
+          setReconcile({ gapDays: assessment.gapDays, pausedAt: assessment.pausedAt })
+          setSheet('reconcile')
+          return
+        }
+        await resumeService.resumeAsIs()
+        await refresh() // AP-281
+        setAnnouncement('Controle de estoque reativado · saldo retomado como estava')
+      } catch (err) {
+        setError((err as Error)?.message ?? 'Erro ao reativar o controle de estoque')
+      } finally {
+        setBusy(false)
+      }
+    })()
+  }, [busy, ready, enabled, refresh])
+
+  return {
+    enabled,
+    ready,
+    neverHadStock,
+    sheet,
+    reconcile,
+    busy,
+    announcement,
+    error,
+    requestToggle,
+    confirmFreeze,
+    resumeAsIs,
+    resumeAndZero,
+    closeSheet,
+  }
+}

--- a/apps/web/src/shared/hooks/__tests__/useStockTracking.test.tsx
+++ b/apps/web/src/shared/hooks/__tests__/useStockTracking.test.tsx
@@ -1,0 +1,102 @@
+// StockTrackingProvider — revalidação multi-device da preferência de estoque (spec 044).
+//
+// Cenário que motiva o teste (smoke da F4a): o usuário desliga o controle de estoque na web
+// enquanto a outra superfície está aberta em segundo plano. A preferência é uma POLÍTICA DE
+// CONTA — quando a aba volta ao foco, as superfícies de estoque precisam obedecer à escolha
+// feita no OUTRO device. O `refresh()` do AP-281 só cobre a escrita feita nesta superfície.
+
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const getStockTracking = vi.fn()
+
+vi.mock('@dosiq/core', () => ({
+  createProfileRepository: () => ({ getStockTracking }),
+}))
+
+vi.mock('@shared/utils/supabase', () => ({ supabase: {}, getUserId: vi.fn() }))
+
+const { StockTrackingProvider, useStockTracking } = await import('../useStockTracking')
+
+function Probe() {
+  const { enabled, ready } = useStockTracking()
+  return <span data-testid="state">{!ready ? 'loading' : enabled ? 'on' : 'off'}</span>
+}
+
+function renderProvider() {
+  return render(
+    <StockTrackingProvider session={{ user: { id: 'u1' } }}>
+      <Probe />
+    </StockTrackingProvider>,
+  )
+}
+
+describe('StockTrackingProvider — revalidação multi-device', () => {
+  beforeEach(() => {
+    getStockTracking.mockResolvedValue({ stock_tracking_enabled: true, stock_paused_at: null })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.clearAllTimers()
+  })
+
+  it('reflete o desligamento feito em OUTRO device quando a aba volta ao foco', async () => {
+    renderProvider()
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('on'))
+
+    // O outro device (mobile) desligou o controle de estoque.
+    getStockTracking.mockResolvedValue({
+      stock_tracking_enabled: false,
+      stock_paused_at: '2026-07-12T10:00:00Z',
+    })
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+    })
+
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('off'))
+  })
+
+  it('revalida no visibilitychange apenas quando a aba está visível', async () => {
+    renderProvider()
+    await waitFor(() => expect(getStockTracking).toHaveBeenCalledTimes(1))
+
+    // Aba indo para segundo plano: não gasta query.
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    expect(getStockTracking).toHaveBeenCalledTimes(1)
+
+    // Aba retomada: revalida.
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await waitFor(() => expect(getStockTracking).toHaveBeenCalledTimes(2))
+  })
+
+  it('falha de rede na revalidação NÃO esconde o estoque de quem o usa (fail-safe AP-277)', async () => {
+    renderProvider()
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('on'))
+
+    getStockTracking.mockRejectedValue(new Error('rede caiu'))
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+    })
+
+    await waitFor(() => expect(getStockTracking).toHaveBeenCalledTimes(2))
+    expect(screen.getByTestId('state')).toHaveTextContent('on')
+  })
+
+  it('sem sessão não consulta o backend', async () => {
+    render(
+      <StockTrackingProvider>
+        <Probe />
+      </StockTrackingProvider>,
+    )
+    await waitFor(() => expect(screen.getByTestId('state')).toHaveTextContent('on'))
+    expect(getStockTracking).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/shared/hooks/useStockTracking.tsx
+++ b/apps/web/src/shared/hooks/useStockTracking.tsx
@@ -74,6 +74,23 @@ export function StockTrackingProvider({ children, session = undefined }: Provide
     refresh()
   }, [refresh])
 
+  // Revalidação multi-device (espelho do mobile): a preferência é uma POLÍTICA DE CONTA — se o
+  // usuário desligou o estoque no celular, a aba que ficou aberta aqui não pode seguir mostrando
+  // saldos. Ponto de retomada = a aba voltar ao foco/visível. Sem polling, sem canal realtime.
+  useEffect(() => {
+    const revalidate = () => {
+      if (document.visibilityState !== 'visible') return
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      refresh()
+    }
+    window.addEventListener('focus', revalidate)
+    document.addEventListener('visibilitychange', revalidate)
+    return () => {
+      window.removeEventListener('focus', revalidate)
+      document.removeEventListener('visibilitychange', revalidate)
+    }
+  }, [refresh])
+
   return (
     <StockTrackingContext.Provider value={value}>
       {children}

--- a/apps/web/src/views/Settings.tsx
+++ b/apps/web/src/views/Settings.tsx
@@ -3,6 +3,7 @@ import { supabase } from '@shared/utils/supabase'
 import SettingsHeader from '@settings/sections/SettingsHeader'
 import NotificationSection from '@settings/sections/NotificationSection'
 import PreferenceSection from '@settings/sections/PreferenceSection'
+import StockSection from '@settings/sections/StockSection'
 import AccountSection from '@settings/sections/AccountSection'
 import AdminSection from '@settings/sections/AdminSection'
 import { useSettingsState } from '@features/settings/hooks/useSettingsState'
@@ -48,6 +49,7 @@ export default function Settings({ onNavigate, mode }) {
       ) : mode === 'account' ? (
         <>
           <PreferenceSection {...preference} />
+          <StockSection />
           <AdminSection isAdmin={isAdmin} dlqCount={dlqCount} onNavigate={onNavigate} />
           <AccountSection
             showPasswordForm={showPasswordForm} setShowPasswordForm={setShowPasswordForm}
@@ -65,6 +67,7 @@ export default function Settings({ onNavigate, mode }) {
         <>
           <NotificationSection {...notification} {...integration} />
           <PreferenceSection {...preference} />
+          <StockSection />
           <AccountSection
             showPasswordForm={showPasswordForm} setShowPasswordForm={setShowPasswordForm}
             handleUpdatePassword={handleUpdatePassword} newPassword={newPassword}

--- a/apps/web/src/views/settings/sections/StockSection.css
+++ b/apps/web/src/views/settings/sections/StockSection.css
@@ -134,6 +134,10 @@
   color: var(--color-on-surface);
 }
 
+.stock-reconcile__actions {
+  margin-top: 1.25rem;
+}
+
 .stock-reconcile__option {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/views/settings/sections/StockSection.css
+++ b/apps/web/src/views/settings/sections/StockSection.css
@@ -1,0 +1,176 @@
+/* StockSection — toggle de controle de estoque + congelamento/reconciliação (spec 044, F4a). */
+
+.stock-toggle {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.stock-toggle__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  flex: 1;
+}
+
+.stock-toggle__label {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-on-surface);
+}
+
+.stock-toggle__sub {
+  font-size: 0.85rem;
+  opacity: 0.7;
+  line-height: 1.4;
+}
+
+.stock-toggle__hint {
+  font-size: 0.8rem;
+  opacity: 0.6;
+  line-height: 1.4;
+}
+
+.stock-toggle__switch {
+  position: relative;
+  flex-shrink: 0;
+  width: 52px;
+  height: 32px;
+  border-radius: 999px;
+  border: none;
+  background: var(--color-outline-ghost, rgba(25, 28, 29, 0.18));
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.stock-toggle__switch--on {
+  background: var(--color-primary);
+}
+
+.stock-toggle__switch:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.stock-toggle__knob {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.15s ease;
+}
+
+.stock-toggle__switch--on .stock-toggle__knob {
+  transform: translateX(20px);
+}
+
+.stock-toggle__status:empty {
+  display: none;
+}
+
+.stock-toggle__status {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: var(--color-primary);
+}
+
+.stock-toggle__error {
+  margin: 0.5rem 0 0;
+  font-size: 0.85rem;
+  color: var(--color-error, #b3261e);
+}
+
+/* ── Modal de congelamento (cadeado, NÃO é ação danger) ── */
+
+.stock-freeze__icon {
+  color: var(--color-primary);
+}
+
+.stock-freeze__body {
+  margin: 0.75rem 0 1.25rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--color-on-surface);
+}
+
+.stock-freeze__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.stock-btn {
+  flex: 1;
+  min-height: 48px;
+  padding: 0 1rem;
+  border-radius: 0.75rem;
+  border: 1.5px solid var(--color-outline-ghost, rgba(25, 28, 29, 0.12));
+  background: transparent;
+  color: var(--color-on-surface);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.stock-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.stock-btn--primary {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  color: #fff;
+}
+
+/* ── Modal de reconciliação (>=30d) ── */
+
+.stock-reconcile__body {
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--color-on-surface);
+}
+
+.stock-reconcile__option {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  width: 100%;
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1.5px solid var(--color-outline-ghost, rgba(25, 28, 29, 0.08));
+  background: transparent;
+  color: var(--color-on-surface);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.stock-reconcile__option:hover {
+  border-color: var(--color-primary);
+}
+
+.stock-reconcile__option:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.stock-reconcile__option--default {
+  border-color: var(--color-primary);
+  background: var(--color-primary-bg, rgba(0, 106, 94, 0.12));
+}
+
+.stock-reconcile__option-label {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.stock-reconcile__option-desc {
+  font-size: 0.85rem;
+  opacity: 0.7;
+  line-height: 1.4;
+}

--- a/apps/web/src/views/settings/sections/StockSection.tsx
+++ b/apps/web/src/views/settings/sections/StockSection.tsx
@@ -1,0 +1,160 @@
+// StockSection — espelho web do toggle "Controle de estoque" (spec 044, T013/T014/T015/T016).
+//
+// Mesma preferência global do mobile (backend), mesmo serviço do core. Congelar NÃO deleta:
+// o modal de confirmação usa cadeado e botão primário comum — não é ação `danger`.
+// Fechar o modal de reconciliação NÃO ativa o estoque.
+
+import { Package, Lock } from 'lucide-react'
+import Modal from '@shared/components/ui/Modal'
+import { parseISO } from '@dosiq/core'
+import { useStockToggle } from '@features/settings/hooks/useStockToggle'
+import './StockSection.css'
+
+/** Subtítulo por estado (§5 das decisões de design do 044). */
+function stockSubtitle(enabled, neverHadStock) {
+  if (enabled) return 'Saldos e avisos de reposição ativos.'
+  if (neverHadStock) return 'Avisa quando o remédio estiver acabando.'
+  return 'Desligado — só lembretes e registro de doses.'
+}
+
+/** Data do congelamento em PT-BR; carimbo ausente/inválido → null (rótulo cai no genérico). */
+function pausedDateLabel(pausedAt) {
+  if (!pausedAt) return null
+  const date = parseISO(pausedAt)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toLocaleDateString('pt-BR')
+}
+
+export default function StockSection() {
+  const {
+    enabled,
+    ready,
+    neverHadStock,
+    sheet,
+    reconcile,
+    busy,
+    announcement,
+    error,
+    requestToggle,
+    confirmFreeze,
+    resumeAsIs,
+    resumeAndZero,
+    closeSheet,
+  } = useStockToggle()
+
+  const gapDays = reconcile?.gapDays ?? 0
+  const dateLabel = pausedDateLabel(reconcile?.pausedAt ?? null)
+
+  return (
+    <section className="sr-section">
+      <h3 className="sr-section__title">
+        <Package size={24} /> Estoque
+      </h3>
+
+      <div className="sr-section__card">
+        <div className="stock-toggle">
+          <div className="stock-toggle__info">
+            <span className="stock-toggle__label">Controle de estoque</span>
+            <span className="stock-toggle__sub">{stockSubtitle(enabled, neverHadStock)}</span>
+            {!enabled && neverHadStock ? (
+              <span className="stock-toggle__hint">
+                Ao ativar, a gente pergunta quanto você tem de cada remédio agora.
+              </span>
+            ) : null}
+          </div>
+
+          <button
+            type="button"
+            role="switch"
+            aria-checked={enabled}
+            aria-label={enabled ? 'Controle de estoque ativado' : 'Controle de estoque desativado'}
+            className={`stock-toggle__switch ${enabled ? 'stock-toggle__switch--on' : ''}`}
+            onClick={requestToggle}
+            disabled={busy || !ready}
+          >
+            <span className="stock-toggle__knob" />
+          </button>
+        </div>
+
+        {/* Anúncio TEXTUAL (a11y §10): a retomada silenciosa não pode ser só visual. */}
+        <p className="stock-toggle__status" role="status" aria-live="polite">
+          {announcement ?? ''}
+        </p>
+        {error ? (
+          <p className="stock-toggle__error" role="alert">
+            {error}
+          </p>
+        ) : null}
+      </div>
+
+      {sheet === 'freeze' ? (
+        <Modal isOpen onClose={closeSheet} title="Desativar o controle de estoque?">
+          <div className="stock-freeze">
+            <Lock size={24} className="stock-freeze__icon" aria-hidden="true" />
+            <p className="stock-freeze__body">
+              Seu estoque fica guardado como está — nada é apagado. Você deixa de ver saldos e
+              avisos de reposição até reativar.
+            </p>
+            <div className="stock-freeze__actions">
+              <button
+                type="button"
+                className="stock-btn stock-btn--primary"
+                onClick={confirmFreeze}
+                disabled={busy}
+              >
+                Desativar
+              </button>
+              <button
+                type="button"
+                className="stock-btn"
+                onClick={closeSheet}
+                disabled={busy}
+              >
+                Cancelar
+              </button>
+            </div>
+          </div>
+        </Modal>
+      ) : null}
+
+      {sheet === 'reconcile' ? (
+        <Modal
+          isOpen
+          onClose={closeSheet}
+          title={`Seu estoque está congelado há ${gapDays} ${gapDays === 1 ? 'dia' : 'dias'}`}
+        >
+          <div className="stock-reconcile">
+            <p className="stock-reconcile__body">Como você quer voltar a usar o estoque?</p>
+
+            {/* "Começar do zero" primeiro = default visual (§7 do design). Fechar não ativa. */}
+            <button
+              type="button"
+              className="stock-reconcile__option stock-reconcile__option--default"
+              onClick={resumeAndZero}
+              disabled={busy}
+            >
+              <span className="stock-reconcile__option-label">Começar do zero</span>
+              <span className="stock-reconcile__option-desc">
+                O saldo volta a zero. O histórico de compras fica guardado.
+              </span>
+            </button>
+
+            <button
+              type="button"
+              className="stock-reconcile__option"
+              onClick={resumeAsIs}
+              disabled={busy}
+            >
+              <span className="stock-reconcile__option-label">
+                {dateLabel ? `Retomar o saldo de ${dateLabel}` : 'Retomar o saldo congelado'}
+              </span>
+              <span className="stock-reconcile__option-desc">
+                Volta exatamente como estava quando você desativou.
+              </span>
+            </button>
+          </div>
+        </Modal>
+      ) : null}
+    </section>
+  )
+}

--- a/apps/web/src/views/settings/sections/StockSection.tsx
+++ b/apps/web/src/views/settings/sections/StockSection.tsx
@@ -4,11 +4,15 @@
 // o modal de confirmação usa cadeado e botão primário comum — não é ação `danger`.
 // Fechar o modal de reconciliação NÃO ativa o estoque.
 
+import { useEffect } from 'react'
 import { Package, Lock } from 'lucide-react'
 import Modal from '@shared/components/ui/Modal'
-import { parseISO } from '@dosiq/core'
+import { parseISO, formatDatePtBR } from '@dosiq/core'
 import { useStockToggle } from '@features/settings/hooks/useStockToggle'
 import './StockSection.css'
+
+/** Fechamento inibido enquanto a escrita está em voo (ver os modais abaixo). */
+const noop = () => {}
 
 /** Subtítulo por estado (§5 das decisões de design do 044). */
 function stockSubtitle(enabled, neverHadStock) {
@@ -17,12 +21,15 @@ function stockSubtitle(enabled, neverHadStock) {
   return 'Desligado — só lembretes e registro de doses.'
 }
 
-/** Data do congelamento em PT-BR; carimbo ausente/inválido → null (rótulo cai no genérico). */
+/**
+ * Data do congelamento em PT-BR; carimbo ausente/inválido → null (rótulo cai no genérico).
+ * Mesma função do mobile (`formatDatePtBR`) para que a copy seja idêntica nas duas superfícies.
+ */
 function pausedDateLabel(pausedAt) {
   if (!pausedAt) return null
   const date = parseISO(pausedAt)
   if (Number.isNaN(date.getTime())) return null
-  return date.toLocaleDateString('pt-BR')
+  return formatDatePtBR(date) || null
 }
 
 export default function StockSection() {
@@ -34,6 +41,7 @@ export default function StockSection() {
     reconcile,
     busy,
     announcement,
+    clearAnnouncement,
     error,
     requestToggle,
     confirmFreeze,
@@ -44,6 +52,14 @@ export default function StockSection() {
 
   const gapDays = reconcile?.gapDays ?? 0
   const dateLabel = pausedDateLabel(reconcile?.pausedAt ?? null)
+
+  // A confirmação é um anúncio, não um estado da tela: sai depois de lida, senão fica poluindo
+  // as Configurações para sempre. 8s — a frase é longa e a região é `aria-live=polite`.
+  useEffect(() => {
+    if (!announcement) return undefined
+    const timer = setTimeout(clearAnnouncement, 8000)
+    return () => clearTimeout(timer)
+  }, [announcement, clearAnnouncement])
 
   return (
     <section className="sr-section">
@@ -88,7 +104,9 @@ export default function StockSection() {
       </div>
 
       {sheet === 'freeze' ? (
-        <Modal isOpen onClose={closeSheet} title="Desativar o controle de estoque?">
+        // Fechar no meio da escrita deixaria a UI opinando sobre um resultado que ainda não
+        // existe: enquanto `busy`, o modal não fecha.
+        <Modal isOpen onClose={busy ? noop : closeSheet} title="Desativar o controle de estoque?">
           <div className="stock-freeze">
             <Lock size={24} className="stock-freeze__icon" aria-hidden="true" />
             <p className="stock-freeze__body">
@@ -120,7 +138,7 @@ export default function StockSection() {
       {sheet === 'reconcile' ? (
         <Modal
           isOpen
-          onClose={closeSheet}
+          onClose={busy ? noop : closeSheet}
           title={`Seu estoque está congelado há ${gapDays} ${gapDays === 1 ? 'dia' : 'dias'}`}
         >
           <div className="stock-reconcile">

--- a/apps/web/src/views/settings/sections/StockSection.tsx
+++ b/apps/web/src/views/settings/sections/StockSection.tsx
@@ -4,7 +4,7 @@
 // o modal de confirmação usa cadeado e botão primário comum — não é ação `danger`.
 // Fechar o modal de reconciliação NÃO ativa o estoque.
 
-import { useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Package, Lock } from 'lucide-react'
 import Modal from '@shared/components/ui/Modal'
 import { parseISO, formatDatePtBR } from '@dosiq/core'
@@ -30,6 +30,106 @@ function pausedDateLabel(pausedAt) {
   const date = parseISO(pausedAt)
   if (Number.isNaN(date.getTime())) return null
   return formatDatePtBR(date) || null
+}
+
+/**
+ * Modal de reconciliação (gap >= 30d). Montado apenas enquanto o sheet está aberto: a
+ * desmontagem é o que devolve a escolha ao default "Começar do zero" a cada nova tentativa —
+ * a opção de uma tentativa anterior nunca volta pré-marcada, muito menos a destrutiva.
+ *
+ * Selecionar NÃO executa: "Começar do zero" zera o saldo, então a confirmação é um segundo ato
+ * deliberado (paridade com o mobile). Radiogroup com roving tabindex — o foco acompanha a
+ * seleção, senão o leitor de tela não anuncia a troca.
+ */
+function ReconcileModal({ gapDays, dateLabel, busy, onZero, onResume, onClose }) {
+  const [choice, setChoice] = useState('zero')
+
+  const handleKeyDown = useCallback(
+    (event) => {
+      if (busy) return
+      const { key } = event
+      let next = null
+      if (['ArrowDown', 'ArrowRight', 'ArrowUp', 'ArrowLeft'].includes(key)) {
+        next = choice === 'zero' ? 'resume' : 'zero'
+      } else if (key === 'Home') {
+        next = 'zero'
+      } else if (key === 'End') {
+        next = 'resume'
+      }
+      if (!next) return
+
+      event.preventDefault()
+      setChoice(next)
+      const radios = event.currentTarget.querySelectorAll('[role="radio"]')
+      radios[next === 'zero' ? 0 : 1]?.focus()
+    },
+    [busy, choice],
+  )
+
+  return (
+    <Modal
+      isOpen
+      onClose={busy ? noop : onClose}
+      title={`Seu estoque está congelado há ${gapDays} ${gapDays === 1 ? 'dia' : 'dias'}`}
+    >
+      <div className="stock-reconcile">
+        <p className="stock-reconcile__body">Como você quer voltar a usar o estoque?</p>
+
+        <div
+          className="stock-reconcile__options"
+          role="radiogroup"
+          aria-label="Opções de reconciliação do estoque"
+          onKeyDown={handleKeyDown}
+        >
+          <button
+            type="button"
+            role="radio"
+            aria-checked={choice === 'zero'}
+            tabIndex={choice === 'zero' ? 0 : -1}
+            className={`stock-reconcile__option ${choice === 'zero' ? 'stock-reconcile__option--default' : ''}`}
+            onClick={() => setChoice('zero')}
+            disabled={busy}
+          >
+            <span className="stock-reconcile__option-label">Começar do zero</span>
+            <span className="stock-reconcile__option-desc">
+              O saldo volta a zero. O histórico de compras fica guardado.
+            </span>
+          </button>
+
+          <button
+            type="button"
+            role="radio"
+            aria-checked={choice === 'resume'}
+            tabIndex={choice === 'resume' ? 0 : -1}
+            className={`stock-reconcile__option ${choice === 'resume' ? 'stock-reconcile__option--default' : ''}`}
+            onClick={() => setChoice('resume')}
+            disabled={busy}
+          >
+            <span className="stock-reconcile__option-label">
+              {dateLabel ? `Retomar o saldo de ${dateLabel}` : 'Retomar o saldo congelado'}
+            </span>
+            <span className="stock-reconcile__option-desc">
+              Volta exatamente como estava quando você desativou.
+            </span>
+          </button>
+        </div>
+
+        <div className="stock-freeze__actions stock-reconcile__actions">
+          <button
+            type="button"
+            className="stock-btn stock-btn--primary"
+            onClick={choice === 'zero' ? onZero : onResume}
+            disabled={busy}
+          >
+            Ativar estoque
+          </button>
+          <button type="button" className="stock-btn" onClick={onClose} disabled={busy}>
+            Cancelar
+          </button>
+        </div>
+      </div>
+    </Modal>
+  )
 }
 
 export default function StockSection() {
@@ -135,43 +235,15 @@ export default function StockSection() {
         </Modal>
       ) : null}
 
-      {sheet === 'reconcile' ? (
-        <Modal
-          isOpen
-          onClose={busy ? noop : closeSheet}
-          title={`Seu estoque está congelado há ${gapDays} ${gapDays === 1 ? 'dia' : 'dias'}`}
-        >
-          <div className="stock-reconcile">
-            <p className="stock-reconcile__body">Como você quer voltar a usar o estoque?</p>
-
-            {/* "Começar do zero" primeiro = default visual (§7 do design). Fechar não ativa. */}
-            <button
-              type="button"
-              className="stock-reconcile__option stock-reconcile__option--default"
-              onClick={resumeAndZero}
-              disabled={busy}
-            >
-              <span className="stock-reconcile__option-label">Começar do zero</span>
-              <span className="stock-reconcile__option-desc">
-                O saldo volta a zero. O histórico de compras fica guardado.
-              </span>
-            </button>
-
-            <button
-              type="button"
-              className="stock-reconcile__option"
-              onClick={resumeAsIs}
-              disabled={busy}
-            >
-              <span className="stock-reconcile__option-label">
-                {dateLabel ? `Retomar o saldo de ${dateLabel}` : 'Retomar o saldo congelado'}
-              </span>
-              <span className="stock-reconcile__option-desc">
-                Volta exatamente como estava quando você desativou.
-              </span>
-            </button>
-          </div>
-        </Modal>
+      {sheet === 'reconcile' && reconcile ? (
+        <ReconcileModal
+          gapDays={gapDays}
+          dateLabel={dateLabel}
+          busy={busy}
+          onZero={resumeAndZero}
+          onResume={resumeAsIs}
+          onClose={closeSheet}
+        />
       ) : null}
     </section>
   )

--- a/apps/web/src/views/settings/sections/__tests__/StockSection.test.tsx
+++ b/apps/web/src/views/settings/sections/__tests__/StockSection.test.tsx
@@ -1,0 +1,96 @@
+// StockSection — modal de reconciliação (>=30d) na web (spec 044, T016).
+//
+// O que este teste protege: "Começar do zero" ZERA o saldo. Selecionar a opção NÃO pode
+// executá-la — a confirmação é um segundo ato deliberado (paridade com o mobile). Um clique
+// só disparando a ação destrutiva foi o achado do review do PR #739.
+
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const resumeAndZero = vi.fn()
+const resumeAsIs = vi.fn()
+const closeSheet = vi.fn()
+
+const toggleState = {
+  enabled: false,
+  ready: true,
+  neverHadStock: false,
+  sheet: 'reconcile',
+  reconcile: { gapDays: 47, pausedAt: '2026-05-01T10:00:00Z' },
+  busy: false,
+  announcement: null,
+  clearAnnouncement: vi.fn(),
+  error: null,
+  requestToggle: vi.fn(),
+  confirmFreeze: vi.fn(),
+  resumeAsIs,
+  resumeAndZero,
+  closeSheet,
+}
+
+vi.mock('@features/settings/hooks/useStockToggle', () => ({
+  useStockToggle: () => toggleState,
+}))
+
+vi.mock('@shared/components/ui/Modal', () => ({
+  default: ({ children, title }: { children: unknown; title: string }) => (
+    <div role="dialog" aria-label={title}>
+      {children as never}
+    </div>
+  ),
+}))
+
+const { default: StockSection } = await import('../StockSection')
+
+describe('StockSection — reconciliação >=30d', () => {
+  beforeEach(() => {
+    toggleState.busy = false
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.clearAllTimers()
+  })
+
+  it('selecionar "Retomar o saldo" NÃO executa nada até confirmar', async () => {
+    render(<StockSection />)
+
+    fireEvent.click(screen.getByRole('radio', { name: /Retomar o saldo/i }))
+
+    // Selecionar é escolher, não executar.
+    expect(resumeAsIs).not.toHaveBeenCalled()
+    expect(resumeAndZero).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ativar estoque' }))
+    await waitFor(() => expect(resumeAsIs).toHaveBeenCalledTimes(1))
+    expect(resumeAndZero).not.toHaveBeenCalled()
+  })
+
+  it('"Começar do zero" é o default pré-marcado e só zera após a confirmação', async () => {
+    render(<StockSection />)
+
+    expect(screen.getByRole('radio', { name: /Começar do zero/i })).toBeChecked()
+    expect(resumeAndZero).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ativar estoque' }))
+    await waitFor(() => expect(resumeAndZero).toHaveBeenCalledTimes(1))
+  })
+
+  it('a data do congelamento aparece em PT-BR (nunca no formato US)', () => {
+    render(<StockSection />)
+    // 2026-05-01 → "01 mai 2026" (formatDatePtBR), jamais "5/1/2026".
+    expect(screen.getByRole('radio', { name: /Retomar o saldo de 01/i })).toBeInTheDocument()
+  })
+
+  it('as setas alternam a opção selecionada (roving tabindex)', async () => {
+    render(<StockSection />)
+
+    const zero = screen.getByRole('radio', { name: /Começar do zero/i })
+    zero.focus()
+    fireEvent.keyDown(zero, { key: 'ArrowDown' })
+
+    expect(screen.getByRole('radio', { name: /Retomar o saldo/i })).toBeChecked()
+    expect(zero).not.toBeChecked()
+    expect(resumeAsIs).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Escopo — T013..T016 (spec 044, F4a) · fecha a camada de UI do PO-5

**Invariante desta fase: OPT-OUT SEMPRE CONGELA.** Zero mutação de saldo/compras. O único caminho que muta estoque é o *"começar do zero"* da reconciliação — por escolha explícita do usuário, via adjustment append-only `legacy_unrecoverable` (R-226). **Nenhum reset automático por tempo.**

A lógica de gap/zeramento é **consumida** do `stockResumeService` (@dosiq/core, entregue na F2/T004) — não foi reimplementada na UI.

## Máquina de estados (`useStockToggle`, espelhado web + mobile)

| Transição | Escrita no banco |
|---|---|
| ON → sheet congelamento → **[Desativar]** | `user_settings`: `enabled=false`, `stock_paused_at=now()`. **Nada** em stock/purchases |
| ON → sheet → **[Cancelar]** | nenhuma |
| OFF → toggle → `assessResume()` | **só leitura** |
| … gap < 30d (ou sem carimbo) | `resumeAsIs()`: `enabled=true`, `stock_paused_at=NULL`. Silencioso + anúncio textual |
| … gap ≥ 30d → **[Começar do zero]** | `adjustToBalance(med, 0, 'legacy_unrecoverable')` por medicamento **e só então** `enabled=true` |
| … gap ≥ 30d → **[Retomar o saldo de {data}]** | `resumeAsIs()` — saldo intacto |
| … gap ≥ 30d → **fechar sem decidir** | **nenhuma.** Segue OFF; o sheet reaparece na próxima tentativa |

Falha no meio do zeramento → a preferência continua OFF (o service só liga no fim): nunca religa o FIFO sobre saldo meio-zerado.

## Detalhes

- **T013** — seção **ESTOQUE** logo após Preferências, **única adição** ao `SettingsScreen`. 3 subtítulos de estado + hint. "Nunca teve estoque" é distinguido de "congelado" por `stock_paused_at` (null vs carimbo) — sem query extra. `accessibilityLabel`/`role=switch` de estado. Espelho na settings web.
- **T014** — sheet com **cadeado**, botão primário comum: **não** é ação danger (congela, não deleta). Copy canônica §9, 2 frases.
- **T015** — retomada <30d silenciosa, anunciada por **TEXTO** (toast mobile / `role=status` web) — leitor de tela, não só visual.
- **T016** — sheet R-233, default visual "Começar do zero". Montagem condicional: desmontar reseta a escolha ao default — senão a opção da tentativa anterior voltaria pré-marcada.
- **AP-281** — toda escrita da preferência chama `refresh()` do provider antes de concluir. Era o bug que a F3 entregou no onboarding.

## Gates

- `validate:agent`: **108 arquivos / 1551 testes** ✅ (9 novos: as 4 transições + freeze + falha no zeramento + never-had-stock)
- `tsc` web + mobile: **0 erros** · `strict-island.sh`: **ratchet OK** · `lint`: **0 errors**
- Jest mobile (profile): 12 ✅

SQP do épico 044 permanece na F5 (T022), como nas fases anteriores.

**PO-5 fica aberto até o smoke do PO** (padrão da F3): as 4 transições precisam ser exercidas no device — a classe de bug desta feature (ciclo de vida do cache) não aparece em teste unitário.

🤖 Generated with [Claude Code](https://claude.com/claude-code)