### PR TITLE
fix(044): exclusão de medicamento travada no modo dose-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ## [Unreleased]
 
+### Mobile — Hotfix 044: excluir medicamento no modo dose-only
+
+- **Fix** (`patch`, mobile `0.27.3 → 0.27.4`, PR #TBD): no modo **dose-only** (controle de estoque desligado), excluir um medicamento que tivesse saldo de estoque caía num **beco sem saída** (Constituição IX): o botão `[Apagar]` vinha desabilitado e o sheet dizia "Desative ou exclua as dependências abaixo" com a **lista vazia** — o usuário lia uma acusação sem réu. Causa: a 044 F3 escondeu o card de estoque do sheet quando o controle está desligado, mas o pré-check (`useMedicineDelete`) continuou bloqueando por `stockUnits > 0` sem consultar `stockTrackingEnabled`. A web já tinha o guard desde a F3 (`Medicines.tsx`); só o mobile ficou de fora. Correção: estoque só conta como dependência com o controle **ligado** — nenhum ajuste de saldo é necessário, porque `stock_medicine_id_fkey` é `ON DELETE CASCADE` (verificado no banco), então apagar o medicamento já limpa os lotes. Bloqueios por **tratamento** e por **etapa da Evolução do tratamento** seguem valendo nos dois modos (o FK `titration_steps_medicine_id_fkey` é `NO ACTION`). O default do parâmetro é `true` (fail-safe AP-277: ausência de dado nunca desliga o estoque por omissão). Matrix de cache (R-236) atualizada: a exclusão passa a invalidar `@dosiq/stock-snapshot`, já que o CASCADE apaga lotes que podiam estar no snapshot. Hook ganhou os primeiros testes (5).
+
 ### Evolução do tratamento — CTA de troca de etapa, push com ações e estados de erro (029 F5)
 
 - **Feat** (`minor` core `0.10.1 → 0.11.0` · `patch` mobile `0.27.2 → 0.27.3` · `patch` web `4.18.0 → 4.18.1`, PR #TBD): a troca de medicamento da Evolução do tratamento passa a ser **acionável pelo paciente**, nas duas superfícies.

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -5,7 +5,7 @@
 
 const BUILD_PROFILE = process.env.EAS_BUILD_PROFILE || 'production'
 
-const APP_VERSION = '0.27.3' // R-182: versão semântica (sem prefixo 'v')
+const APP_VERSION = '0.27.4' // R-182: versão semântica (sem prefixo 'v')
 const [major, minor, patch] = APP_VERSION.split('.').map(Number)
 // buildNumber/versionCode derivado da versão semântica: major*10000 + minor*100 + patch
 // 0.2.4 → 204 | 0.3.0 → 300 | 1.0.0 → 10000

--- a/apps/mobile/src/features/medications/hooks/__tests__/useMedicineDelete.test.ts
+++ b/apps/mobile/src/features/medications/hooks/__tests__/useMedicineDelete.test.ts
@@ -1,0 +1,68 @@
+// useMedicineDelete.test.ts — preCheck de dependências (spec 044 F3 / 029 F5)
+// Framework: Jest (jest-expo) — rodar em apps/mobile/
+
+import { renderHook } from '@testing-library/react-native'
+import { useMedicineDelete as useMedicineDeleteImport } from '../useMedicineDelete'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const useMedicineDelete = useMedicineDeleteImport as any
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ goBack: jest.fn() }),
+}))
+
+jest.mock('@shared/components/feedback/Toast', () => ({
+  useToast: () => ({ show: jest.fn() }),
+}))
+
+jest.mock('@shared/utils/haptics', () => ({
+  successHaptic: jest.fn(),
+  errorHaptic: jest.fn(),
+}))
+
+jest.mock('../../services/medicineService', () => ({
+  medicineService: { delete: jest.fn() },
+}))
+
+const MEDICINE_WITH_STOCK = {
+  id: 'm1',
+  name: 'Ozempic',
+  protocols: [],
+  titration_steps: [],
+  stock: [{ id: 's1', quantity: 4 }],
+}
+
+afterEach(() => {
+  jest.clearAllMocks()
+  jest.clearAllTimers()
+})
+
+describe('useMedicineDelete — preCheck', () => {
+  it('bloqueia por estoque quando o controle de estoque está ligado', () => {
+    const { result } = renderHook(() => useMedicineDelete(MEDICINE_WITH_STOCK, true))
+    expect(result.current.preCheck.canDelete).toBe(false)
+    expect(result.current.preCheck.stockUnits).toBe(4)
+  })
+
+  it('modo dose-only: estoque não bloqueia (CASCADE do FK zera no banco)', () => {
+    const { result } = renderHook(() => useMedicineDelete(MEDICINE_WITH_STOCK, false))
+    expect(result.current.preCheck.canDelete).toBe(true)
+  })
+
+  it('modo dose-only: tratamento ainda bloqueia', () => {
+    const medicine = { ...MEDICINE_WITH_STOCK, protocols: [{ id: 'p1', active: true }] }
+    const { result } = renderHook(() => useMedicineDelete(medicine, false))
+    expect(result.current.preCheck.canDelete).toBe(false)
+  })
+
+  it('modo dose-only: etapa de titulação ainda bloqueia (FK sem ON DELETE)', () => {
+    const medicine = { ...MEDICINE_WITH_STOCK, titration_steps: [{ id: 'ts1' }] }
+    const { result } = renderHook(() => useMedicineDelete(medicine, false))
+    expect(result.current.preCheck.canDelete).toBe(false)
+  })
+
+  it('default do parâmetro é estoque ligado (fail-safe)', () => {
+    const { result } = renderHook(() => useMedicineDelete(MEDICINE_WITH_STOCK))
+    expect(result.current.preCheck.canDelete).toBe(false)
+  })
+})

--- a/apps/mobile/src/features/medications/hooks/useMedicineDelete.ts
+++ b/apps/mobile/src/features/medications/hooks/useMedicineDelete.ts
@@ -16,21 +16,23 @@ import { successHaptic, errorHaptic } from '@shared/utils/haptics'
 import { medicineService } from '../services/medicineService'
 
 const MEDICINES_CACHE_KEY = '@dosiq/medicines-snapshot'
+const STOCK_CACHE_KEY = '@dosiq/stock-snapshot'
 
 /**
  * Cache invalidation matrix (R-236) — useMedicineDelete:
  *
  * confirmDelete só dispara se preCheck.canDelete (hard block contra protocolos
- * e stock > 0). Quando passa o pre-check, garantidamente:
+ * e, com controle de estoque ligado, stock > 0). Quando passa o pre-check:
  *   - sem protocols → nada em treatments-snapshot/today-snapshot
- *   - sem stock     → nada em stock-snapshot
- * Logo invalida APENAS:
+ * MAS no modo dose-only (stockTrackingEnabled=false) o estoque deixa de bloquear:
+ * o CASCADE do FK apaga lotes que podiam estar no snapshot. Logo invalida:
  *   - @dosiq/medicines-snapshot
+ *   - @dosiq/stock-snapshot
  *
- * Se algum dia o hard block virar soft, ESTA matrix muda — adicionar
- * treatments-snapshot, today-snapshot e stock-snapshot ao Promise.all abaixo.
+ * Se algum dia o hard block de protocolos virar soft, ESTA matrix muda — adicionar
+ * treatments-snapshot e today-snapshot ao Promise.all abaixo.
  */
-export function useMedicineDelete(medicine) {
+export function useMedicineDelete(medicine, stockTrackingEnabled = true) {
   const navigation = useNavigation()
   const { show } = useToast()
   const [isLoading, setIsLoading] = useState(false)
@@ -51,7 +53,14 @@ export function useMedicineDelete(medicine) {
     // Etapas já `completed` também contam: apagar o medicamento apagaria o histórico da escada.
     const titrationSteps = Array.isArray(medicine?.titration_steps) ? medicine.titration_steps : []
 
-    const hasDependencies = protocols.length > 0 || stockUnits > 0 || titrationSteps.length > 0
+    // 044 F3: no modo dose-only o estoque é superfície invisível — o sheet de bloqueio
+    // esconde o card de estoque, então bloquear por `stockUnits > 0` produzia um beco sem
+    // saída (botão desabilitado, "dependências abaixo", lista vazia). O FK
+    // `stock_medicine_id_fkey` é ON DELETE CASCADE: apagar o medicamento zera o estoque
+    // no banco sem passo extra. Estoque só é dependência quando o controle está ligado.
+    const stockBlocks = stockTrackingEnabled && stockUnits > 0
+
+    const hasDependencies = protocols.length > 0 || stockBlocks || titrationSteps.length > 0
 
     return {
       canDelete: !hasDependencies,
@@ -61,14 +70,14 @@ export function useMedicineDelete(medicine) {
       stockLots,
       hasStock: stockUnits > 0,
     }
-  }, [medicine])
+  }, [medicine, stockTrackingEnabled])
 
   const confirmDelete = useCallback(async () => {
     if (!medicine?.id) return false
     setIsLoading(true)
     try {
       await medicineService.delete(medicine.id)
-      await AsyncStorage.removeItem(MEDICINES_CACHE_KEY).catch(() => {})
+      await AsyncStorage.multiRemove([MEDICINES_CACHE_KEY, STOCK_CACHE_KEY]).catch(() => {})
       successHaptic()
       show('Medicamento removido', { variant: 'success' })
       navigation.goBack()

--- a/apps/mobile/src/features/medications/screens/MedicineDetailScreen.tsx
+++ b/apps/mobile/src/features/medications/screens/MedicineDetailScreen.tsx
@@ -263,8 +263,11 @@ function useMedicineDetailState() {
   // tem dependência), então ocultamos o botão pra não exibir ação morta.
   const hideDelete = route.params?.hideDelete === true
   const { data, loading, error, refresh } = useMedicine(id)
-  const { preCheck, confirmDelete, isLoading: deleteLoading } = useMedicineDelete(data)
   const { enabled: stockTrackingEnabled } = useStockTracking()
+  const { preCheck, confirmDelete, isLoading: deleteLoading } = useMedicineDelete(
+    data,
+    stockTrackingEnabled
+  )
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [blockedOpen, setBlockedOpen] = useState(false)
 


### PR DESCRIPTION
## Problema

No modo **dose-only** (controle de estoque desligado), excluir um medicamento com saldo de estoque caía num **beco sem saída** (Constituição IX):

- botão `[Apagar]` desabilitado
- sheet dizendo "Desative ou exclua as **dependências abaixo**"
- **lista vazia** — acusação sem réu

Reportado pelo PO em smoke.

## Causa raiz

A **044 F3** escondeu o card de estoque do sheet quando o controle está desligado ([`MedicineDeleteBlockedSheet.tsx:101`](../blob/main/apps/mobile/src/features/medications/components/MedicineDeleteBlockedSheet.tsx#L101)), mas o pré-check em `useMedicineDelete` continuou bloqueando por `stockUnits > 0` sem consultar `stockTrackingEnabled`.

A **web já tinha o guard** desde a F3 (`views/Medicines.tsx:39`). Só o mobile ficou de fora.

## Correção

Estoque só conta como dependência com o controle **ligado**.

**Nenhum ajuste de saldo é necessário** — verificado no banco (`pg_constraint`):

| FK | `confdeltype` |
|---|---|
| `stock_medicine_id_fkey` | `c` (CASCADE) |
| `protocols_medicine_id_fkey` | `c` (CASCADE) |
| `medicine_logs` / `purchases` / `stock_adjustments` / `stock_consumptions` | `c` (CASCADE) |
| `titration_steps_medicine_id_fkey` | `a` (NO ACTION) |

Apagar o medicamento já limpa os lotes pelo CASCADE. O único FK restritivo é o de `titration_steps` — e aquele bloqueio (029 F5) segue valendo, junto com o bloqueio por tratamento, nos **dois** modos.

Detalhes:
- default do parâmetro é `true` — fail-safe AP-277: ausência de dado nunca desliga o estoque por omissão
- matrix de cache (R-236) atualizada: a exclusão passa a invalidar `@dosiq/stock-snapshot`, já que o CASCADE apaga lotes que podiam estar no snapshot
- hook ganhou os primeiros testes (5)

## SQP

`patch` mobile `0.27.3 → 0.27.4` — fix, sem mudança de contrato. Changelog em `[Unreleased]`.

## Gates

- `validate:agent`: 154 suites / 2064 testes ✅
- mobile jest: 57 suites / 473 testes ✅
- `lint`: 0 errors ✅
- `strict-island.sh`: ratchet OK, nível A limpo ✅
- smoke do PO: **validado** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)