### PR TITLE
feat(063): Phase 3A — Mobile Design System Color Tokens

### DIFF
--- a/apps/mobile/src/features/dashboard/components/PriorityActionCard.tsx
+++ b/apps/mobile/src/features/dashboard/components/PriorityActionCard.tsx
@@ -4,7 +4,7 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native'
 import * as LucideIcons from 'lucide-react-native'
 const { BellRing, Check } = LucideIcons as any
 import { LinearGradient } from 'expo-linear-gradient'
-import { colors, spacing, borderRadius } from '../../../shared/styles/tokens'
+import { colors, spacing, borderRadius } from '@shared/styles/tokens'
 
 /**
  * PriorityActionCard - Card de alta urgência para doses na janela de agora (Now/Late)
@@ -70,7 +70,7 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.12,
     shadowRadius: 24,
     elevation: 8,
-    backgroundColor: 'transparent',
+    backgroundColor: colors.doseDelayed.borderNone,
   },
   container: {
     borderRadius: borderRadius.xl,
@@ -99,7 +99,7 @@ const styles = StyleSheet.create({
   },
   timeInfo: {
     fontSize: 15,
-    color: 'rgba(255, 255, 255, 0.7)',
+    color: colors.brand.light,
     marginBottom: spacing[6],
   },
   actionButton: {

--- a/apps/mobile/src/features/dashboard/components/PriorityActionCard.tsx
+++ b/apps/mobile/src/features/dashboard/components/PriorityActionCard.tsx
@@ -70,7 +70,7 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.12,
     shadowRadius: 24,
     elevation: 8,
-    backgroundColor: colors.doseDelayed.borderNone,
+    backgroundColor: colors.bg.card,
   },
   container: {
     borderRadius: borderRadius.xl,

--- a/apps/mobile/src/features/dashboard/components/StockAlertInline.tsx
+++ b/apps/mobile/src/features/dashboard/components/StockAlertInline.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native'
+import { View, Text, StyleSheet } from 'react-native'
+import { colors } from '@shared/styles/tokens'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob nodenext
 import * as LucideIcons from 'lucide-react-native'
 const { PackageSearch, AlertTriangle } = LucideIcons as any
@@ -23,9 +24,9 @@ export default function StockAlertInline({ alerts = [] }) {
     ]}>
       <View style={styles.iconContainer}>
         {isCritical ? (
-          <AlertTriangle size={20} color="#ba1a1a" />
+          <AlertTriangle size={20} color={colors.status.error} />
         ) : (
-          <PackageSearch size={20} color="#904d00" />
+          <PackageSearch size={20} color={colors.status.warning} />
         )}
       </View>
       
@@ -52,12 +53,12 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   warning: {
-    backgroundColor: '#ffdec1', // Warning container
-    borderColor: '#904d00',
+    backgroundColor: colors.status.warningLight,
+    borderColor: colors.status.warning,
   },
   critical: {
-    backgroundColor: '#ffdad6', // Error container
-    borderColor: '#ba1a1a',
+    backgroundColor: colors.status.errorLight,
+    borderColor: colors.status.error,
   },
   iconContainer: {
     marginRight: 12,
@@ -70,14 +71,14 @@ const styles = StyleSheet.create({
     fontWeight: '700',
   },
   titleWarning: {
-    color: '#904d00',
+    color: colors.status.warning,
   },
   titleCritical: {
-    color: '#ba1a1a',
+    color: colors.status.error,
   },
   description: {
     fontSize: 13,
-    color: '#44474e',
+    color: colors.text.secondary,
     marginTop: 2,
   },
 })

--- a/apps/mobile/src/features/dashboard/components/TodaySummaryCard.tsx
+++ b/apps/mobile/src/features/dashboard/components/TodaySummaryCard.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react'
 import { View, Text, StyleSheet } from 'react-native'
+import { colors } from '@shared/styles/tokens'
 import AdherenceRing from './AdherenceRing'
 
 /**
@@ -46,13 +47,13 @@ export default function TodaySummaryCard({ totalExpected, totalTaken, score }) {
 
 const styles = StyleSheet.create({
   card: {
-    backgroundColor: '#fff',
+    backgroundColor: colors.bg.card,
     borderRadius: 24,
     padding: 24,
     marginHorizontal: 16,
     marginBottom: 16,
     // Sanctuary Ambient Shadow (lg)
-    shadowColor: '#000',
+    shadowColor: colors.neutral[900],
     shadowOffset: { width: 0, height: 8 },
     shadowOpacity: 0.08,
     shadowRadius: 24,
@@ -73,24 +74,24 @@ const styles = StyleSheet.create({
   statValue: {
     fontSize: 32, // Maior para destaque premium
     fontWeight: '800',
-    color: '#1a1c1e', // neutral.800
+    color: colors.text.primary,
     letterSpacing: -1,
   },
   statLabel: {
     fontSize: 13,
     fontWeight: '600',
-    color: '#44474e', // neutral.600
+    color: colors.text.secondary,
     marginTop: -2,
   },
   footer: {
     marginTop: 20,
     paddingTop: 16,
     borderTopWidth: 1,
-    borderTopColor: '#f1f4f9', // neutral.100
+    borderTopColor: colors.border.light,
   },
   footerText: {
     fontSize: 14,
-    color: '#44474e',
+    color: colors.text.secondary,
     textAlign: 'center',
     fontStyle: 'italic',
     fontWeight: '500',

--- a/apps/mobile/src/features/dose/components/BulkDoseRegisterModal.tsx
+++ b/apps/mobile/src/features/dose/components/BulkDoseRegisterModal.tsx
@@ -416,7 +416,7 @@ function BulkDoseActions({ loading, selectedCount, onCancel, onConfirm }) {
         disabled={loading || selectedCount === 0}
       >
         {loading
-          ? <ActivityIndicator color="#fff" size="small" />
+          ? <ActivityIndicator color={colors.text.inverse} size="small" />
           : <Text style={styles.confirmText}>
               Registrar {selectedCount} {selectedCount === 1 ? 'dose' : 'doses'}
             </Text>

--- a/apps/mobile/src/features/dose/components/DoseRegisterModal.tsx
+++ b/apps/mobile/src/features/dose/components/DoseRegisterModal.tsx
@@ -249,7 +249,7 @@ export default function DoseRegisterModal({
               disabled={loading}
             >
               {loading
-                ? <ActivityIndicator color="#fff" size="small" />
+                ? <ActivityIndicator color={colors.text.inverse} size="small" />
                 : <Text style={styles.confirmText}>Confirmar</Text>
               }
             </Pressable>
@@ -267,7 +267,7 @@ const styles = StyleSheet.create({
   },
   backdrop: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.4)',
+    backgroundColor: colors.bg.overlay,
   },
   sheet: {
     backgroundColor: colors.bg.card,
@@ -431,6 +431,6 @@ const styles = StyleSheet.create({
   confirmText: {
     fontSize: 15,
     fontWeight: '600',
-    color: '#fff',
+    color: colors.text.inverse,
   },
 })

--- a/apps/mobile/src/features/medications/screens/MedicineFormScreen.tsx
+++ b/apps/mobile/src/features/medications/screens/MedicineFormScreen.tsx
@@ -431,14 +431,14 @@ const styles = StyleSheet.create({
   warningBox: {
     padding: spacing[3],
     borderRadius: borderRadius.md,
-    backgroundColor: '#fffbeb',
+    backgroundColor: colors.supplement[50],
     borderWidth: 1,
-    borderColor: '#fef3c7',
+    borderColor: colors.supplement[50],
     marginTop: spacing[2],
   },
   warningText: {
     fontSize: 13,
-    color: '#d97706',
+    color: colors.supplement[500],
     lineHeight: 18,
   },
 })

--- a/apps/mobile/src/features/medications/screens/MedicineFormScreen.tsx
+++ b/apps/mobile/src/features/medications/screens/MedicineFormScreen.tsx
@@ -433,7 +433,7 @@ const styles = StyleSheet.create({
     borderRadius: borderRadius.md,
     backgroundColor: colors.supplement[50],
     borderWidth: 1,
-    borderColor: colors.supplement[50],
+    borderColor: colors.supplement[500],
     marginTop: spacing[2],
   },
   warningText: {

--- a/apps/mobile/src/features/notifications/screens/NotificationInboxScreen.tsx
+++ b/apps/mobile/src/features/notifications/screens/NotificationInboxScreen.tsx
@@ -226,7 +226,7 @@ function NotificationInboxHeader({ navigation, unreadCount, loading }) {
         accessibilityLabel="Voltar"
         hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
       >
-        <ArrowLeft size={22} color={colors.text?.primary ?? '#111827'} strokeWidth={2} />
+        <ArrowLeft size={22} color={colors.text.primary} strokeWidth={2} />
       </TouchableOpacity>
       <View style={styles.titleBlock}>
         <Text style={styles.title}>Avisos</Text>
@@ -243,7 +243,7 @@ function NotificationInboxHeader({ navigation, unreadCount, loading }) {
         accessibilityLabel="Preferências de notificação"
         hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
       >
-        <Settings size={22} color={colors.text?.primary ?? '#111827'} strokeWidth={2} />
+        <Settings size={22} color={colors.text.primary} strokeWidth={2} />
       </TouchableOpacity>
     </View>
   )
@@ -422,7 +422,7 @@ export default function NotificationInboxScreen({ navigation, route }) {
     if (loading) return null
     return (
       <View style={styles.emptyState}>
-        <BellOff size={40} color={colors.text?.muted ?? '#9ca3af'} strokeWidth={1.5} />
+        <BellOff size={40} color={colors.text.muted} strokeWidth={1.5} />
         <Text style={styles.emptyTitle}>Tudo em dia por aqui</Text>
         <Text style={styles.emptyBody}>
           {effectiveFilter !== 'all'
@@ -444,7 +444,7 @@ export default function NotificationInboxScreen({ navigation, route }) {
       {/* ── Banner offline ── */}
       {stale && (
         <View style={styles.offlineBanner}>
-          <WifiOff size={14} color={colors.status?.warning ?? '#d97706'} strokeWidth={2} />
+          <WifiOff size={14} color={colors.status.warning} strokeWidth={2} />
           <Text style={styles.offlineText}>Exibindo dados salvos localmente</Text>
         </View>
       )}
@@ -490,45 +490,43 @@ export default function NotificationInboxScreen({ navigation, route }) {
   )
 }
 
-const PRIMARY = colors.primary?.[600] ?? '#006a5e'
-
 const styles = StyleSheet.create({
-  safe:             { flex: 1, backgroundColor: (colors.bg as any)?.default ?? '#f9fafb' },
+  safe:             { flex: 1, backgroundColor: colors.bg.screen },
 
   // Header
-  header:           { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingTop: 8, paddingBottom: 12, gap: 12, borderBottomWidth: 1, borderBottomColor: colors.border?.light ?? '#e5e7eb' },
-  iconButton:       { width: 36, height: 36, borderRadius: 18, backgroundColor: colors.bg?.card ?? '#f3f4f6', alignItems: 'center', justifyContent: 'center', flexShrink: 0 },
+  header:           { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingTop: 8, paddingBottom: 12, gap: 12, borderBottomWidth: 1, borderBottomColor: colors.border.light },
+  iconButton:       { width: 36, height: 36, borderRadius: 18, backgroundColor: colors.bg.card, alignItems: 'center', justifyContent: 'center', flexShrink: 0 },
   titleBlock:       { flex: 1 },
-  title:            { fontSize: 28, fontWeight: '800', letterSpacing: -0.5, color: colors.text?.primary ?? '#111827' },
+  title:            { fontSize: 28, fontWeight: '800', letterSpacing: -0.5, color: colors.text.primary },
   subtitle:         { fontSize: 13, fontWeight: '500', marginTop: 1 },
 
   // Banner offline
-  offlineBanner:    { flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 20, paddingVertical: 8, backgroundColor: 'rgba(251, 191, 36, 0.15)', borderBottomWidth: 1, borderBottomColor: 'rgba(217, 119, 6, 0.20)' },
-  offlineText:      { fontSize: 13, fontWeight: '500', color: colors.status?.warning ?? '#d97706' },
+  offlineBanner:    { flexDirection: 'row', alignItems: 'center', gap: 6, paddingHorizontal: 20, paddingVertical: 8, backgroundColor: colors.status.warningLight, borderBottomWidth: 1, borderBottomColor: colors.status.warning },
+  offlineText:      { fontSize: 13, fontWeight: '500', color: colors.status.warning },
 
   // Chips de filtro
-  filtersScroll:    { flexGrow: 0, borderBottomWidth: 1, borderBottomColor: colors.border?.light ?? '#e5e7eb' },
+  filtersScroll:    { flexGrow: 0, borderBottomWidth: 1, borderBottomColor: colors.border.light },
   filtersContent:   { paddingHorizontal: 16, paddingVertical: 12, gap: 8 },
   chip:             { borderRadius: 20, paddingHorizontal: 16, paddingVertical: 8, minHeight: 34, borderWidth: 1, justifyContent: 'center', alignItems: 'center' },
-  chipInactive:     { backgroundColor: colors.bg?.card ?? '#ffffff', borderColor: (colors.border as any)?.medium ?? '#d1d5db' },
+  chipInactive:     { backgroundColor: colors.bg.card, borderColor: colors.border.default },
   chipText:         { fontSize: 14, fontWeight: '600', lineHeight: 18 },
-  chipTextActive:   { color: '#ffffff' },
-  chipTextInactive: { color: colors.text?.secondary ?? '#374151' },
+  chipTextActive:   { color: colors.text.inverse },
+  chipTextInactive: { color: colors.text.secondary },
 
   // Loading / error
   loadingContainer: { flex: 1, alignItems: 'center', justifyContent: 'center' },
-  errorContainer:   { margin: 20, padding: 16, borderRadius: 12, backgroundColor: 'rgba(220, 38, 38, 0.06)' },
-  errorText:        { fontSize: 14, color: colors.status?.error ?? '#dc2626' },
+  errorContainer:   { margin: 20, padding: 16, borderRadius: 12, backgroundColor: colors.status.errorLight },
+  errorText:        { fontSize: 14, color: colors.status.error },
 
   // Lista
   sectionHeader:    { paddingHorizontal: 20, paddingTop: 20, paddingBottom: 6 },
-  sectionTitle:     { fontSize: 12, fontWeight: '600', color: colors.text?.muted ?? '#6b7280', textTransform: 'uppercase', letterSpacing: 0.8 },
-  separator:        { height: 1, marginHorizontal: 20, backgroundColor: colors.border?.light ?? '#e5e7eb' },
+  sectionTitle:     { fontSize: 12, fontWeight: '600', color: colors.text.muted, textTransform: 'uppercase', letterSpacing: 0.8 },
+  separator:        { height: 1, marginHorizontal: 20, backgroundColor: colors.border.light },
   listContent:      { paddingBottom: 40 },
   emptyList:        { flex: 1 },
 
   // Zero state
   emptyState:       { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
-  emptyTitle:       { fontSize: 18, fontWeight: '600', color: '#1a1a1a', marginBottom: 8, textAlign: 'center', marginTop: 16 },
-  emptyBody:        { fontSize: 14, color: '#6b7280', textAlign: 'center', lineHeight: 20 },
+  emptyTitle:       { fontSize: 18, fontWeight: '600', color: colors.text.primary, marginBottom: 8, textAlign: 'center', marginTop: 16 },
+  emptyBody:        { fontSize: 14, color: colors.text.secondary, textAlign: 'center', lineHeight: 20 },
 })

--- a/apps/mobile/src/features/profile/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/features/profile/screens/ProfileScreen.tsx
@@ -171,7 +171,7 @@ export default function ProfileScreen() {
         {/* Ordem (PO feedback #6): FERRAMENTAS → AVISOS → OUTROS → MINHA CONTA → Sair → versão */}
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>FERRAMENTAS</Text>
-          <View style={[styles.card, { paddingVertical: 0 }]}>
+          <View style={styles.cardNoPadding}>
             <TouchableOpacity
               style={styles.otherRow}
               onPress={() => (navigation.navigate as any)(ROUTES.DOSE_HISTORY)}
@@ -183,7 +183,7 @@ export default function ProfileScreen() {
               <ChevronRight size={18} color={colors.text.secondary} strokeWidth={1.5} />
             </TouchableOpacity>
             <TouchableOpacity
-              style={[styles.otherRow, { borderTopWidth: 1, borderTopColor: colors.border.light }]}
+              style={styles.otherRowBorderTop}
               onPress={() => (navigation.navigate as any)(ROUTES.MEASURES)}
               activeOpacity={0.7}
             >
@@ -223,7 +223,7 @@ export default function ProfileScreen() {
 
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>SOBRE O DOSIQ</Text>
-          <View style={[styles.card, { paddingVertical: 0 }]}>
+          <View style={styles.cardNoPadding}>
             <TouchableOpacity
               style={styles.otherRow}
               onPress={handlePrivacyData}
@@ -257,7 +257,7 @@ export default function ProfileScreen() {
                 {user?.email || '...'}
               </Text>
             </View>
-            <View style={[styles.infoRow, { borderBottomWidth: 0 }]}>
+            <View style={styles.infoRowLast}>
               <Text style={styles.label}>Status</Text>
               <Text style={[styles.value, { color: colors.status.success }]}>Ativo</Text>
             </View>
@@ -467,6 +467,14 @@ const styles = StyleSheet.create({
     marginHorizontal: 16,
     ...shadows.sm,
   },
+  cardNoPadding: {
+    backgroundColor: colors.bg.card,
+    borderRadius: borderRadius.lg,
+    paddingHorizontal: spacing[4],
+    paddingVertical: 0,
+    marginHorizontal: 16,
+    ...shadows.sm,
+  },
   infoRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -474,6 +482,13 @@ const styles = StyleSheet.create({
     paddingVertical: spacing[3],
     borderBottomWidth: 1,
     borderBottomColor: colors.border.light,
+  },
+  infoRowLast: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: spacing[3],
+    borderBottomWidth: 0,
   },
   label: {
     fontSize: 14,
@@ -540,6 +555,14 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingVertical: spacing[4],
   },
+  otherRowBorderTop: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing[4],
+    borderTopWidth: 1,
+    borderTopColor: colors.border.light,
+  },
   otherLabel: {
     fontSize: 16,
     color: colors.text.primary,
@@ -587,7 +610,7 @@ const styles = StyleSheet.create({
   inboxBadgeText: {
     fontSize: 11,
     fontWeight: '700',
-    color: '#ffffff',
+    color: colors.text.inverse,
   },
   versionSection: {
     paddingVertical: spacing[4],

--- a/apps/mobile/src/features/treatments/components/ProtocolFormBody.tsx
+++ b/apps/mobile/src/features/treatments/components/ProtocolFormBody.tsx
@@ -723,7 +723,7 @@ const styles = StyleSheet.create({
   },
   backdrop: {
     flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.5)',
+    backgroundColor: colors.bg.overlay,
     justifyContent: 'center',
     paddingHorizontal: spacing[5],
   },

--- a/apps/mobile/src/screens/LandingScreen.tsx
+++ b/apps/mobile/src/screens/LandingScreen.tsx
@@ -58,7 +58,7 @@ export default function LandingScreen({ navigation }) {
           {/* Next Dose Card */}
           <View style={[styles.card, styles.doseCard]}>
             <View style={styles.doseIconContainer}>
-              <Sun size={32} color="#f9a825" />
+              <Sun size={32} color={colors.status.warningBright} />
             </View>
             <View style={styles.doseInfo}>
               <Text style={styles.doseLabel}>PRÓXIMA DOSE</Text>
@@ -132,7 +132,7 @@ export default function LandingScreen({ navigation }) {
           accessibilityRole="button"
           accessibilityLabel="Criar conta"
         >
-          <UserPlus size={20} color="#fff" />
+          <UserPlus size={20} color={colors.text.inverse} />
           <Text style={styles.createAccountText}>Criar conta</Text>
         </Pressable>
         
@@ -178,7 +178,7 @@ const styles = StyleSheet.create({
     letterSpacing: -1.5,
   },
   heroContainer: {
-    backgroundColor: '#f1f3f4',
+    backgroundColor: colors.neutral[100],
     marginHorizontal: spacing[6],
     borderRadius: 32,
     padding: spacing[6],
@@ -241,7 +241,7 @@ const styles = StyleSheet.create({
     width: 48,
     height: 48,
     borderRadius: 12,
-    backgroundColor: '#FFFFFF', // white
+    backgroundColor: colors.bg.card,
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: spacing[4],
@@ -393,7 +393,7 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     flexDirection: 'row',
-    backgroundColor: '#fff',
+    backgroundColor: colors.bg.card,
     paddingHorizontal: spacing[6],
     paddingTop: spacing[4],
     borderTopWidth: 1,
@@ -411,7 +411,7 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   createAccountText: {
-    color: '#fff',
+    color: colors.text.inverse,
     fontSize: 16,
     fontWeight: 'bold',
   },


### PR DESCRIPTION
## Summary
- Replaced 25+ hardcoded hex and rgba color literals across 10 mobile files with design tokens from `@shared/styles/tokens`.
- Cleaned up inline styles in `ProfileScreen.tsx` and moved card/row styling into `StyleSheet.create`.
- Refactored `StockAlertInline.tsx`, `TodaySummaryCard.tsx`, `PriorityActionCard.tsx`, `NotificationInboxScreen.tsx`, `LandingScreen.tsx`, `MedicineFormScreen.tsx`, `ProfileScreen.tsx`, `ProtocolFormBody.tsx`, `DoseRegisterModal.tsx`, and `BulkDoseRegisterModal.tsx`.
- Reduced `react-native/no-color-literals` warnings from 41x down to 16x (and `react-native/no-inline-styles` to 0).

## Quality Verification
- ✅ `rtk bash .metaswarm/shims/run-swarm-check.sh` passed clean
- ✅ `rtk npx tsc -p apps/mobile/tsconfig.json --noEmit` passed clean
- ✅ TS Ratchet green
