### PR TITLE
feat(034): guardrails ESLint determinísticos — enum não-pt-BR e res.json sem status

### DIFF
--- a/apps/web/src/schemas/__tests__/eslintGuardrails.test.ts
+++ b/apps/web/src/schemas/__tests__/eslintGuardrails.test.ts
@@ -1,0 +1,79 @@
+// 034-A T015 — SC-002: guardrails de lint determinístico (sem LLM).
+// Valida COMPORTAMENTO das regras novas contra o eslint.config.js REAL:
+// se o seletor for removido/alterado no config, o teste quebra junto.
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { Linter } from 'eslint'
+// config flat da raiz do monorepo (fonte única dos guardrails)
+import rootConfig from '../../../../../eslint.config.js'
+
+type Restriction = { selector: string; message: string }
+
+// extrai as entradas de no-restricted-syntax do bloco base do flat config
+function loadRestrictions(): Restriction[] {
+  const blocks = rootConfig as Array<{ rules?: Record<string, unknown> }>
+  for (const block of blocks) {
+    const rule = block.rules?.['no-restricted-syntax'] as unknown[] | undefined
+    if (Array.isArray(rule)) return rule.slice(1) as Restriction[]
+  }
+  throw new Error('no-restricted-syntax não encontrado no eslint.config.js')
+}
+
+function lint(code: string): string[] {
+  const linter = new Linter()
+  const messages = linter.verify(code, {
+    languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+    rules: { 'no-restricted-syntax': ['error', ...loadRestrictions()] },
+  })
+  return messages.map((m) => m.message)
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.clearAllTimers()
+})
+
+describe('034-A guardrails — enum não-pt-BR em z.enum() (AP-299)', () => {
+  it('rejeita enum de DB em inglês', () => {
+    const msgs = lint(`z.enum(['daily', 'weekly'])`)
+    expect(msgs.some((m) => m.includes('AP-299'))).toBe(true)
+  })
+
+  it('rejeita a versão SEM acento (o CHECK do banco rejeita — 23514)', () => {
+    const msgs = lint(`z.enum(['diario', 'quando_necessario'])`)
+    expect(msgs.filter((m) => m.includes('AP-299'))).toHaveLength(2)
+  })
+
+  it("rejeita 'cp' em z.enum (comprimido em protocols é NULL)", () => {
+    const msgs = lint(`z.enum(['gotas', 'ml', 'UI', 'mg', 'cp'])`)
+    expect(msgs.some((m) => m.includes('AP-299'))).toBe(true)
+  })
+
+  it('aceita os valores pt-BR verbatim do banco', () => {
+    const msgs = lint(
+      `z.enum(['diário', 'dias_alternados', 'semanal', 'personalizado', 'quando_necessário'])`
+    )
+    expect(msgs).toHaveLength(0)
+  })
+
+  it('NÃO alcança literais fora de z.enum (mapas de normalização tolerante são legítimos)', () => {
+    const msgs = lint(`const FREQ_MAP = { daily: 'diário', diario: 'diário' }`)
+    expect(msgs).toHaveLength(0)
+  })
+})
+
+describe('034-A guardrails — res.json sem res.status (R-090 / lição Sprint 7)', () => {
+  it('rejeita res.json(body) direto', () => {
+    const msgs = lint(`res.json({ ok: true })`)
+    expect(msgs.some((m) => m.includes('R-090'))).toBe(true)
+  })
+
+  it('aceita res.status(code).json(body)', () => {
+    const msgs = lint(`res.status(200).json({ ok: true })`)
+    expect(msgs).toHaveLength(0)
+  })
+
+  it('aceita res.json() de fetch Response (zero args)', () => {
+    const msgs = lint(`const data = await res.json()`)
+    expect(msgs).toHaveLength(0)
+  })
+})

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -137,6 +137,20 @@ export default [
         {
           selector: 'BlockStatement > :matches(VariableDeclaration:has(CallExpression[callee.name="useCallback"]), ExpressionStatement:has(CallExpression[callee.name=/^(useEffect|useLayoutEffect|useFocusEffect|useInsertionEffect)$/])) ~ VariableDeclaration:has(CallExpression[callee.name="useMemo"])',
           message: 'R-010: Ordem dos hooks incorreta. Declare Memos (useMemo) antes de Effects e Handlers.'
+        },
+        // 034-A/AP-299: enum de DB em z.enum() DEVE ser pt-BR COM acento (o CHECK do banco
+        // rejeita a versão sem — 23514). Só literais DIRETOS no z.enum(); constantes tolerantes
+        // de leitura (mapas de normalização) ficam fora de propósito. 'cp' só existe em
+        // titration_steps (TITRATION_INTAKE_UNITS compõe via [...INTAKE_UNITS, 'cp'], não aqui).
+        {
+          selector: 'CallExpression[callee.object.name="z"][callee.property.name="enum"] Literal[value=/^(daily|weekly|monthly|biweekly|as_needed|when_needed|diario|quando_necessario|cp)$/]',
+          message: 'Enum de DB em inglês ou sem acento dentro de z.enum(). Os CHECKs do banco exigem pt-BR verbatim (ex.: "diário", "quando_necessário"; comprimido = NULL, não "cp"). Ver CLAUDE.md §Schemas — enums (AP-299).'
+        },
+        // 034-A/R-090 (lição Sprint 7): res.json(body) sem res.status() quebra no Vercel.
+        // [arguments.length>0] distingue do res.json() de fetch Response (0 args).
+        {
+          selector: 'CallExpression[callee.object.name="res"][callee.property.name="json"][arguments.length>0]',
+          message: 'res.json(body) direto quebra no Vercel. Use SEMPRE res.status(code).json(body) (R-090 / lição Sprint 7).'
         }
       ],
 


### PR DESCRIPTION
## Spec 034-A — T012/T013/T015

Camada L0 (determinística, $0, sem LLM) da defesa pós-Gemini.

### T012 — enum de DB não-pt-BR em `z.enum()` (AP-299)
Literal em inglês ou sem acento (`'daily'`, `'diario'`, `'quando_necessario'`, `'cp'`…) dentro de `z.enum()` = erro de lint. Escopo cirúrgico: **só literal direto no z.enum** — mapas de normalização tolerante (doseCalendarService, adherenceLogic…) usam literais EN de propósito e ficam fora; `TITRATION_INTAKE_UNITS` compõe `'cp'` via constante, não dispara.

### T013 — `res.json(body)` sem `res.status()` (R-090, lição Sprint 7)
`[arguments.length>0]` distingue do `res.json()` de fetch Response (0 args). Base auditada por grep: zero ocorrência — zero falso-positivo.

### T015 — teste SC-002
`src/schemas/__tests__/eslintGuardrails.test.ts`: 8 casos carregando os seletores do `eslint.config.js` **real** (drift no config quebra o teste). Posicionado em glob do validate:agent — total 2023→2031 (lição AP-290).

### T024 (bônus — smoke RC5/RC6 real)
Branch descartável com bypass sintético de `medicine_logs` em componente UI → RC6 (agy) retornou **Critical citando AP-231** + High R-020/R-022 + Medium (erro descartado). 4/4 plantas. De quebra expôs bug do RC6: contexto >160KB degradava o agy em silêncio — corrigido na skill (devflow `3855f5a`).

### Gates
lint 0 errors (base limpa) · tsc 0 · validate:agent **2031/2031**.

### Achado colateral (não tocado)
`reminderOptimizerService.ts:55` compara `frequency === 'quando_necessario'` **sem acento** — nunca casa (branch morto). Follow-up na próxima passada do domínio protocols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)