### PR TITLE
fix(063): zerar hooks/exhaustive-deps + fast-refresh residuais (fase 9b)

### DIFF
--- a/apps/mobile/src/features/measures/components/ScatterTrend.tsx
+++ b/apps/mobile/src/features/measures/components/ScatterTrend.tsx
@@ -85,7 +85,8 @@ export default function ScatterTrend({ items, unit, typeLabel = 'Medida', isPa =
 
   const sysValues = days.flatMap((d) => d.values)
   const diaValues = days.flatMap((d) => d.valuesSec)
-  const allValues = [...sysValues, ...diaValues] // escala unifica as 2 séries (PA)
+  // escala unifica as 2 séries (PA); useMemo evita nova ref a cada render (dep do scale abaixo)
+  const allValues = useMemo(() => [...sysValues, ...diaValues], [sysValues, diaValues])
   const hasData = allValues.length > 0
   const avg = mean(sysValues)
   const avgDia = mean(diaValues)

--- a/apps/mobile/src/features/treatments/screens/ProtocolDetailScreen.tsx
+++ b/apps/mobile/src/features/treatments/screens/ProtocolDetailScreen.tsx
@@ -184,7 +184,7 @@ function useProtocolDetailState() {
     // devolve um `protocol_activated` diferente. Recarregar cobre esse caso: o tratamento desta
     // tela não foi encerrado, então não há nada de que fugir.)
     await refresh()
-  }, [refresh, navigation, id])
+  }, [refresh])
 
   const onDelete = useCallback(() => {
     if (isDeleting) return

--- a/apps/mobile/src/platform/consent/useConsentGate.tsx
+++ b/apps/mobile/src/platform/consent/useConsentGate.tsx
@@ -176,5 +176,3 @@ export function ConsentGateProvider({
 export function useConsentGate(): ConsentGateValue {
   return useContext(ConsentGateContext)
 }
-
-export default useConsentGate

--- a/apps/mobile/src/shared/hooks/useStockTracking.tsx
+++ b/apps/mobile/src/shared/hooks/useStockTracking.tsx
@@ -132,6 +132,7 @@ export function StockTrackingProvider({ children, session = undefined }: Provide
   )
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useStockTracking(): StockTrackingValue {
   return useContext(StockTrackingContext)
 }

--- a/apps/web/src/shared/hooks/useConsentGate.tsx
+++ b/apps/web/src/shared/hooks/useConsentGate.tsx
@@ -163,6 +163,7 @@ export function ConsentGateProvider({ children, session = null }: ProviderProps)
   return <ConsentGateContext.Provider value={value}>{children}</ConsentGateContext.Provider>
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useConsentGate(): ConsentGateValue {
   return useContext(ConsentGateContext)
 }


### PR DESCRIPTION
## Resumo
- Fase 9b do épico 063: zera os 5 warnings residuais de `react-hooks/exhaustive-deps` + `react-refresh/only-export-components`.
- `ScatterTrend.tsx`: `allValues` movido pra `useMemo` (evitava recriar deps do `useMemo` do `scale` a cada render).
- `ProtocolDetailScreen.tsx`: `useCallback` de `handleStartPendingStep` sem `navigation`/`id` (não usados no corpo).
- `useConsentGate.tsx` (mobile): `export default` morto removido (nada importava por default).
- `useStockTracking.tsx` (mobile) e `useConsentGate.tsx` (web): `eslint-disable-next-line react-refresh/only-export-components` no hook — justificado no PR: Provider+Context+hook colocados de propósito (Context não é re-exportado, evita instância duplicada de estado — mesmo padrão já presente no arquivo mobile espelho antes deste PR).

## Test plan
- [x] `rtk lint` — 0 erros, 6 warnings restantes (todos `complexity`/`max-lines-per-function`, fora do escopo desta fase — fase 9c)
- [x] `rtk npm run test:critical` — 164/164 arquivos, 2204/2204 testes
- [x] `rtk bash ./scripts/strict-island.sh` — ratchet OK, todos buckets dentro do teto

🤖 Generated with [Claude Code](https://claude.com/claude-code)