### PR TITLE
fix(dlq): auto-retry job pra failed_notification_queue no cron 10h

### DIFF
--- a/api/notify.ts
+++ b/api/notify.ts
@@ -263,7 +263,7 @@ async function retryPendingDlq(notificationDispatcher, correlationId) {
     });
 
     if (dispatchResult.success) {
-      await supabase
+      const { error: updateError } = await supabase
         .from('failed_notification_queue')
         .update({
           status: 'resolved',
@@ -271,10 +271,14 @@ async function retryPendingDlq(notificationDispatcher, correlationId) {
           resolution_notes: 'Reprocessado automaticamente via cron dlq_auto_retry'
         })
         .eq('id', entry.id);
-      resolved++;
+      if (updateError) {
+        logger.error('[dlq_auto_retry] Falha ao marcar como resolvido no banco', updateError, { entryId: entry.id });
+      } else {
+        resolved++;
+      }
     } else {
       const nextRetryCount = (entry.retry_count || 0) + 1;
-      await supabase
+      const { error: updateError } = await supabase
         .from('failed_notification_queue')
         .update({
           retry_count: nextRetryCount,
@@ -283,7 +287,11 @@ async function retryPendingDlq(notificationDispatcher, correlationId) {
           error_message: dispatchResult.errors?.[0]?.message || entry.error_message
         })
         .eq('id', entry.id);
-      failedCount++;
+      if (updateError) {
+        logger.error('[dlq_auto_retry] Falha ao atualizar tentativas no banco', updateError, { entryId: entry.id });
+      } else {
+        failedCount++;
+      }
     }
   }
 

--- a/api/notify.ts
+++ b/api/notify.ts
@@ -229,6 +229,74 @@ function createNotifyBotAdapter(token) {
   };
 }
 
+// === HELPER: retryPendingDlq ===
+// Reprocessa entradas 'pending'/'retrying' da DLQ com retry_count < max_retries (AP a registrar:
+// getPendingForRetry/markForRetry em server/services/deadLetterQueue.ts eram código morto — nada
+// chamava; sem isso, falhas transitórias (ex.: Expo 503) ficavam presas até retry manual no admin).
+async function retryPendingDlq(notificationDispatcher, correlationId) {
+  const { data: pendingEntries, error: fetchError } = await supabase
+    .from('failed_notification_queue')
+    .select('*')
+    .in('status', ['pending', 'retrying'])
+    .lt('retry_count', 3)
+    .order('created_at', { ascending: true })
+    .limit(50);
+
+  if (fetchError) {
+    logger.error('[dlq_auto_retry] Falha ao buscar pendências', fetchError, { correlationId });
+    return { attempted: 0, resolved: 0, failed: 0 };
+  }
+
+  let resolved = 0;
+  let failedCount = 0;
+
+  for (const entry of pendingEntries || []) {
+    const dispatchResult = await notificationDispatcher.dispatch({
+      userId: entry.user_id,
+      kind: entry.notification_type,
+      data: entry.notification_payload || {},
+      context: {
+        correlationId: entry.correlation_id || `dlq_retry_${entry.id}`,
+        isRetry: true,
+        details: { originalNotificationId: entry.id }
+      }
+    });
+
+    if (dispatchResult.success) {
+      await supabase
+        .from('failed_notification_queue')
+        .update({
+          status: 'resolved',
+          resolved_at: getServerTimestamp(),
+          resolution_notes: 'Reprocessado automaticamente via cron dlq_auto_retry'
+        })
+        .eq('id', entry.id);
+      resolved++;
+    } else {
+      const nextRetryCount = (entry.retry_count || 0) + 1;
+      await supabase
+        .from('failed_notification_queue')
+        .update({
+          retry_count: nextRetryCount,
+          status: nextRetryCount >= entry.max_retries ? 'failed' : 'retrying',
+          updated_at: getServerTimestamp(),
+          error_message: dispatchResult.errors?.[0]?.message || entry.error_message
+        })
+        .eq('id', entry.id);
+      failedCount++;
+    }
+  }
+
+  logger.info('[dlq_auto_retry] Ciclo concluído', {
+    correlationId,
+    attempted: (pendingEntries || []).length,
+    resolved,
+    failed: failedCount
+  });
+
+  return { attempted: (pendingEntries || []).length, resolved, failed: failedCount };
+}
+
 // === HELPER: createNotificationDispatcher ===
 
 function _createNotificationDispatcher(bot) {
@@ -328,6 +396,8 @@ async function _executeCronJobs(notificationDispatcher, bot, correlationId, spDa
       await runJob('stock_alerts', 'stock_alerts',
         (context) => checkStockAlerts(bot, { ...context, notificationDispatcher }));
     }
+    await runJob('dlq_auto_retry', 'dlq_auto_retry',
+      (context) => retryPendingDlq(notificationDispatcher, context.correlationId));
     await runJob('dlq_digest', 'dlq_digest',
       (context) => sendDLQDigest(notificationDispatcher, context));
   }


### PR DESCRIPTION
## Bug

Relatório diário de adesão falhou em produção (2026-07-16 12:00 UTC, user Kety) — Expo devolveu 503 (upstream transitório). Caiu em `failed_notification_queue` (DLQ) e ficou `pending` indefinidamente.

## Causa raiz

DLQ nunca reprocessava sozinha. `getPendingForRetry`/`markForRetry` em `server/services/deadLetterQueue.ts` eram código morto — nada chamava. Única saída era retry manual via admin (`/api/dlq/:id/retry`). Confirmado via git log: **não** foi introduzido pelo 046 (LGPD) nem 043 (outbox) — gap pré-existente, só exposto agora pelo 503 do Expo.

## Fix

Novo job `dlq_auto_retry` no cron já existente (`api/notify.ts`, bloco 10h, antes do `dlq_digest`):
- Busca até 50 entradas `pending`/`retrying` com `retry_count < 3`
- Redespacha via `notificationDispatcher` (mesma lógica do retry manual do admin)
- Sucesso → `status: resolved`
- Falha → incrementa `retry_count`; esgotou tentativas → `status: failed`

Zero função serverless nova (R-090) — reusa `api/notify.ts` (5/12 → segue 7/12 total).

## AI Review Response

| Sugestão | Prioridade | Decisão | Motivo |
|----------|-----------|---------|--------|
| Checar erro de update Supabase (evita duplicata se update falhar após reenvio bem-sucedido) | High | Aplicado | Commit `3ba5eb9` |
| `entry.max_retries` indefinido (coluna não existiria) | High | Recusado | Verificado via Supabase MCP: coluna `max_retries integer DEFAULT 3` existe e vem preenchida (`information_schema.columns` + dados reais de prod) |

## Test plan
- [x] `tsc -p api/tsconfig.json --noEmit` — zero erros
- [x] `rtk lint` — zero erros (warnings pré-existentes não relacionados)
- [ ] Pós-merge: confirmar próximo ciclo 10h SP resolve a entrada `de37e217-52a0-4ed6-9dbf-eb2886aed2d7` pendente hoje

🤖 Generated with [Claude Code](https://claude.com/claude-code)
