### PR TITLE
refactor(mobile): remover eslint-disable obsoletos (etapa 9a)

### DIFF
--- a/apps/mobile/src/features/dose/components/BulkDoseRegisterModal.tsx
+++ b/apps/mobile/src/features/dose/components/BulkDoseRegisterModal.tsx
@@ -17,7 +17,6 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx (features/treatments)
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { CheckCircle, Circle, Calendar, Clock, Folder, ChevronRight, ChevronUp, AlertTriangle } = LucideIcons as any
 import DateTimePicker, { DateTimePickerAndroid } from '@react-native-community/datetimepicker'

--- a/apps/mobile/src/features/dose/hooks/usePlanProtocols.ts
+++ b/apps/mobile/src/features/dose/hooks/usePlanProtocols.ts
@@ -71,7 +71,6 @@ export function usePlanProtocols({ mode, planId, protocolIds, scheduledTime, use
           const todayStr = getTodayLocal()
           setProtocols(
             all
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               .filter(p => (p.treatment_plan as any)?.id === planId)
               .filter(p => isTreatmentSchedulableOn(p, todayStr))
               .filter(p => isInWindow(p, scheduledTime))

--- a/apps/mobile/src/features/dose/services/doseService.ts
+++ b/apps/mobile/src/features/dose/services/doseService.ts
@@ -9,7 +9,6 @@ import { supabase as supabaseImport } from '@platform/supabase/nativeSupabaseCli
 // TODO(040-strict): apps/mobile pina @supabase/supabase-js 2.91.0 vs ^2.90.1 na
 // root — duplicata de instalação quebra nominal typing do client (protected member
 // 'supabaseUrl' não bate estruturalmente). Fix real = alinhar versão (fora do lote).
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const supabase = supabaseImport as any
 import { cancelAlarm } from '@platform/alarms/alarmService'
 import { endDoseActivity, showDoseDone, readSurfaceLabel } from '@platform/doseActivity/doseActivitySurfaceService'
@@ -156,7 +155,6 @@ export async function undoDose(instanceId) {
 
     await doseLogCore.undoDose(instanceId)
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await logEvent(EVENTS.DOSE_LOGGED, { action: 'undo', medicine_id: (instance as any).medicine_id })
     return { success: true }
   } catch (err) {
@@ -176,7 +174,6 @@ export async function undoDose(instanceId) {
 export async function updateOrphanLog(logId, updates) {
   try {
     const logEntry = await doseLogCore.updateOrphanLog(logId, updates)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await logEvent(EVENTS.DOSE_LOGGED, { action: 'update_orphan', medicine_id: (logEntry as any).medicine_id })
     return { success: true }
   } catch (err) {

--- a/apps/mobile/src/features/medications/components/MedicineDeleteBlockedSheet.tsx
+++ b/apps/mobile/src/features/medications/components/MedicineDeleteBlockedSheet.tsx
@@ -11,7 +11,6 @@ import { View, Text, Modal, Pressable, ScrollView, StyleSheet, Platform, StatusB
 import { SafeAreaView } from 'react-native-safe-area-context'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { AlertCircle, Layers, Package, ChevronRight, Trash2, BarChart3 } = LucideIcons as any
 import { colors, spacing, borderRadius, typography } from '@shared/styles/tokens'

--- a/apps/mobile/src/features/medications/screens/MedicineFormScreen.tsx
+++ b/apps/mobile/src/features/medications/screens/MedicineFormScreen.tsx
@@ -9,7 +9,6 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useNavigation, useRoute } from '@react-navigation/native'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { ChevronLeft } = LucideIcons as any
 import {

--- a/apps/mobile/src/features/medications/screens/MedicinesListScreen.tsx
+++ b/apps/mobile/src/features/medications/screens/MedicinesListScreen.tsx
@@ -13,7 +13,6 @@ import {
 import { useNavigation, useFocusEffect } from '@react-navigation/native'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { Search, X, Plus, ChevronLeft, Pill } = LucideIcons as any
 import ScreenContainer from '@shared/components/ui/ScreenContainer'

--- a/apps/mobile/src/features/medications/services/medicineService.ts
+++ b/apps/mobile/src/features/medications/services/medicineService.ts
@@ -11,7 +11,6 @@ import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
 // TODO(040-strict): apps/mobile pina @supabase/supabase-js 2.91.0 vs ^2.90.1 na
 // factory do core — tipos nominais do client divergem entre versões (private
 // 'supabaseUrl' não bate estruturalmente). Fix real = alinhar versão (fora do lote).
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const typedClient = supabase as any
 
 async function getUserId() {

--- a/apps/mobile/src/features/profile/screens/ProfileEditScreen.tsx
+++ b/apps/mobile/src/features/profile/screens/ProfileEditScreen.tsx
@@ -51,7 +51,6 @@ function formProps(form, name) {
   }
 }
 
-// eslint-disable-next-line max-lines-per-function
 export default function ProfileEditScreen() {
   // States (R-010 — States → Memos → Effects → Handlers)
   const navigation = useNavigation()

--- a/apps/mobile/src/features/stock/components/StockIndicators.tsx
+++ b/apps/mobile/src/features/stock/components/StockIndicators.tsx
@@ -9,7 +9,6 @@
 import { View, Text, StyleSheet } from 'react-native'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { Package, TrendingDown, Clock, Tag } = LucideIcons as any
 import { formatBRL, formatActiveIngredientShort, isLiquidMedicine, formatNumberPtBR } from '@dosiq/core'

--- a/apps/mobile/src/features/stock/components/StockItem.tsx
+++ b/apps/mobile/src/features/stock/components/StockItem.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { View, Text, StyleSheet } from 'react-native'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { Plus, Syringe } = LucideIcons as any
 import SectionCard from '../../../shared/components/ui/SectionCard'

--- a/apps/mobile/src/features/stock/components/StockLevelBadge.tsx
+++ b/apps/mobile/src/features/stock/components/StockLevelBadge.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { View, Text, StyleSheet } from 'react-native'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { AlertCircle, AlertTriangle, CheckCircle, TrendingUp } = LucideIcons as any
 

--- a/apps/mobile/src/features/stock/screens/PurchaseFormScreen.tsx
+++ b/apps/mobile/src/features/stock/screens/PurchaseFormScreen.tsx
@@ -28,7 +28,6 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useNavigation, useRoute } from '@react-navigation/native'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { ChevronLeft, Package } = LucideIcons as any
 import { stockCreateSchema, getTodayLocal, parseLocalDate, formatLocalDate, getNow, formatActiveIngredientShort, INJECTION_CONTAINERS, INJECTION_CONTAINER_LABELS, formatDose } from '@dosiq/core'
@@ -268,7 +267,6 @@ function usePurchaseForm(route, navigation) {
     medicineService
       .getById(medicineId)
       // TODO(040-strict): getById do repo core retorna unknown — tipar Medicine no core
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .then((med: any) => {
         if (cancelled || !med) return
         setMedicine(med)

--- a/apps/mobile/src/features/stock/screens/PurchaseHistoryScreen.tsx
+++ b/apps/mobile/src/features/stock/screens/PurchaseHistoryScreen.tsx
@@ -15,7 +15,6 @@ import {
 import { useFocusEffect } from '@react-navigation/native'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { ChevronLeft } = LucideIcons as any
 import MedicineIcon from '@shared/components/ui/MedicineIcon'

--- a/apps/mobile/src/features/stock/screens/StockAdjustmentScreen.tsx
+++ b/apps/mobile/src/features/stock/screens/StockAdjustmentScreen.tsx
@@ -30,7 +30,6 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useNavigation, useRoute, useFocusEffect } from '@react-navigation/native'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { ChevronLeft, Package } = LucideIcons as any
 import FormInput from '@shared/components/form/FormInput'

--- a/apps/mobile/src/features/stock/screens/StockDetailScreen.tsx
+++ b/apps/mobile/src/features/stock/screens/StockDetailScreen.tsx
@@ -20,7 +20,6 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useRoute, useFocusEffect } from '@react-navigation/native'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { ChevronLeft, Plus, SlidersHorizontal } = LucideIcons as any
 import MedicineIcon from '@shared/components/ui/MedicineIcon'

--- a/apps/mobile/src/features/stock/screens/StockScreen.tsx
+++ b/apps/mobile/src/features/stock/screens/StockScreen.tsx
@@ -7,7 +7,6 @@ import { SectionList, RefreshControl, StyleSheet, Text, View, Pressable } from '
 import { useNavigation, useFocusEffect } from '@react-navigation/native'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { Plus, PackageOpen } = LucideIcons as any
 import { useStock } from '@stock/hooks/useStock'

--- a/apps/mobile/src/features/stock/services/stockService.ts
+++ b/apps/mobile/src/features/stock/services/stockService.ts
@@ -100,7 +100,6 @@ export async function getStockData(userId) {
 // TODO(040-strict): apps/mobile pina @supabase/supabase-js 2.91.0 vs ^2.90.1 na
 // factory do core — tipos nominais do client divergem entre versões (private
 // 'supabaseUrl' não bate estruturalmente). Fix real = alinhar versão (fora do lote).
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const typedClient = nativeSupabaseClient as any
 
 const stockRepo = createStockRepository({ client: typedClient, getUserId })

--- a/apps/mobile/src/features/treatments/components/MedicineSelectorRow.tsx
+++ b/apps/mobile/src/features/treatments/components/MedicineSelectorRow.tsx
@@ -3,7 +3,6 @@
 import { View, Text, Pressable, StyleSheet } from 'react-native'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { Plus, ChevronRight } = LucideIcons as any
 import { formatConcentration } from '@dosiq/core'

--- a/apps/mobile/src/features/treatments/components/MedicineSelectorSheet.tsx
+++ b/apps/mobile/src/features/treatments/components/MedicineSelectorSheet.tsx
@@ -21,7 +21,6 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { Search, X, Plus, Pill } = LucideIcons as any
 import MedicineIcon from '@shared/components/ui/MedicineIcon'

--- a/apps/mobile/src/features/treatments/components/PlanSelectField.tsx
+++ b/apps/mobile/src/features/treatments/components/PlanSelectField.tsx
@@ -19,7 +19,6 @@ import { useCallback } from 'react'
 import { View, Text, TextInput, Pressable, StyleSheet } from 'react-native'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { Check, ArrowUpRight } = LucideIcons as any
 import FormSelect from '@shared/components/form/FormSelect'

--- a/apps/mobile/src/features/treatments/components/ProtocolDeleteSheet.tsx
+++ b/apps/mobile/src/features/treatments/components/ProtocolDeleteSheet.tsx
@@ -10,7 +10,6 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305/TS2724
 // sob apps/mobile/tsconfig.json (CheckCircle2 é alias deprecated de CircleCheck —
 // existe em runtime, só não no .d.ts) — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { AlertTriangle, CheckCircle2, CalendarDays, Info, Trash2 } = LucideIcons as any
 import { useProtocolStats } from '@treatments/hooks/useProtocolStats'

--- a/apps/mobile/src/features/treatments/components/ProtocolFormBody.tsx
+++ b/apps/mobile/src/features/treatments/components/ProtocolFormBody.tsx
@@ -8,7 +8,6 @@ import { View, Text, Switch, Alert, Linking, StyleSheet, Modal, TouchableOpacity
 //   passa a "não existir".
 // Custo aceito: nome de ícone errado vira `undefined` e só quebra no render. Mitigação = manter a
 // lista curta e conferir cada nome contra `node_modules/lucide-react-native/dist/icons.d.ts`.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 
 // Conferidos no d.ts do pacote (1703 ícones): `CircleQuestionMark` é o nome ATUAL — `CircleHelp` e

--- a/apps/mobile/src/features/treatments/components/TimeSchedulePicker.tsx
+++ b/apps/mobile/src/features/treatments/components/TimeSchedulePicker.tsx
@@ -13,7 +13,6 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import DateTimePicker, { DateTimePickerAndroid } from '@react-native-community/datetimepicker'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { Clock, X, Plus } = LucideIcons as any
 import { getNow } from '@dosiq/core'

--- a/apps/mobile/src/features/treatments/components/TreatmentPlanHeader.tsx
+++ b/apps/mobile/src/features/treatments/components/TreatmentPlanHeader.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { View, Text, StyleSheet, TouchableOpacity, Platform } from 'react-native'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { ChevronRight, ChevronUp } = LucideIcons as any
 import { colors, spacing, typography } from '../../../shared/styles/tokens'

--- a/apps/mobile/src/features/treatments/hooks/_treatmentsTransformer.ts
+++ b/apps/mobile/src/features/treatments/hooks/_treatmentsTransformer.ts
@@ -14,7 +14,6 @@ export function groupTreatmentsByPlanOrClass(data) {
       return timeA.localeCompare(timeB)
     })
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const groupsMap: Record<string, any> = {}
 
   validProtocols.forEach(p => {

--- a/apps/mobile/src/features/treatments/hooks/useProtocolFormSubmit.ts
+++ b/apps/mobile/src/features/treatments/hooks/useProtocolFormSubmit.ts
@@ -46,7 +46,6 @@ async function resolveInlinePlan(planField, show) {
     color: planField.inline.color,
     emoji: planField.inline.emoji,
   })
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return { ok: true, planId: (created as any)?.id ?? null, useInline: true }
 }
 

--- a/apps/mobile/src/features/treatments/screens/ProtocolFormScreen.tsx
+++ b/apps/mobile/src/features/treatments/screens/ProtocolFormScreen.tsx
@@ -22,7 +22,6 @@ import {
 import { useNavigation, useRoute, useFocusEffect } from '@react-navigation/native'
 // TODO(040-strict): named imports do lucide-react-native batem em TS2305 sob
 // apps/mobile/tsconfig.json — ver nota em TreatmentsScreen.tsx
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { ArrowLeft, AlertCircle } = LucideIcons as any
 import { getTodayLocal, formatLocalDate } from '@dosiq/core'

--- a/apps/mobile/src/features/treatments/screens/TreatmentsScreen.tsx
+++ b/apps/mobile/src/features/treatments/screens/TreatmentsScreen.tsx
@@ -4,7 +4,6 @@ import { useNavigation, useFocusEffect } from '@react-navigation/native'
 // TODO(040-strict): named imports de 4 ícones simultâneos do lucide-react-native
 // batem em TS2305 sob apps/mobile/tsconfig.json (moduleResolution bundler + expo
 // base) mesmo existindo no barrel — resolver isolado confirma export presente.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import * as LucideIcons from 'lucide-react-native'
 const { Pill, ChevronRight, Plus, CalendarClock } = LucideIcons as any
 import ScreenContainer from '@shared/components/ui/ScreenContainer'

--- a/apps/mobile/src/features/treatments/services/protocolService.ts
+++ b/apps/mobile/src/features/treatments/services/protocolService.ts
@@ -11,7 +11,6 @@ import { supabase } from '../../../platform/supabase/nativeSupabaseClient'
 // TODO(040-strict): apps/mobile pina @supabase/supabase-js 2.91.0 vs ^2.90.1 na
 // root — duplicata de instalação quebra nominal typing do client (protected member
 // 'supabaseUrl' não bate estruturalmente). Fix real = alinhar versão (fora do lote).
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const typedClient = supabase as any
 
 async function getUserId() {

--- a/apps/mobile/src/features/treatments/services/treatmentPlanService.ts
+++ b/apps/mobile/src/features/treatments/services/treatmentPlanService.ts
@@ -16,7 +16,6 @@ async function getUserId() {
 // TODO(040-strict): apps/mobile pina @supabase/supabase-js 2.91.0 vs ^2.90.1 na
 // root — duplicata de instalação quebra nominal typing do client (protected member
 // 'supabaseUrl' não bate estruturalmente). Fix real = alinhar versão (fora do lote).
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const typedClient = supabase as any
 
 export const treatmentPlanService = createTreatmentPlanRepository({

--- a/apps/mobile/src/platform/telemetry/syncDeviceActivity.test.ts
+++ b/apps/mobile/src/platform/telemetry/syncDeviceActivity.test.ts
@@ -24,7 +24,6 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 }))
 
 import AsyncStorageImport from '@react-native-async-storage/async-storage'
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const AsyncStorage = AsyncStorageImport as any
 
 import { syncDeviceActivity } from './syncDeviceActivity'

--- a/apps/mobile/src/platform/telemetry/syncDeviceActivity.ts
+++ b/apps/mobile/src/platform/telemetry/syncDeviceActivity.ts
@@ -20,7 +20,6 @@ export async function syncDeviceActivity({
   supabase,
   now = () => Date.now(),
 }: {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   supabase: any
   now?: () => number
 }): Promise<void> {


### PR DESCRIPTION
## Summary
- Zera os 35 warnings de `Unused eslint-disable directive` residuais em `apps/mobile` (32 arquivos) — quase todos `@typescript-eslint/no-explicit-any` que não dispara mais nesses paths (1 exceção: `max-lines-per-function` em `ProfileEditScreen.tsx`).
- Primeira das 4 subfases do replanejamento pós-#790 da etapa 9 (46 warnings residuais eram grande demais pra 1 PR só — ver `plans/specs/063-zero-lint-regressions/playbook.md` §2.1, local-only).
- Limpeza puramente mecânica: 1 linha deletada por ocorrência, sem tocar lógica. Delegado majoritariamente a `cavecrew-builder` (Haiku) em batches paralelos, 1 arquivo por agente — critério de delegação já validado na etapa 7 (alvo exato, verificável objetivamente, zero julgamento visual/semântico).

## Test plan
- [x] `rtk lint` — 0 `Unused eslint-disable directive` restantes (sobraram só os 11 warnings de complexity/hooks/fast-refresh das próximas subfases)
- [x] `npm run test:critical` — 164 arquivos / 2204 testes passando
- [x] Verificação real (lint+testes) rodada pelo orquestrador após todos os spawns completarem, sem confiar no relato dos subagentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)