### PR TITLE
feat(mobile): aplicar OTA em sessão viva (051-A PR 1.6b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ## [Unreleased]
 
+### Aplicação de OTA em sessão viva (spec 051-A, PR 1.6b)
+
+- **Feature** (release OTA sobre `0.30.0` — **sem bump de `APP_VERSION`**, ADR-082: mudança
+  JS-only, bumpar criaria `runtimeVersion` novo e tornaria o update órfão, nunca alcançando os
+  binários `0.30.0` já instalados/publicados na loja). Identidade da release: `[0.30.0+ota.N]` +
+  updateId + SHA da main, atualizado no publish real.
+
+  O app passa a checar e baixar update do EAS Update também com o processo já vivo (`AppState` →
+  `active`, throttle ~15min) — antes só o cold start (checagem nativa no launch, FR-005) acionava
+  a checagem, e o padrão de uso brasileiro de deixar o app minimizado por dias deixava a
+  alcançabilidade do ADR-088 pela metade.
+
+  A aplicação continua exclusivamente por decisão do usuário: banner fixo "Atualização pronta ·
+  Reiniciar" na aba Hoje, visível só quando a tela está ociosa (nenhum modal de registro de dose
+  aberto, nenhum alarme na tela — reusa `useAlarmScreenActive` do PR 1.5b). `Updates.reloadAsync()`
+  nunca dispara sozinho: recarregaria a árvore React inteira e apagaria formulário meio preenchido,
+  tela de alarme ou fluxo de estoque em andamento.
+
+  Banner reusa o COMPONENTE `NudgeBanner` (consistência visual, zero CSS novo), não o pipeline de
+  `useNudges` — nudge é dado remoto (`in_app_nudges`), o estado de update pronto é local do device.
+  Quem só fecha e reabre o app (cold start) continua recebendo o update sem ver banner nenhum — a
+  FR-005 não muda.
+
 ### Atualizações OTA (EAS Update) no app mobile (spec 051-A, PR 1.6)
 
 - **Feature** (`minor`, mobile `0.29.3 → 0.30.0`): o app passa a embutir o cliente `expo-updates`,

--- a/apps/mobile/src/features/dashboard/screens/TodayScreen.tsx
+++ b/apps/mobile/src/features/dashboard/screens/TodayScreen.tsx
@@ -37,6 +37,8 @@ import BulkDoseRegisterModal from '@dose/components/BulkDoseRegisterModal'
 import StaleBanner from '@shared/components/feedback/StaleBanner'
 import NudgeBanner from '@shared/components/ui/NudgeBanner'
 import { useNudges } from '@profile/hooks/useNudges'
+import { useOtaUpdate } from '@platform/updates/useOtaUpdate'
+import { useAlarmScreenActive } from '@platform/versionGate/useAlarmScreenActive'
 import { useStockTracking } from '@shared/hooks/useStockTracking'
 import { navigateCrossTab } from '@navigation/navigateCrossTab'
 import { useStockUpsell } from '@dashboard/hooks/useStockUpsell'
@@ -339,6 +341,24 @@ function TodayScreenContent({
   const [speedDialOpen, setSpeedDialOpen] = useState(false)
   const [measureLogOpen, setMeasureLogOpen] = useState(false)
 
+  // OTA em sessão viva (051-A PR 1.6b / FR-023 / PO-11). Banner FIXO reusa o COMPONENTE
+  // NudgeBanner (consistência visual), NÃO o pipeline de useNudges — nudge é dado remoto
+  // (in_app_nudges), update é estado local do device; ver decisão em tasks.md T052.
+  const { updateReady, applyUpdate } = useOtaUpdate()
+  const alarmScreenActive = useAlarmScreenActive()
+  // "Ocioso": nenhum modal de registro de dose aberto (individual/lote/medida/speed-dial) e
+  // nenhum alarme na tela — reusa useAlarmScreenActive (PR 1.5b), não reimplementa.
+  const isIdleForOtaBanner = modalProtocol === null && bulkModal === null
+    && !measureLogOpen && !speedDialOpen && !alarmScreenActive
+  const otaBanner = (updateReady && isIdleForOtaBanner)
+    ? {
+        title: 'Atualização no Dosiq',
+        body: 'Uma nova atualização de segurança no app foi baixada e está pronta para uso.',
+        action_type: 'apply',
+        action_payload: { label: 'Reiniciar o aplicativo' },
+      }
+    : null
+
   const priorityDoses = useMemo(() => {
     const todayUrgent = timeline.filter(d => d.timelineStatus === 'PROXIMA' || d.timelineStatus === 'ATRASADA')
     const aheadImminent = lookAhead.filter(d => d.timelineStatus === 'PROXIMA')
@@ -395,7 +415,11 @@ function TodayScreenContent({
         {priorityDoses.length > 0 ? (
           <HeroDoseCard doses={priorityDoses} onPress={() => setBulkModal({ mode: 'hero', items: heroItems })} />
         ) : (
-          <NudgeBanner nudge={dashboardNudge} onAction={handleNudgeAction} onDismiss={dismissNudge} />
+          <NudgeBanner
+            nudge={otaBanner ?? dashboardNudge}
+            onAction={otaBanner ? applyUpdate : handleNudgeAction}
+            onDismiss={otaBanner ? undefined : dismissNudge}
+          />
         )}
         <OptionalDoseSection
           title="Doses pendentes"

--- a/apps/mobile/src/platform/updates/useOtaUpdate.ts
+++ b/apps/mobile/src/platform/updates/useOtaUpdate.ts
@@ -1,0 +1,70 @@
+// useOtaUpdate.ts — checagem+download de OTA em sessão viva (spec 051-A · FR-023/PO-11)
+//
+// Só CHECA e BAIXA aqui — nunca aplica sozinho. `Updates.reloadAsync()` recarrega a árvore React
+// inteira (apagaria formulário meio preenchido, tela de alarme, fluxo de estoque em andamento);
+// quem decide é o usuário, sempre, tocando no banner (TodayScreen.tsx). FR-005 (checagem no
+// launch nativo) já cobre o cold start — este hook só cobre o caso "processo já vivo, app volta
+// do background", que a FR-005 não alcança.
+//
+// Throttle de ~15min: sem ele cada alternância de app dispara 1 request — custo de bateria/dados
+// relevante no plano de dados limitado que é a regra no Brasil.
+//
+// Não checa no mount: só reage a transições REAIS pra 'active' (AppState.addEventListener não
+// dispara no registro, só em mudança de estado). Rodar no mount duplicaria a checagem nativa do
+// cold start e poderia deixar o banner pronto para aparecer logo na abertura — quebraria a
+// garantia de FR-005/T056 ("cold start não vê banner").
+
+import { useEffect, useRef, useState } from 'react'
+import { AppState } from 'react-native'
+import * as Updates from 'expo-updates'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+const THROTTLE_MS = 15 * 60 * 1000
+const LAST_CHECK_KEY = 'ota_update:last_check_at'
+
+export interface UseOtaUpdateResult {
+  /** true quando um update foi baixado e está pronto para `applyUpdate()`. */
+  updateReady: boolean
+  /** Recarrega o app no bundle baixado. Só chamar por toque explícito do usuário (PO-11). */
+  applyUpdate: () => void
+}
+
+export function useOtaUpdate(): UseOtaUpdateResult {
+  const [updateReady, setUpdateReady] = useState(false)
+  const checkingRef = useRef(false)
+
+  useEffect(() => {
+    async function checkAndDownload() {
+      if (checkingRef.current || !Updates.isEnabled) return
+      checkingRef.current = true
+      try {
+        const lastRaw = await AsyncStorage.getItem(LAST_CHECK_KEY)
+        const last = lastRaw ? Number(lastRaw) : 0
+        if (Date.now() - last < THROTTLE_MS) return
+        await AsyncStorage.setItem(LAST_CHECK_KEY, String(Date.now()))
+
+        const result = await Updates.checkForUpdateAsync()
+        if (!result.isAvailable) return
+        await Updates.fetchUpdateAsync()
+        setUpdateReady(true)
+      } catch {
+        // Fail-silent — mesma postura de bundleInfo.ts: falha de rede/checagem não pode
+        // interromper o uso do app, só custa não saber que há update pronto.
+      } finally {
+        checkingRef.current = false
+      }
+    }
+
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') checkAndDownload()
+    })
+
+    return () => subscription.remove()
+  }, [])
+
+  function applyUpdate() {
+    Updates.reloadAsync().catch(() => {})
+  }
+
+  return { updateReady, applyUpdate }
+}

--- a/apps/mobile/src/shared/components/ui/NudgeBanner.tsx
+++ b/apps/mobile/src/shared/components/ui/NudgeBanner.tsx
@@ -31,14 +31,16 @@ export default function NudgeBanner({ nudge, onAction, onDismiss }) {
           </TouchableOpacity>
         )}
       </View>
-      <TouchableOpacity
-        onPress={() => onDismiss?.(nudge)}
-        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-        accessibilityRole="button"
-        accessibilityLabel="Dispensar aviso"
-      >
-        <X size={18} color={colors.text.secondary} strokeWidth={2} />
-      </TouchableOpacity>
+      {onDismiss && (
+        <TouchableOpacity
+          onPress={() => onDismiss(nudge)}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityRole="button"
+          accessibilityLabel="Dispensar aviso"
+        >
+          <X size={18} color={colors.text.secondary} strokeWidth={2} />
+        </TouchableOpacity>
+      )}
     </View>
   )
 }


### PR DESCRIPTION
## Summary
- `useOtaUpdate.ts` (novo): checagem+download de OTA em `AppState → active` (throttle 15min), sem nunca aplicar sozinho — só `Updates.reloadAsync()` por toque explícito do usuário.
- `TodayScreen.tsx`: banner fixo "Atualização pronta · Reiniciar" na aba Hoje, reusando o COMPONENTE `NudgeBanner` (não o pipeline `useNudges`), visível só com usuário ocioso (nenhum modal de registro de dose aberto, nenhum alarme na tela — reusa `useAlarmScreenActive` do PR 1.5b).
- `NudgeBanner.tsx`: fix — X de dispensar só renderiza quando `onDismiss` é passado (achado no smoke: banner fixo passava `onDismiss=undefined` e o X ficava visível mas inerte, confuso).
- Sem bump de `APP_VERSION` (ADR-082): mudança JS-only, ships como release OTA sobre `0.30.0`.

Resolve FR-023/US10/SC-015/SC-016, fecha PO-11 (spec 051-A).

## Test plan
- [x] lint 0 erros, tsc apps/web + mobile 0 erros, strict-island ratchet OK
- [x] validate:agent 2204/164, jest mobile 532/532
- [x] RC5 self-review clean
- [x] Smoke MANUAL device real (moto g06/Android, canal `preview`):
  - T054 caminho feliz: publish → minimizar → foreground → banner aparece → Reiniciar → updateId bate
  - T055 guarda negativo: modal de dose aberto → banner não aparece; fecha modal → aparece na hora
  - T056 cold start: force-stop+reabertura com update pendente → nenhum banner (FR-005 intacta)
- [ ] RC6 (agy-only, RC6_MAIN=feature/055-w1-sdk54) — rodando a seguir

🤖 Generated with [Claude Code](https://claude.com/claude-code)