### PR TITLE
fix(034): gate re-avalia quando a review RC6 chega depois do push (T041)

### DIFF
--- a/.github/workflows/ai-review-gate.yml
+++ b/.github/workflows/ai-review-gate.yml
@@ -22,6 +22,12 @@ on:
       - '*.md'
       - 'scripts/**'
       - 'scratches/**'
+  # Re-avalia quando a review RC6 é publicada DEPOIS do último push (T041:
+  # no #753 o gate rodou no push e ficou em warning stale — o --post veio depois
+  # e nada re-disparava). pull_request_review NÃO suporta paths-ignore; o guard
+  # de payload no step ignora reviews que não são do RC6.
+  pull_request_review:
+    types: [submitted]
 
 permissions:
   pull-requests: read
@@ -42,6 +48,14 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request.number;
+
+            // Em pull_request_review, só interessa a chegada de uma review RC6
+            // (review humana não muda o veredito do gate; evita run redundante).
+            if (context.eventName === 'pull_request_review' &&
+                !(context.payload.review?.body || '').includes('RC6 — Independent AI Review')) {
+              core.info('Review não-RC6 — nada a reavaliar.');
+              return;
+            }
 
             // Reviews do PR (o RC6 posta como review COMMENT com header fixo)
             const reviews = await github.paginate(github.rest.pulls.listReviews, {


### PR DESCRIPTION
Gap provado no #753: o gate rodou no push e o `rtk ai-review 753 --post` publicou a review DEPOIS — o warning ficou stale (nada re-disparava o check).

- Trigger novo `pull_request_review: [submitted]` re-avalia na chegada da review.
- Guard de payload: review sem o header RC6 sai cedo (`core.info`) — review humana não muda o veredito do gate.
- `pull_request_review` não suporta `paths-ignore` (documentado no yml); o early-return cobre.

Verificação T041 registrada: run 29554605200 (#752) → `##[warning] PR #752 sem review RC6` (SC-003 negativo ✅); run 29556164345 (#753) → warning stale que ESTE fix elimina.

🤖 Generated with [Claude Code](https://claude.com/claude-code)